### PR TITLE
Fix remaining typos in docs and example policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ A complete, commented example ships in
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `min_bug_age_days` | integer | `0` (disabled) | Bugs created less than N days ago are **invisible** — treated exactly like nonexistent bugs, evaluated before any rule. A bug whose `creation_time` is missing or unparseable is denied (fail closed) |
+| `min_bug_age_days` | integer | `0` (disabled) | Bugs created less than N days ago are **invisible** — treated exactly like nonexistent bugs, evaluated before any rule. A bug whose `creation_time` is missing or unparsable is denied (fail closed) |
 | `allow_private_comments` | boolean | `false` | Master switch for private comments. Even when `true`, each `bug_comments` call must also pass `include_private = true` |
 | `read_only` | boolean | `false` | Strip write capabilities from every grant and remove write tools from the tool listing. The `--read-only` flag ORs into this |
 | `disabled_tools` | array of strings | `[]` | Tool names to remove from the tool listing entirely |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -28,7 +28,7 @@ Dependency direction: `bugwarden -> bugwarden-core`, never the reverse.
 - **I3** Search filtering is silent: counts of dropped/filtered results are
   never returned to the client (server-side debug logging is fine).
 - **I4** Fail closed: classification-fetch failure, bug absent from the
-  response, or missing/unparseable `creation_time` when an age rule applies =>
+  response, or missing/unparsable `creation_time` when an age rule applies =>
   Denied.
 - **I5** Private comments (`is_private: true`) are returned only when policy
   `global.allow_private_comments = true` AND the call sets

--- a/examples/policy.toml
+++ b/examples/policy.toml
@@ -54,7 +54,7 @@ read_only = false
 # ---------------------------------------------------------------------------
 # Embargoed security bugs: fully invisible.
 #
-# NOTE: criteria inside one `match` are ANDed (a bug must satisfy all of
+# NOTE: criteria inside one `match` are AND-ed (a bug must satisfy all of
 # them), while entries inside one list are ORed. "In an embargo group OR
 # carrying the embargo keyword" therefore needs two consecutive deny rules.
 #
@@ -111,7 +111,7 @@ capabilities = ["summary"]
 [rule.match]
 # Matches if ANY of the bug's components matches ANY of these globs,
 # regardless of product. Add e.g. products = ["SUSE *"] to narrow it —
-# criteria in one match table are ANDed.
+# criteria in one match table are AND-ed.
 components = ["Partner*"]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Completes the typo cleanup: the earlier fix was based on a truncated CI log. Fixes `unparseable` in docs/DESIGN.md and README.md, rephrases `ANDed` as `AND-ed` in examples/policy.toml (the checker tokenizes it as AN+Ded). Verified with a local `typos` run over the whole tree.