### PR TITLE
feat(server): add guarded attachment download

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ touched or data is returned.
 
 ## Features
 
-- **Complete Bugzilla tool surface**: bug details,
-  history, comments, attachment metadata, quicksearch, comment/status/field/
+- **Complete Bugzilla tool surface**: bug details, history, comments,
+  attachment metadata and content, quicksearch, comment/status/field/
   assignee/CC/dependency updates, duplicate marking, server info, quicksearch
   syntax docs, and a bug-summarization prompt tool.
 - **Guard policy engine**: per-bug `allow` / `deny` / `restrict` decisions
@@ -219,9 +219,10 @@ A complete, commented example ships in
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `min_bug_age_days` | integer | `0` (disabled) | Bugs created less than N days ago are **invisible** — treated exactly like nonexistent bugs, evaluated before any rule. A bug whose `creation_time` is missing or unparsable is denied (fail closed) |
-| `allow_private_comments` | boolean | `false` | Master switch for private comments. Even when `true`, each `bug_comments` call must also pass `include_private = true` |
+| `allow_private_comments` | boolean | `false` | Master switch for **all** private content: comments, attachment metadata, and attachment downloads. Even when `true`, each call must also pass `include_private = true`. On an attachment download a *missing* privacy flag counts as private |
 | `read_only` | boolean | `false` | Strip write capabilities from every grant and remove write tools from the tool listing. The `--read-only` flag ORs into this |
 | `disabled_tools` | array of strings | `[]` | Tool names to remove from the tool listing entirely |
+| `max_attachment_bytes` | integer | `2097152` (2 MiB) | Largest attachment `download_attachment` may return (decoded size). `0` removes the cap. Attachment content is embedded base64 in the tool result and lands in the model's context — raise deliberately |
 
 ### `[[rule]]`
 
@@ -272,7 +273,7 @@ Eleven capabilities exist. `read` implies `summary`; nothing else is implied.
 | `summary` | read | redacted summary-only view (id, summary, status, resolution, product, component, severity, priority, creation/last-change time) |
 | `comments` | read | reading comments (also needed by `summarize_bug`) |
 | `history` | read | reading the bug's change history |
-| `attachments` | read | listing attachment metadata |
+| `attachments` | read | listing attachment metadata and downloading attachment content |
 | `comment` | write | adding a comment |
 | `status` | write | changing status/resolution, marking duplicates |
 | `fields` | write | changing priority, severity, resolution, `cf_*` custom fields |
@@ -294,6 +295,7 @@ action.
 | `bugs_quicksearch` | Bugzilla [quicksearch](https://bugzilla.readthedocs.io/en/latest/using/finding.html#quicksearch); results are silently policy-filtered (denied dropped, summary-only redacted) | per result: `read` / `summary` |
 | `summarize_bug` | Returns a summarization prompt built from the bug's public comments | `comments` |
 | `list_attachments` | Attachment metadata (never attachment content) | `attachments` |
+| `download_attachment` | Content of one attachment (raster images as image content, everything else as a base64 blob resource), capped by `max_attachment_bytes`; private attachments need the private-content double opt-in and, on download, a *missing* privacy flag counts as private | `attachments` on the owning bug |
 | `add_comment` | Add a comment to a bug | `comment` |
 | `update_bug_status` | Change status/resolution (CLOSED requires a resolution) | `status` |
 | `assign_bug` | Set the assignee | `assign` |
@@ -308,8 +310,6 @@ action.
 
 ## Roadmap
 
-- Attachment **download** with operator-configured size caps (currently only
-  metadata listing is exposed).
 - **OBS / openSUSE packaging** for installation via zypper.
 
 ## License

--- a/crates/bugwarden-core/src/client.rs
+++ b/crates/bugwarden-core/src/client.rs
@@ -279,6 +279,43 @@ impl BugzillaClient {
             .unwrap_or_else(|| Value::Array(Vec::new())))
     }
 
+    /// GET `/rest/bug/attachment/{attachment_id}?exclude_fields=data` — the
+    /// metadata of one attachment, without its content. Returns `None` when
+    /// the response carries no entry for the id.
+    pub async fn attachment_meta(&self, key: &str, attachment_id: u64) -> Result<Option<Value>> {
+        self.attachment_envelope(
+            key,
+            attachment_id,
+            &[("exclude_fields", "data".to_string())],
+        )
+        .await
+    }
+
+    /// GET `/rest/bug/attachment/{attachment_id}` — one attachment including
+    /// its base64 `data` field. Returns `None` when the response carries no
+    /// entry for the id.
+    ///
+    /// Callers must run the guard's attachment gate on the metadata BEFORE
+    /// calling this (I8): the blob is the sensitive payload.
+    pub async fn attachment_data(&self, key: &str, attachment_id: u64) -> Result<Option<Value>> {
+        self.attachment_envelope(key, attachment_id, &[]).await
+    }
+
+    async fn attachment_envelope(
+        &self,
+        key: &str,
+        attachment_id: u64,
+        query: &[(&str, String)],
+    ) -> Result<Option<Value>> {
+        let path = format!("/bug/attachment/{attachment_id}");
+        let v = self.get_json(key, &path, query).await?;
+        let id_key = attachment_id.to_string();
+        Ok(v.get("attachments")
+            .and_then(|atts| atts.get(id_key.as_str()))
+            .cloned()
+            .filter(|att| !att.is_null()))
+    }
+
     /// GET `{base_url}/page.cgi?id=quicksearch.html` — the quicksearch
     /// syntax documentation page. This is a plain HTML page, not a REST
     /// endpoint, and needs no authentication: no API key is attached.

