### PR TITLE
Fix CI failures: typos and cargo-deny wildcard

### DIFF
--- a/crates/bugwarden-core/src/policy.rs
+++ b/crates/bugwarden-core/src/policy.rs
@@ -204,7 +204,7 @@ pub struct Matcher {
     pub whiteboard_contains: Vec<String>,
     /// Matches when `creation_time` is newer than `now - N days`.
     ///
-    /// A bug with a missing/unparseable `creation_time` MATCHES this
+    /// A bug with a missing/unparsable `creation_time` MATCHES this
     /// criterion (fail closed, I4): this matcher exists to deny or restrict
     /// young bugs, so a bug of unknown age must be treated as young.
     #[serde(default)]
@@ -440,7 +440,7 @@ impl Policy {
     /// Evaluation order (normative):
     ///
     /// 1. `global.min_bug_age_days` — a bug younger than the minimum age is
-    ///    Denied before any rule runs. A missing/unparseable `creation_time`
+    ///    Denied before any rule runs. A missing/unparsable `creation_time`
     ///    while this gate is active is also Denied (fail closed, I4).
     /// 2. Rules in file order, first match wins.
     /// 3. `default_action`.
@@ -520,7 +520,7 @@ pub struct BugMeta {
     pub groups: Vec<String>,
     /// Whiteboard text.
     pub whiteboard: String,
-    /// Creation time; `None` when absent or unparseable, which fails closed
+    /// Creation time; `None` when absent or unparsable, which fails closed
     /// wherever an age criterion applies (I4).
     pub creation_time: Option<DateTime<Utc>>,
 }
@@ -555,7 +555,7 @@ impl BugMeta {
     /// REST `component` field may be a string or an array of strings; `groups`
     /// elements may be plain names or objects carrying a `name` key; the
     /// whiteboard may arrive as `whiteboard` or (XML-RPC style)
-    /// `status_whiteboard`. An unparseable `creation_time` becomes `None`,
+    /// `status_whiteboard`. An unparsable `creation_time` becomes `None`,
     /// which is treated fail-closed by every age criterion (I4).
     pub fn from_json(v: &Value) -> BugMeta {
         let whiteboard = {
@@ -986,7 +986,7 @@ products = ["SUSE*"]
 
     #[test]
     fn reject_unknown_top_level_key() {
-        let err = Policy::from_toml_str("defualt_action = \"deny\"").unwrap_err();
+        let err = Policy::from_toml_str("unknown_option = \"deny\"").unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("unknown field"), "unexpected error: {msg}");
     }

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-bugwarden-core = { path = "../bugwarden-core" }
+bugwarden-core = { path = "../bugwarden-core", version = "0.1.0" }
 
 rmcp = { version = "2.2", features = [
     "server",

--- a/typos.toml
+++ b/typos.toml
@@ -7,3 +7,6 @@
 extend-exclude = []
 
 [default.extend-words]
+# glob_match backtracking test data in bugwarden-core/src/policy.rs: the
+# pattern "*a*b*" must NOT match the deliberately reversed string "ba".
+ba = "ba"


### PR DESCRIPTION
Fixes the two workflow failures from the initial push:

- **typos**: two real spellings (`unparseable` -> `unparsable`), the deliberate-typo unknown-key test probe replaced with a neutral `unknown_option` key, and the glob backtracking test string `ba` allowlisted in typos.toml with a justification comment.
- **rust-deny**: cargo-deny's `wildcards = "deny"` flags versionless path dependencies; the `bugwarden-core` path dep now pins `version = "0.1.0"`.


