### PR TITLE
ci: publish to crates.io from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,3 +101,47 @@ jobs:
           --title "$GITHUB_REF_NAME"
           --generate-notes
           dist/*
+
+  publish:
+    # crates.io last: a version can be yanked but never replaced, so it only
+    # goes out once every platform built and the GitHub release exists.
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      # Trusted Publishing exchanges this OIDC token for a short-lived
+      # crates.io token, so no registry credential is stored in the repo.
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
+        with:
+          # Keep in sync with rust-toolchain.toml.
+          toolchain: "1.97.0"
+
+      - name: Authenticate to crates.io
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18  # v1.0.5
+        id: auth
+
+      - name: Publish crates
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$GITHUB_REF_NAME"
+          # bugwarden-core first: the binary crate resolves its dependency
+          # from the index and cannot even be packaged before core is there.
+          for crate in bugwarden-core bugwarden; do
+            # Re-running a release must not fail on a version already up.
+            if curl -sSf -H 'User-Agent: bugwarden-release' \
+                 "https://crates.io/api/v1/crates/${crate}/${version}" >/dev/null 2>&1; then
+              echo "::notice::${crate} ${version} is already published, skipping"
+              continue
+            fi
+            cargo publish --locked -p "$crate"
+          done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,3 +128,26 @@ are never a justification for undoing them.
 - Changes to guard behavior get an adversarial review against the DESIGN.md
   invariants before the PR is opened, and the findings addressed or
   explicitly rebutted in the PR body.
+
+## Releases
+
+A release is one push of an annotated tag; nothing is released by hand.
+
+- The tag is the bare version, no `v` prefix (`0.1.0`, `0.2.0rc1`), and must
+  equal `[workspace.package] version` — the workflow refuses to build a tag
+  that disagrees with the manifest. Bump the version in a normal PR first,
+  then tag the merge commit on `main`.
+- `.github/workflows/release.yml` then does everything: hermetic builds for
+  x86_64-unknown-linux-gnu and aarch64-apple-darwin, a GitHub release with
+  both tarballs and their `.sha256` files, and finally the crates.io publish
+  — `bugwarden-core` before `bugwarden`, because the binary crate resolves
+  its dependency from the index and cannot be packaged before core is there.
+- Publishing uses crates.io Trusted Publishing over the workflow's OIDC
+  token, so the repository stores no registry credential. Both crates must
+  have this repository, workflow `release.yml`, and no environment
+  configured under their crates.io *Trusted Publishing* settings; without
+  that the publish job fails to authenticate.
+- The publish step skips a crate whose version is already on crates.io, so a
+  re-run of a partially failed release is safe. A published version can be
+  yanked but never replaced: treat the tag push as irreversible, and prefer
+  fixing forward with a new patch version.


### PR DESCRIPTION
## What

Releases now publish to crates.io themselves. A `publish` job runs after the
GitHub release exists, so the registry only ever sees a version whose
platforms all built — and crates.io versions can be yanked but never
replaced, which makes "last" the right position for it.

- `bugwarden-core` is published before `bugwarden`: the binary crate resolves
  its dependency from the index and cannot even be *packaged* before core is
  there.
- A crate whose version is already on crates.io is skipped, so re-running a
  release that failed halfway is harmless.
- AGENTS.md gains a Releases section describing the whole flow.

## Authentication

Trusted Publishing, exchanging the job's OIDC token for a short-lived
registry token — no `CARGO_REGISTRY_TOKEN` secret is stored in the repo.

**This needs one-time setup on crates.io before the next tag**, for *both*
crates, under the crate's *Settings → Trusted Publishing → Add GitHub
publisher*:

| field | value |
|---|---|
| repository owner | `plusky` |
| repository name | `bugwarden` |
| workflow filename | `release.yml` |
| environment | *(leave empty)* |

Without it the publish job fails to authenticate. If you would rather use a
long-lived token instead, the job only needs `CARGO_REGISTRY_TOKEN` in the
repository secrets and the auth step dropped.

## Verification

The job cannot be exercised without pushing a tag, so 0.1.0 was published by
hand and this automates what those commands did, in the same order. The
workflow parses and the job graph is `build → release → publish`; the skip
check was run against the live crates.io API for `bugwarden-core` 0.1.0
(already published → skip) and a nonexistent version (→ publish).