--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -211,6 +211,60 @@ impl Guard {
         self.filter_private(attachments, include_private)
     }
 
+    /// The uniform attachment denial text.
+    ///
+    /// Mirrors `denial` (I2): a policy-blocked attachment and a nonexistent
+    /// attachment id MUST be indistinguishable, so an MCP client can never
+    /// probe attachment ids to learn whether hidden attachments exist.
+    pub fn attachment_denial(id: u64) -> String {
+        format!("Attachment {id} is not accessible through this server")
+    }
+
+    /// Gate for downloading a single attachment's content, evaluated on its
+    /// metadata BEFORE the blob is fetched. Returns the refusal text when
+    /// the download must be blocked, `None` when it may proceed.
+    ///
+    /// Two checks:
+    /// - private attachments need the I5 double opt-in — stricter than the
+    ///   metadata listing: a MISSING `is_private` flag on a full-content
+    ///   download is treated as private (fail closed, I4), because the blob
+    ///   is the payload the guard exists to protect;
+    /// - the upstream-reported `size` must fit
+    ///   `global.max_attachment_bytes` (`0` = no cap); a missing size while
+    ///   a cap is active fails closed.
+    pub fn attachment_gate(&self, attachment: &Value, include_private: bool) -> Option<String> {
+        let id = attachment.get("id").and_then(Value::as_u64).unwrap_or(0);
+        let is_private = attachment
+            .get("is_private")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+        if is_private && !(include_private && self.policy.global.allow_private_comments) {
+            return Some(Self::attachment_denial(id));
+        }
+        // The refusal names neither the attachment's size nor the configured
+        // cap: `max_attachment_bytes` is not among the policy fields I1
+        // permits a client to learn, and one oversized download must not
+        // disclose the operator's configuration.
+        let cap = self.policy.global.max_attachment_bytes;
+        if cap > 0 {
+            match attachment.get("size").and_then(Value::as_u64) {
+                Some(size) if size <= cap => {}
+                Some(_) => {
+                    return Some(format!(
+                        "Attachment {id} exceeds the size limit of this server"
+                    ));
+                }
+                None => {
+                    return Some(format!(
+                        "Attachment {id} has no reported size and cannot be \
+                         checked against the size limit of this server"
+                    ));
+                }
+            }
+        }
+        None
+    }
+
     /// Shared I5 double-opt-in filter for objects carrying an `is_private`
     /// flag. A missing flag means public.
     fn filter_private(&self, items: Vec<Value>, include_private: bool) -> Vec<Value> {
@@ -548,5 +602,98 @@ products = ["NoView*"]
         assert_eq!(dropped, 1);
         assert_eq!(kept.len(), 1);
         assert_eq!(kept[0]["id"], json!(2));
+    }
+
+    // ---------- attachment_gate ----------
+
+    fn public_attachment(size: u64) -> Value {
+        json!({ "id": 7, "is_private": false, "size": size })
+    }
+
+    #[test]
+    fn attachment_denial_matches_bug_denial_shape_i2() {
+        assert_eq!(
+            Guard::attachment_denial(7),
+            "Attachment 7 is not accessible through this server"
+        );
+    }
+
+    #[test]
+    fn attachment_gate_allows_public_within_cap() {
+        let g = Guard {
+            policy: Policy::default(),
+        };
+        assert_eq!(g.attachment_gate(&public_attachment(1024), false), None);
+    }
+
+    #[test]
+    fn attachment_gate_denies_private_without_double_opt_in_i5() {
+        let allowing = Guard {
+            policy: policy("[global]\nallow_private_comments = true"),
+        };
+        let strict = Guard {
+            policy: Policy::default(),
+        };
+        let private = json!({ "id": 7, "is_private": true, "size": 10 });
+        // Policy alone is not enough...
+        assert!(allowing.attachment_gate(&private, false).is_some());
+        // ...the flag alone is not enough...
+        assert!(strict.attachment_gate(&private, true).is_some());
+        // ...both together are.
+        assert_eq!(allowing.attachment_gate(&private, true), None);
+        // The private denial is the uniform text (I2).
+        assert_eq!(
+            strict.attachment_gate(&private, true),
+            Some(Guard::attachment_denial(7))
+        );
+    }
+
+    #[test]
+    fn attachment_gate_missing_is_private_fails_closed_i4() {
+        let g = Guard {
+            policy: Policy::default(),
+        };
+        assert!(g
+            .attachment_gate(&json!({ "id": 7, "size": 10 }), false)
+            .is_some());
+    }
+
+    #[test]
+    fn attachment_gate_enforces_size_cap() {
+        let g = Guard {
+            policy: policy("[global]\nmax_attachment_bytes = 100"),
+        };
+        assert_eq!(g.attachment_gate(&public_attachment(100), false), None);
+        let refusal = g.attachment_gate(&public_attachment(101), false);
+        assert!(refusal.is_some_and(|r| r.contains("size limit")));
+    }
+
+    #[test]
+    fn attachment_gate_missing_size_fails_closed_under_cap_i4() {
+        let g = Guard {
+            policy: Policy::default(),
+        };
+        let no_size = json!({ "id": 7, "is_private": false });
+        assert!(g.attachment_gate(&no_size, false).is_some());
+        // Without a cap there is nothing to check against.
+        let uncapped = Guard {
+            policy: policy("[global]\nmax_attachment_bytes = 0"),
+        };
+        assert_eq!(uncapped.attachment_gate(&no_size, false), None);
+    }
+
+    #[test]
+    fn default_policy_caps_attachments_at_two_mib() {
+        assert_eq!(
+            Policy::default().global.max_attachment_bytes,
+            2 * 1024 * 1024
+        );
+        // TOML without the key gets the same non-zero default (fail closed).
+        assert_eq!(
+            policy("default_action = \"allow\"")
+                .global
+                .max_attachment_bytes,
+            2 * 1024 * 1024
+        );
     }
 }

--- a/crates/bugwarden-core/src/policy.rs
+++ b/crates/bugwarden-core/src/policy.rs
@@ -63,7 +63,7 @@ pub enum Capability {
     Comments,
     /// Read change history.
     History,
-    /// List attachment metadata.
+    /// List attachment metadata and download attachment content.
     Attachments,
     /// Write: add a comment.
     Comment,
@@ -307,7 +307,7 @@ pub struct Rule {
 }
 
 /// Policy-wide guards applied on top of (and before) the rule list.
-#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct GlobalGuards {
     /// Deny every bug younger than this many days; `0` disables the gate.
@@ -329,6 +329,30 @@ pub struct GlobalGuards {
     /// Enforcement lives in the `bugwarden` binary crate.
     #[serde(default)]
     pub disabled_tools: Vec<String>,
+    /// Largest attachment (decoded bytes, as reported by Bugzilla) that
+    /// `download_attachment` may return; `0` removes the cap. Defaults to
+    /// 2 MiB — attachment blobs are base64-embedded in tool results and land
+    /// in the model's context, so unlimited is an explicit operator choice.
+    #[serde(default = "default_max_attachment_bytes")]
+    pub max_attachment_bytes: u64,
+}
+
+fn default_max_attachment_bytes() -> u64 {
+    2 * 1024 * 1024
+}
+
+// Hand-written so the no-policy-file default carries the 2 MiB attachment
+// cap: a derived `Default` would zero it, which means "no cap" (fail open).
+impl Default for GlobalGuards {
+    fn default() -> Self {
+        Self {
+            min_bug_age_days: 0,
+            allow_private_comments: false,
+            read_only: false,
+            disabled_tools: Vec::new(),
+            max_attachment_bytes: default_max_attachment_bytes(),
+        }
+    }
 }
 
 fn default_default_action() -> Action {

--- a/crates/bugwarden-core/tests/attachment_wiremock.rs
+++ b/crates/bugwarden-core/tests/attachment_wiremock.rs
@@ -1,0 +1,112 @@
+//! HTTP-level integration tests for the attachment client endpoints
+//! (wiremock), pinning the contracts DESIGN.md asserts for
+//! `attachment_meta` / `attachment_data`: the string-keyed envelope parse,
+//! `None` when the response carries no entry for the id, exclusion of the
+//! blob from the metadata request, and error mapping that never leaks the
+//! API key (I12).
+
+use bugwarden_core::client::BugzillaClient;
+use serde_json::json;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Deliberately distinctive so a leak into any error text is unmistakable (I12).
+const KEY: &str = "SUPERSECRETKEY123";
+
+fn client(server: &MockServer) -> BugzillaClient {
+    BugzillaClient::new(&server.uri(), false).expect("client must build")
+}
+
+#[tokio::test]
+async fn attachment_meta_parses_string_keyed_envelope_without_data() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/77"))
+        .and(query_param("exclude_fields", "data"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "attachments": {
+                "77": { "id": 77, "bug_id": 4242, "size": 12, "is_private": false }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let meta = client(&server)
+        .attachment_meta(KEY, 77)
+        .await
+        .expect("request must succeed")
+        .expect("id 77 must be present");
+    assert_eq!(meta["bug_id"], json!(4242));
+    assert!(meta.get("data").is_none(), "metadata must carry no blob");
+}
+
+#[tokio::test]
+async fn attachment_data_returns_the_blob() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/77"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "attachments": {
+                "77": { "id": 77, "bug_id": 4242, "data": "aGVsbG8=" }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let att = client(&server)
+        .attachment_data(KEY, 77)
+        .await
+        .expect("request must succeed")
+        .expect("id 77 must be present");
+    assert_eq!(att["data"], json!("aGVsbG8="));
+}
+
+#[tokio::test]
+async fn absent_id_maps_to_none_not_an_error() {
+    let server = MockServer::start().await;
+    // A response whose envelope simply does not mention the requested id, and
+    // one that maps it to null: both are "no such attachment", not a failure.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/1"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!({ "attachments": { "2": { "id": 2 } } })),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/3"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "attachments": { "3": null } })),
+        )
+        .mount(&server)
+        .await;
+
+    let c = client(&server);
+    assert!(c.attachment_meta(KEY, 1).await.expect("ok").is_none());
+    assert!(c.attachment_data(KEY, 3).await.expect("ok").is_none());
+}
+
+#[tokio::test]
+async fn error_response_maps_to_error_without_leaking_the_key() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/9"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "error": true, "message": "You must log in before using this part of Bugzilla."
+        })))
+        .mount(&server)
+        .await;
+
+    let err = client(&server)
+        .attachment_meta(KEY, 9)
+        .await
+        .expect_err("401 must be an error");
+    let text = format!("{err:#}");
+    assert!(text.contains("401"), "status must be reported: {text}");
+    assert!(text.contains("You must log in"), "message kept: {text}");
+    assert!(
+        !text.contains(KEY),
+        "API key leaked into error text: {text}"
+    );
+}

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -96,6 +96,47 @@ fn dep_change(add: Option<&Vec<u64>>, remove: Option<&Vec<u64>>) -> Option<Value
     }
 }
 
+/// Decoded byte length of a base64 payload, counting the `=` padding out.
+///
+/// Used to re-check an attachment against the size cap without decoding the
+/// blob. Whitespace inside the payload (some encoders wrap lines) is ignored,
+/// so a wrapped body is not mistaken for a larger one.
+fn decoded_len(blob: &str) -> u64 {
+    let chars = blob.chars().filter(|c| !c.is_whitespace()).count() as u64;
+    let padding = blob
+        .trim_end()
+        .chars()
+        .rev()
+        .take_while(|&c| c == '=')
+        .count() as u64;
+    // 4 encoded chars carry 3 bytes; an unpadded tail of 2 or 3 chars carries
+    // 1 or 2 bytes respectively.
+    let full = chars / 4 * 3;
+    let tail = (chars % 4).saturating_sub(1);
+    (full + tail).saturating_sub(padding)
+}
+
+/// Whether attachment content of this media type may be returned as MCP
+/// image content rather than an opaque blob resource.
+///
+/// The media type comes from whoever uploaded the attachment, so this is a
+/// strict allowlist of raster formats, not a `image/` prefix test. Anything
+/// else — notably `image/svg+xml`, which is script-bearing markup in a client
+/// webview — travels as a blob resource, keeping attacker-chosen bytes out of
+/// the model's image channel and out of client image renderers.
+fn is_inline_image(mime: &str) -> bool {
+    let base = mime
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    matches!(
+        base.as_str(),
+        "image/png" | "image/jpeg" | "image/gif" | "image/webp" | "image/bmp"
+    )
+}
+
 fn default_status() -> String {
     "ALL".to_string()
 }
@@ -257,6 +298,15 @@ pub struct ListAttachmentsParams {
     /// Bug ID.
     pub bug_id: u64,
     /// Include metadata of private attachments (subject to server policy).
+    #[serde(default)]
+    pub include_private: bool,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct DownloadAttachmentParams {
+    /// Attachment id (as returned by list_attachments).
+    pub attachment_id: u64,
+    /// Allow downloading a private attachment (subject to server policy).
     #[serde(default)]
     pub include_private: bool,
 }
@@ -976,6 +1026,148 @@ impl BugWarden {
     }
 
     #[tool(
+        description = "Download the content of a single attachment by its attachment id (see list_attachments). Raster images are returned as image content, everything else as a base64 blob resource. Subject to server policy: a size limit applies, and private attachments must be requested explicitly.",
+        annotations(read_only_hint = true, open_world_hint = true)
+    )]
+    async fn download_attachment(
+        &self,
+        Parameters(p): Parameters<DownloadAttachmentParams>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        tracing::info!(
+            attachment_id = p.attachment_id,
+            include_private = p.include_private,
+            "tool: download_attachment"
+        );
+        let key = self.api_key(&ctx)?;
+
+        // Metadata first, never the blob: it names the owning bug for guard
+        // assessment and feeds the private/size gates, all BEFORE any content
+        // is pulled (I8). Every refusal on this path is the uniform
+        // attachment denial (I2) — a fetch error, an unknown id, a denied
+        // owning bug and a private attachment must be indistinguishable.
+        let meta = match self.bz.attachment_meta(&key, p.attachment_id).await {
+            Ok(Some(meta)) => Some(meta),
+            Ok(None) => None,
+            Err(e) => {
+                tracing::debug!(
+                    attachment_id = p.attachment_id,
+                    error = %e,
+                    "attachment metadata fetch failed"
+                );
+                None
+            }
+        };
+        // Bug id 0 never exists, so the classification below is a pure
+        // constant-cost stand-in when there is no metadata. Without it the
+        // "no metadata" paths would issue one upstream request and the
+        // "metadata found" paths two, letting a client time its calls to
+        // learn which attachment ids exist — the very oracle the uniform
+        // denial closes (I2).
+        let assess_id = meta
+            .as_ref()
+            .and_then(|m| m.get("bug_id"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let assessments = self.assess(&key, &[assess_id]).await;
+        let allowed = assessments
+            .get(&assess_id)
+            .is_some_and(|(access, _)| access.allows(Capability::Attachments));
+
+        let Some(meta) = meta.filter(|_| allowed && assess_id != 0) else {
+            // Missing metadata, missing bug id, or a denied owning bug: one
+            // uniform denial. The bug-level denial text is deliberately NOT
+            // reused — it would confirm which bug owns the attachment.
+            return Ok(err_text(Guard::attachment_denial(p.attachment_id)));
+        };
+        if let Some(refusal) = self.guard.attachment_gate(&meta, p.include_private) {
+            return Ok(err_text(refusal));
+        }
+
+        let attachment = match self.bz.attachment_data(&key, p.attachment_id).await {
+            Ok(Some(att)) => att,
+            // A failed blob fetch gets the same uniform denial as an unknown
+            // id: the upstream status and message would otherwise distinguish
+            // the two and disclose server detail.
+            Ok(None) => return Ok(err_text(Guard::attachment_denial(p.attachment_id))),
+            Err(e) => {
+                tracing::debug!(
+                    attachment_id = p.attachment_id,
+                    error = %e,
+                    "attachment data fetch failed"
+                );
+                return Ok(err_text(Guard::attachment_denial(p.attachment_id)));
+            }
+        };
+        // The gate ran on the metadata response; the bytes come from a second,
+        // later request. Re-run it on what actually arrived and re-check the
+        // owning bug, so an attachment that turns private (or moves to another
+        // bug) between the two calls cannot be served.
+        if attachment.get("bug_id").and_then(Value::as_u64) != Some(assess_id) {
+            return Ok(err_text(Guard::attachment_denial(p.attachment_id)));
+        }
+        if let Some(refusal) = self.guard.attachment_gate(&attachment, p.include_private) {
+            return Ok(err_text(refusal));
+        }
+
+        let Some(blob) = attachment
+            .get("data")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+        else {
+            return Ok(err_text("Attachment has no data"));
+        };
+        // Defense in depth: the size gate trusted the upstream-REPORTED size;
+        // re-check the payload itself so a wrong or lying `size` cannot
+        // smuggle an oversized blob past the cap. The decoded length is
+        // computed exactly (4 base64 chars per 3 bytes, minus the padding)
+        // so the cap stays inclusive, matching the metadata gate.
+        let cap = self.guard.policy.global.max_attachment_bytes;
+        if cap > 0 && decoded_len(&blob) > cap {
+            return Ok(err_text(format!(
+                "Attachment {} exceeds the size limit of this server",
+                p.attachment_id
+            )));
+        }
+
+        let mime = attachment
+            .get("content_type")
+            .and_then(Value::as_str)
+            .unwrap_or("application/octet-stream")
+            .to_string();
+        let file_name = attachment
+            .get("file_name")
+            .and_then(Value::as_str)
+            .unwrap_or("attachment")
+            .to_string();
+        let summary = json!({
+            "id": p.attachment_id,
+            "bug_id": assess_id,
+            "file_name": file_name,
+            "content_type": mime,
+            "size": attachment.get("size").cloned().unwrap_or(Value::Null),
+        });
+        let content = if is_inline_image(&mime) {
+            ContentBlock::image(blob, mime)
+        } else {
+            // The uri carries only the attachment id: `file_name` is chosen by
+            // whoever uploaded the attachment and may contain `../`, control
+            // characters, or query/fragment syntax. It is reported in the
+            // summary block above, where it is inert.
+            ContentBlock::resource(ResourceContents::BlobResourceContents {
+                uri: format!("bugzilla://attachment/{}", p.attachment_id),
+                mime_type: Some(mime),
+                blob,
+                meta: None,
+            })
+        };
+        Ok(CallToolResult::success(vec![
+            ContentBlock::text(serde_json::to_string_pretty(&summary).unwrap_or_default()),
+            content,
+        ]))
+    }
+
+    #[tool(
         description = "Returns the bug url",
         annotations(read_only_hint = true, open_world_hint = false)
     )]
@@ -1170,5 +1362,19 @@ mod tests {
             );
         }
         assert!(server.tool_router.has_route("bug_info"));
+    }
+
+    #[test]
+    fn inline_image_allowlist_excludes_svg_and_unknown_types() {
+        assert!(is_inline_image("image/png"));
+        assert!(is_inline_image("IMAGE/PNG"));
+        assert!(is_inline_image("image/jpeg; charset=binary"));
+        // Script-bearing or unverified media types must travel as blobs.
+        assert!(!is_inline_image("image/svg+xml"));
+        assert!(!is_inline_image("image/svg+xml; charset=utf-8"));
+        assert!(!is_inline_image("text/html"));
+        assert!(!is_inline_image("application/octet-stream"));
+        assert!(!is_inline_image("image/"));
+        assert!(!is_inline_image("imagexpng"));
     }
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -30,9 +30,11 @@ Dependency direction: `bugwarden -> bugwarden-core`, never the reverse.
 - **I4** Fail closed: classification-fetch failure, bug absent from the
   response, or missing/unparsable `creation_time` when an age rule applies =>
   Denied.
-- **I5** Private comments (`is_private: true`) are returned only when policy
+- **I5** Private content (`is_private: true`) is returned only when policy
   `global.allow_private_comments = true` AND the call sets
-  `include_private = true`. Default policy (no file) has
+  `include_private = true`. This one switch governs private comments,
+  private attachment metadata, and private attachment content alike; on a
+  content download a MISSING flag counts as private (I4). Default policy (no file) has
   `allow_private_comments = false` — private data is strictly opt-in.
 - **I6** Capability implication: `read` implies `summary`. Nothing else is
   implied.
@@ -77,7 +79,7 @@ pub enum Capability {
     Summary,     // redacted summary-only view
     Comments,    // read comments
     History,     // read history
-    Attachments, // list attachment metadata
+    Attachments, // list attachment metadata + download attachment content
     Comment,     // write: add comment
     Status,      // write: status/resolution/duplicate
     Fields,      // write: priority/severity/resolution/custom cf_* fields
@@ -126,14 +128,19 @@ pub struct Rule {
     #[serde(default)] pub capabilities: Vec<Capability>, // only for action = "restrict"
 }
 
-#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct GlobalGuards {
     #[serde(default)] pub min_bug_age_days: i64,        // 0 = disabled
     #[serde(default)] pub allow_private_comments: bool, // default false
     #[serde(default)] pub read_only: bool,
     #[serde(default)] pub disabled_tools: Vec<String>,
+    // Cap on download_attachment content (decoded bytes); 0 = no cap.
+    // serde default AND the hand-written `Default` impl are BOTH 2 MiB — a
+    // derived Default would zero it, silently removing the cap (fail open).
+    #[serde(default = "default_max_attachment_bytes")] pub max_attachment_bytes: u64,
 }
+impl Default for GlobalGuards; // all fields as above, max_attachment_bytes = 2 MiB
 
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -211,6 +218,23 @@ impl Guard {
 
     /// Drops is_private comments unless include_private && policy allows (I5).
     pub fn filter_comments(&self, comments: Vec<serde_json::Value>, include_private: bool) -> Vec<serde_json::Value>;
+
+    /// Same I5 double opt-in for private attachment METADATA (listing).
+    pub fn filter_attachments(&self, attachments: Vec<serde_json::Value>, include_private: bool) -> Vec<serde_json::Value>;
+
+    /// Uniform denial text for attachments (I2 analogue): blocked and
+    /// nonexistent attachment ids must be indistinguishable.
+    pub fn attachment_denial(id: u64) -> String; // "Attachment {id} is not accessible through this server"
+
+    /// Pre-download gate on attachment METADATA (run before the blob fetch,
+    /// I8): private needs the I5 double opt-in and a MISSING is_private flag
+    /// counts as private on download (stricter than listing; the blob is the
+    /// payload, fail closed I4); reported size must fit
+    /// global.max_attachment_bytes (0 = no cap; missing size under an active
+    /// cap fails closed; the refusal names neither the size nor the cap —
+    /// max_attachment_bytes is not I1-disclosable). Returns
+    /// Some(refusal_text) when blocked.
+    pub fn attachment_gate(&self, attachment: &serde_json::Value, include_private: bool) -> Option<String>;
 }
 ```
 
@@ -234,6 +258,8 @@ impl BugzillaClient {
     pub async fn update_bug(&self, key: &str, id: u64, payload: serde_json::Value) -> anyhow::Result<serde_json::Value>;
     pub async fn attachments(&self, key: &str, id: u64) -> anyhow::Result<serde_json::Value>;
     pub async fn quicksearch_syntax_html(&self) -> anyhow::Result<String>;
+    pub async fn attachment_meta(&self, key: &str, attachment_id: u64) -> anyhow::Result<Option<serde_json::Value>>; // exclude_fields=data
+    pub async fn attachment_data(&self, key: &str, attachment_id: u64) -> anyhow::Result<Option<serde_json::Value>>; // includes base64 `data`
 }
 ```
 
@@ -250,6 +276,8 @@ Endpoint mapping:
 | quicksearch | GET /rest/bug?quicksearch={status}+" "+{query}&include_fields=..&limit=..&offset=..&order=relevance | envelope |
 | update_bug | PUT /rest/bug/{id} with caller-built payload (caller adds `"comment": {"body": ..}` when set) | envelope |
 | attachments | GET /rest/bug/{id}/attachment?exclude_fields=data | `envelope.bugs.{id}` array as Value |
+| attachment_meta | GET /rest/bug/attachment/{attachment_id}?exclude_fields=data | `envelope.attachments.{id}` object, `None` when absent |
+| attachment_data | GET /rest/bug/attachment/{attachment_id} | `envelope.attachments.{id}` object incl. base64 `data`, `None` when absent |
 | quicksearch_syntax_html | GET {base_url}/page.cgi?id=quicksearch.html (no auth needed) | HTML string |
 
 Auth per request: `use_auth_header` ? header `Authorization: Bearer {key}` :
@@ -261,7 +289,8 @@ HTTP status and Bugzilla `message` field; reqwest errors sanitized with
 ## MCP tool surface (crates/bugwarden/src/server.rs)
 
 Result convention: success => `CallToolResult::success` with ONE text block of
-pretty-printed JSON. Guard refusals and input-validation failures =>
+pretty-printed JSON. The sole exception is `download_attachment`, which
+returns a JSON summary text block PLUS one image or blob-resource block. Guard refusals and input-validation failures =>
 `CallToolResult::error` with a text block (NOT a protocol error). Protocol
 issues (missing API key header) => `McpError::invalid_request`.
 
@@ -282,6 +311,7 @@ constraints the model must know.
 | add_cc_to_bug | bug_id, cc_email | cc (write) | payload `{"cc": {"add": [email]}}` |
 | mark_as_duplicate | bug_id, duplicate_of, comment = "" | status on bug_id + summary on duplicate_of (I11) | default comment "Marking as duplicate of bug {duplicate_of}"; payload status CLOSED, resolution DUPLICATE, dupe_of |
 | list_attachments | bug_id | attachments | metadata only (`exclude_fields=data`) |
+| download_attachment | attachment_id, include_private: bool = false | attachments (on the owning bug) | metadata fetched FIRST (no blob) for guard assessment + attachment_gate; unknown id, metadata OR blob fetch failure, denied owning bug, missing bug_id, and private-without-opt-in all yield the uniform attachment denial. Constant upstream request count on every path (a metadata miss still runs one classify call against bug id 0) so call latency is not an existence oracle. The gate AND the bug-id check re-run on the blob response (TOCTOU), then the actual base64 size is re-checked against the cap (a lying `size` cannot bypass it). Raster image types from a strict allowlist => ContentBlock::image; everything else (incl. image/svg+xml) => BlobResourceContents whose uri carries only the attachment id (uploader-chosen file_name never enters the uri) |
 | bug_url | bug_id | none (I8 exception) | `{base_url}/show_bug.cgi?id={id}` |
 | bugzilla_server_info | — | none | client.server_info |
 | quicksearch_syntax | — | none | HTML doc page |

--- a/examples/policy.toml
+++ b/examples/policy.toml
@@ -1,16 +1,12 @@
 # bugwarden guard policy — worked example
 # =======================================
 #
-# This is the scenario bugwarden was built for: an AI agent may work with a
-# public Bugzilla instance, but
+# The scenario this file implements:
 #
-#   * bugs younger than one week do not exist for it (they are the ones most
-#     likely to carry not-yet-triaged sensitive details),
-#   * embargoed security bugs are completely invisible,
-#   * on the security product it may only see redacted summaries and add
-#     comments,
-#   * on a partner component it may only see redacted summaries,
-#   * everything else is fully allowed.
+#   * embargoed security bugs are completely invisible, always;
+#   * bugs labelled "security" are invisible while they are fresher than
+#     5 days (the window in which details are typically still unreviewed);
+#   * everything else is shown to the user in full.
 #
 # The policy is read once at server startup (--policy / BUGWARDEN_POLICY) and
 # is never visible to the MCP client. Parsing is strict: unknown keys anywhere
@@ -25,21 +21,22 @@
 # priorities): case-insensitive match of the whole value; '*' matches any
 # (possibly empty) substring; everything else is literal.
 
-# What happens to bugs that no rule below matches.
+# What happens to bugs that no rule below matches: everything not caught by a
+# rule stays fully visible.
 # One of "allow" | "deny" ("restrict" is not permitted here — use a catch-all
 # restrict rule as the last [[rule]] instead).
 default_action = "allow"
 
 [global]
-# Bugs created less than N days ago are treated exactly like nonexistent bugs:
-# same denial text, silently dropped from search results. A bug whose
-# creation_time cannot be determined is also denied (fail closed).
-# 0 disables the check.
-min_bug_age_days = 7
+# Blanket minimum age for EVERY bug, regardless of labels. This example does
+# not use it — freshness is only restricted for security bugs, via the rules
+# below — but set it to N to make all bugs younger than N days invisible.
+min_bug_age_days = 0
 
-# Master switch for private comments. Even with `true`, a bug_comments call
-# must additionally pass include_private = true to receive them.
-# Default (and recommended): false.
+# Master switch for private content: comments, attachment metadata, and
+# attachment downloads. Even with `true`, each call must additionally pass
+# include_private = true. On an attachment download a MISSING privacy flag
+# counts as private. Default (and recommended): false.
 allow_private_comments = false
 
 # Strip all write capabilities from every grant and remove the write tools
@@ -51,8 +48,13 @@ read_only = false
 # them). Works independently of read_only.
 #disabled_tools = ["update_bug_dependencies", "mark_as_duplicate"]
 
+# Largest attachment (decoded bytes) download_attachment may return; the
+# content is embedded base64 in the tool result and consumes model context.
+# 0 removes the cap. Default: 2 MiB.
+#max_attachment_bytes = 2097152
+
 # ---------------------------------------------------------------------------
-# Embargoed security bugs: fully invisible.
+# 1. Embargoed security bugs: fully invisible, at any age.
 #
 # NOTE: criteria inside one `match` are AND-ed (a bug must satisfy all of
 # them), while entries inside one list are ORed. "In an embargo group OR
@@ -65,7 +67,7 @@ read_only = false
 
 [[rule]]
 name = "embargoed-groups"
-description = "Bugs restricted to security/embargo groups are invisible to the agent"
+description = "Bugs restricted to security/embargo groups are invisible"
 action = "deny"
 [rule.match]
 # Matches if ANY of the bug's group names matches ANY of these globs.
@@ -73,72 +75,87 @@ groups = ["security-team", "embargo*"]
 
 [[rule]]
 name = "embargo-keyword"
-description = "Bugs flagged with the embargo keyword are invisible to the agent"
+description = "Bugs flagged with an embargo keyword are invisible"
 action = "deny"
 [rule.match]
-keywords = ["security-embargo"]
+keywords = ["security-embargo", "embargo*"]
 
 # ---------------------------------------------------------------------------
-# Security product: the agent may triage (see redacted summaries, leave
-# comments) but not read full bug bodies, comments, history or attachments,
-# and not perform any other write.
+# 2. Fresh security bugs: invisible until they are 5 days old.
 #
-# "read" is NOT granted here; note that granting "read" would implicitly
-# grant "summary" as well (read implies summary — the only implication).
+# Both criteria are AND-ed, so these rules hide a bug only while it is BOTH
+# security-labelled AND younger than 5 days. Once it ages past the window no
+# rule matches it any more and default_action ("allow") applies — the bug
+# becomes fully visible without any policy change.
+#
+# A bug whose creation_time is missing or unparsable MATCHES younger_than_days
+# (fail closed): an age that cannot be established is treated as fresh.
+#
+# Three rules because "security" can be expressed three ways; drop the ones
+# your instance does not use.
 # ---------------------------------------------------------------------------
 
 [[rule]]
-name = "security-product-comment-only"
-description = "Summary view plus commenting on the security product; nothing else"
-action = "restrict"
-# Required (non-empty) because action = "restrict"; must be absent for
-# allow/deny rules. Full vocabulary, for reference:
-#   read summary comments history attachments   (read capabilities)
-#   comment status fields assign cc deps        (write capabilities)
-capabilities = ["summary", "comment"]
+name = "fresh-security-keyword"
+description = "Security-keyworded bugs are hidden for their first 5 days"
+action = "deny"
 [rule.match]
-products = ["Security*"]
-
-# ---------------------------------------------------------------------------
-# Partner component: redacted summaries only, read-only.
-# ---------------------------------------------------------------------------
+keywords = ["security*"]
+younger_than_days = 5
 
 [[rule]]
-name = "partner-summary-only"
-description = "Partner bugs expose only the redacted summary view"
-action = "restrict"
-capabilities = ["summary"]
+name = "fresh-security-group"
+description = "Bugs in a security group are hidden for their first 5 days"
+action = "deny"
 [rule.match]
-# Matches if ANY of the bug's components matches ANY of these globs,
-# regardless of product. Add e.g. products = ["SUSE *"] to narrow it —
-# criteria in one match table are AND-ed.
-components = ["Partner*"]
+groups = ["security*"]
+younger_than_days = 5
+
+[[rule]]
+name = "fresh-security-whiteboard"
+description = "Bugs whiteboard-tagged security are hidden for their first 5 days"
+action = "deny"
+[rule.match]
+# Case-insensitive substring search in the bug's whiteboard.
+whiteboard_contains = ["security"]
+younger_than_days = 5
 
 # ---------------------------------------------------------------------------
-# Inactive example: every remaining match criterion, in one rule.
+# Inactive examples: the remaining actions and match criteria.
 # Uncomment and adapt as needed. A rule with NO match table at all is a
 # catch-all that matches every bug.
 # ---------------------------------------------------------------------------
 
+# Redacted summary view plus commenting, nothing else. Note that "read" is NOT
+# granted here; granting "read" would implicitly grant "summary" as well
+# (read implies summary — the only implication).
 #[[rule]]
-#name = "fresh-hot-bugs-look-dont-touch"
-#description = "Recent, escalated, still-open bugs: readable but frozen"
+#name = "security-product-comment-only"
+#description = "Summary view plus commenting on the security product"
+#action = "restrict"
+## Required (non-empty) because action = "restrict"; must be absent for
+## allow/deny rules. Full vocabulary, for reference:
+##   read summary comments history attachments   (read capabilities)
+##   comment status fields assign cc deps        (write capabilities)
+#capabilities = ["summary", "comment"]
+#[rule.match]
+#products = ["Security*"]
+
+# Every remaining match criterion, in one rule.
+#[[rule]]
+#name = "hot-bugs-look-dont-touch"
+#description = "Escalated, still-open bugs: readable but frozen"
 #action = "restrict"
 #capabilities = ["read", "comments", "history", "attachments"]
 #[rule.match]
+## Matches if ANY of the bug's components matches ANY of these globs.
+#components = ["Partner*"]
 ## Bug status must match one of these globs...
 #statuses = ["NEW", "IN_PROGRESS", "CONFIRMED"]
 ## ...AND severity one of these...
 #severities = ["critical", "urgent"]
-## ...AND priority one of these...
+## ...AND priority one of these.
 #priorities = ["P0", "P1"]
-## ...AND the whiteboard must contain one of these case-insensitive
-## substrings...
-#whiteboard_contains = ["escalation", "hot"]
-## ...AND the bug must have been created within the last 30 days. A bug whose
-## creation_time is missing MATCHES this criterion (fail closed: a deny or
-## restrict rule still catches bugs of unknown age).
-#younger_than_days = 30
 
 # No catch-all rule: bugs that reach the end of the list get default_action
 # ("allow" above), minus write capabilities whenever the server runs


### PR DESCRIPTION
Adds `download_attachment`, the last non-packaging roadmap item. Metadata is fetched first — never the blob — so guard assessment on the owning bug (I8) and a new pre-download gate both run before any content is pulled.

**Policy:** new `global.max_attachment_bytes` (default 2 MiB, `0` removes the cap) bounds what may be embedded in a tool result, enforced on the reported size and re-checked against the actual base64 payload. Private attachments need the same double opt-in as private comments (I5), and on download a *missing* privacy flag counts as private (I4).

**Hardened per pre-PR adversarial review** (findings against DESIGN.md invariants, all addressed in this branch):

| Finding | Fix |
|---|---|
| Existence oracle via upstream request count/latency (1 request for a missing id vs 2 for a real one) | constant request count on every path — a metadata miss still runs one classify call |
| Blob-fetch failure returned the raw upstream status/message, distinguishable from an unknown id | uniform attachment denial (I2) on that path too |
| TOCTOU: gate ran on the metadata response, bytes came from a second request | gate and owning-bug check re-run on the blob response |
| Size refusal disclosed both the attachment size and the configured cap | refusal names neither (I1 limits what policy a client may learn) |
| Uploader-chosen `file_name` interpolated into the resource uri (`../` traversal for clients persisting by uri) | uri carries only the attachment id; the name stays in the inert JSON summary |
| Any `image/*` went to the model's image channel, incl. script-bearing `image/svg+xml` | strict raster allowlist; everything else travels as a blob resource |

Verified: `cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (105 tests, incl. new gate and media-type cases), `typos`.