### PR TITLE
fix(core): classify one id per request, whatever the answer

### DIFF
--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -15,7 +15,7 @@
 //!   per-call opt-in in [`Guard::filter_comments`]; the same double opt-in
 //!   gates private attachment metadata in [`Guard::filter_attachments`].
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::Utc;
 use serde_json::{Map, Value};
@@ -57,15 +57,39 @@ impl Guard {
         format!("Bug {id} is not accessible through this server")
     }
 
+    /// Largest number of distinct ids one [`Guard::assess`] call will fetch.
+    ///
+    /// Classification costs one upstream request per distinct id, so the id
+    /// count multiplies the work a caller can demand of the Bugzilla behind
+    /// this server. The bound lives here, in the crate that owns the fan-out,
+    /// rather than in whichever binary happens to call it: `assess` is public
+    /// API and must not hand an unbounded loop to an out-of-tree caller.
+    pub const MAX_ASSESS_IDS: usize = 25;
+
     /// Classify `ids` against the policy.
     ///
-    /// Fetches `CLASSIFY_FIELDS` for all ids in one batched request; if the
-    /// batch call fails, retries each id individually so one bad id cannot
-    /// take down the whole batch. Any id that still fails or is absent from
-    /// the response maps to `(Access::Denied { rule: "unavailable" },
-    /// Value::Null)` — every requested id has an entry in the returned map,
-    /// and unavailability is indistinguishable from policy denial downstream
-    /// (fail closed, I4 + I2).
+    /// Fetches `CLASSIFY_FIELDS` with exactly ONE request per distinct id,
+    /// sequentially, whatever the outcome. The upstream request count is
+    /// therefore a function of the requested ids alone and never of what the
+    /// answers turn out to be (I2).
+    ///
+    /// This is why the batch is gone. Bugzilla reports a nonexistent id by
+    /// failing the WHOLE request, while a bug the caller may not see is
+    /// silently omitted from a successful one — so any scheme that reacts to
+    /// a batch failure spends different work on "no such bug" than on "hidden
+    /// bug", and a client with a clock can tell the two apart. Per-id also
+    /// removes batch poisoning outright: one bad id can no longer take the
+    /// others down with it, which is what the old retry existed to repair.
+    ///
+    /// Any id that fails or is absent from its response maps to
+    /// `(Access::Denied { rule: "unavailable" }, Value::Null)` — every
+    /// requested id has an entry in the returned map, and unavailability is
+    /// indistinguishable from policy denial downstream (fail closed, I4 + I2).
+    ///
+    /// Cost: one sequential upstream request per distinct id, bounded by
+    /// [`Guard::MAX_ASSESS_IDS`]; ids beyond the bound are denied without
+    /// being fetched. Sequential rather than concurrent because some Bugzilla
+    /// deployments drop parallel connections (see `client::server_info`).
     ///
     /// The API key is only forwarded to the client and never logged (I12).
     pub async fn assess(
@@ -83,45 +107,48 @@ impl Guard {
         // Classification objects fetched from Bugzilla, keyed by the id the
         // SERVER reported. Requested ids are only trusted when the response
         // actually contains a bug with that id (fail closed).
+        //
+        // One request per DISTINCT id, unconditionally: the work done must not
+        // depend on the answers, or the clock becomes an oracle (I2). Repeats
+        // in `ids` are collapsed so a caller cannot inflate the cost, or read
+        // anything into it, by asking for the same bug twice.
         let mut fetched: BTreeMap<u64, Value> = BTreeMap::new();
-        match bz.get_bugs(key, ids, Some(CLASSIFY_FIELDS)).await {
-            Ok(envelope) => {
-                if let Some(bugs) = envelope.get("bugs").and_then(Value::as_array) {
-                    for bug in bugs {
-                        if let Some(id) = bug.get("id").and_then(Value::as_u64) {
-                            fetched.insert(id, bug.clone());
-                        }
-                    }
-                }
+        let mut requested: BTreeSet<u64> = BTreeSet::new();
+        for &id in ids {
+            if !requested.insert(id) {
+                continue;
             }
-            Err(err) if ids.len() > 1 => {
-                // Batch failed (e.g. one denied id poisoning the whole
-                // request on some Bugzilla versions): retry per id.
-                tracing::debug!(error = %err, "batch classification fetch failed; retrying per id");
-                for &id in ids {
-                    match bz.get_bugs(key, &[id], Some(CLASSIFY_FIELDS)).await {
-                        Ok(envelope) => {
-                            if let Some(bugs) = envelope.get("bugs").and_then(Value::as_array) {
-                                for bug in bugs {
-                                    if bug.get("id").and_then(Value::as_u64) == Some(id) {
-                                        fetched.insert(id, bug.clone());
-                                    }
-                                }
+            if requested.len() > Self::MAX_ASSESS_IDS {
+                // Past the bound nothing is fetched, so every remaining id
+                // falls through to the denial below (I4). Callers are
+                // expected to refuse the request outright with a message;
+                // this is the backstop that keeps the fan-out finite even
+                // when they do not.
+                tracing::warn!(
+                    ids = ids.len(),
+                    max = Self::MAX_ASSESS_IDS,
+                    "assess called with more ids than the bound; denying the excess"
+                );
+                break;
+            }
+            match bz.get_bugs(key, &[id], Some(CLASSIFY_FIELDS)).await {
+                Ok(envelope) => {
+                    if let Some(bugs) = envelope.get("bugs").and_then(Value::as_array) {
+                        for bug in bugs {
+                            // Only the bug the server itself labels with this
+                            // id counts — never the position in the response.
+                            if bug.get("id").and_then(Value::as_u64) == Some(id) {
+                                fetched.insert(id, bug.clone());
                             }
                         }
-                        Err(err) => {
-                            tracing::debug!(id, error = %err, "per-id classification fetch failed");
-                        }
                     }
                 }
-            }
-            Err(err) => {
-                // Single-id batch: a per-id retry would repeat the identical
-                // request and could never recover anything. Skipping it also
-                // keeps the upstream request count (and thus latency)
-                // identical for a nonexistent id and a policy-denied one, so
-                // a client timing its calls gets no existence oracle (I2).
-                tracing::debug!(error = %err, "single-id classification fetch failed");
+                Err(err) => {
+                    // Nonexistent, forbidden upstream, or a transport failure:
+                    // all indistinguishable from here, and all fail closed
+                    // below (I4). Never logged with the key (I12).
+                    tracing::debug!(id, error = %err, "classification fetch failed");
+                }
             }
         }
 

--- a/crates/bugwarden-core/tests/guard_wiremock.rs
+++ b/crates/bugwarden-core/tests/guard_wiremock.rs
@@ -102,18 +102,74 @@ async fn assess_min_bug_age_denies_young_and_missing_creation_time() {
 }
 
 #[tokio::test]
-async fn assess_batch_failure_falls_back_per_id_and_fails_closed() {
+async fn assess_costs_one_request_per_distinct_id_whatever_the_answer() {
+    // The heart of it: a bug that does not exist and a bug the policy hides
+    // must cost the SAME upstream work. Bugzilla reports the first by failing
+    // the request and the second by quietly omitting it, so the two answers
+    // arrive by different routes — the request count must not follow.
     let server = MockServer::start().await;
-    // The batched request (both ids) fails with a 500 ...
+    // id 1: served normally.
     Mock::given(method("GET"))
         .and(path("/rest/bug"))
-        .and(query_param("id", "1,2"))
+        .and(query_param("id", "1"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "bugs": [bug(1, &[], OLD)] })),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    // id 2: nonexistent — Bugzilla errors the request.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "2"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": true, "code": 101, "message": "Bug #2 does not exist."
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    // id 3: exists but is withheld upstream — a 200 that simply omits it.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let g = guard(""); // default allow-all policy
+    let bz = client(&server);
+    let out = g.assess(&bz, KEY, &[1, 2, 3]).await;
+
+    assert_eq!(out.len(), 3, "every requested id has an entry (I4)");
+    assert!(out[&1].0.allows(Capability::Read));
+    for id in [2u64, 3] {
+        match &out[&id].0 {
+            Access::Denied { rule } => assert_eq!(rule, "unavailable"),
+            other => panic!("bug {id} must be denied, got {other:?}"),
+        }
+        assert!(out[&id].1.is_null());
+    }
+    // The .expect(1) assertions above are verified on drop: each id is
+    // fetched exactly once. (They bound the mocked paths only — wiremock does
+    // not fail on requests that match no mock — but a batched `id=1,2,3`
+    // would match none of these three and leave all counts at zero.)
+}
+
+#[tokio::test]
+async fn assess_never_batches_so_one_bad_id_cannot_poison_the_others() {
+    // The batch this replaced could be failed wholesale by a single bad id,
+    // taking healthy ids down with it. Per-id fetching makes that impossible
+    // without any retry logic to re-open the timing gap.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "9"))
         .respond_with(ResponseTemplate::new(500).set_body_json(json!({
             "error": true, "message": "internal server error"
         })))
         .mount(&server)
         .await;
-    // ... the per-id retry succeeds (200) for 1 ...
     Mock::given(method("GET"))
         .and(path("/rest/bug"))
         .and(query_param("id", "1"))
@@ -122,62 +178,78 @@ async fn assess_batch_failure_falls_back_per_id_and_fails_closed() {
         )
         .mount(&server)
         .await;
-    // ... and keeps failing for 2.
-    Mock::given(method("GET"))
-        .and(path("/rest/bug"))
-        .and(query_param("id", "2"))
-        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
-            "error": true, "message": "internal server error"
-        })))
-        .mount(&server)
-        .await;
+    // A request naming both ids at once would not match either mock: proof
+    // that no batch is attempted.
 
-    let g = guard(""); // default allow-all policy
+    let g = guard("");
     let bz = client(&server);
-    let out = g.assess(&bz, KEY, &[1, 2]).await;
+    let out = g.assess(&bz, KEY, &[9, 1]).await;
 
-    assert_eq!(out.len(), 2, "every requested id has an entry (I4)");
-    assert!(out[&1].0.allows(Capability::Read));
-    match &out[&2].0 {
+    assert!(out[&1].0.allows(Capability::Read), "healthy id survives");
+    match &out[&9].0 {
         Access::Denied { rule } => assert_eq!(rule, "unavailable"),
-        other => panic!("unavailable bug must be denied, got {other:?}"),
+        other => panic!("failed id must be denied, got {other:?}"),
     }
-    assert!(out[&2].1.is_null());
 }
 
 #[tokio::test]
-async fn assess_single_id_failure_makes_exactly_one_request() {
-    // A failing single-id batch must NOT trigger the per-id fallback: the
-    // retry would repeat the identical request, and the extra round trip
-    // would give a timing client an existence oracle (nonexistent id => two
-    // requests, policy-denied id => one) that I2's uniform text hides.
+async fn assess_fan_out_is_bounded_and_the_excess_is_denied() {
+    // assess() is public API: an out-of-tree caller that forgets to bound its
+    // input must not be able to turn one call into an unbounded run of
+    // upstream requests. Past the bound nothing is fetched and everything
+    // falls through to the denial (I4).
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/rest/bug"))
-        .and(query_param("id", "7"))
-        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
-            "error": true, "code": 101, "message": "Bug #7 does not exist."
-        })))
-        .expect(1) // exactly one upstream request, no retry
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .expect(Guard::MAX_ASSESS_IDS as u64) // never more, whatever was asked
         .mount(&server)
         .await;
 
-    let g = guard(""); // default allow-all policy
+    let ids: Vec<u64> = (1..=Guard::MAX_ASSESS_IDS as u64 * 4).collect();
+    let g = guard("");
     let bz = client(&server);
-    let out = g.assess(&bz, KEY, &[7]).await;
+    let out = g.assess(&bz, KEY, &ids).await;
 
-    assert_eq!(out.len(), 1, "the requested id has an entry (I4)");
-    match &out[&7].0 {
-        Access::Denied { rule } => assert_eq!(rule, "unavailable"),
-        other => panic!("unavailable bug must be denied, got {other:?}"),
+    assert_eq!(out.len(), ids.len(), "every id still gets an entry (I4)");
+    for id in &ids {
+        match &out[id].0 {
+            Access::Denied { .. } => {}
+            other => panic!("bug {id} must be denied, got {other:?}"),
+        }
     }
-    assert!(out[&7].1.is_null());
 }
 
 #[tokio::test]
-async fn assess_id_absent_from_successful_batch_is_denied() {
+async fn assess_repeated_ids_are_fetched_once() {
+    // A caller cannot multiply the upstream cost — or read anything into it —
+    // by naming the same bug several times.
     let server = MockServer::start().await;
-    // Successful batch that simply lacks bug 2 (server-side hidden).
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "5"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "bugs": [bug(5, &[], OLD)] })),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let g = guard("");
+    let bz = client(&server);
+    let out = g.assess(&bz, KEY, &[5, 5, 5]).await;
+
+    assert_eq!(out.len(), 1);
+    assert!(out[&5].0.allows(Capability::Read));
+}
+
+#[tokio::test]
+async fn assess_id_absent_from_its_own_response_is_denied() {
+    // A 200 that does not contain the bug is Bugzilla's way of saying "not
+    // for you". It must land on the same denial as an outright failure, and
+    // the response for one id must never be credited to another (the mock
+    // answers every id with bug 1's body).
+    let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/rest/bug"))
         .respond_with(
@@ -195,6 +267,36 @@ async fn assess_id_absent_from_successful_batch_is_denied() {
         Access::Denied { rule } => assert_eq!(rule, "unavailable"),
         other => panic!("absent bug must be denied (I4), got {other:?}"),
     }
+    assert!(
+        out[&2].1.is_null(),
+        "a mismatched body must never be attached to the requested id"
+    );
+}
+
+#[tokio::test]
+async fn assess_single_id_failure_makes_exactly_one_request() {
+    // Unchanged contract, now the general rule rather than a special case.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "7"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": true, "code": 101, "message": "Bug #7 does not exist."
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let g = guard(""); // default allow-all policy
+    let bz = client(&server);
+    let out = g.assess(&bz, KEY, &[7]).await;
+
+    assert_eq!(out.len(), 1, "the requested id has an entry (I4)");
+    match &out[&7].0 {
+        Access::Denied { rule } => assert_eq!(rule, "unavailable"),
+        other => panic!("unavailable bug must be denied, got {other:?}"),
+    }
+    assert!(out[&7].1.is_null());
 }
 
 #[tokio::test]

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -55,6 +55,23 @@ fn action_name(action: Action) -> &'static str {
     }
 }
 
+/// Refuse a call naming more distinct bug ids than the guard will classify.
+///
+/// The bound itself is [`Guard::MAX_ASSESS_IDS`], defined next to the loop it
+/// bounds. Refusing here rather than letting the guard silently deny the
+/// excess turns a confusing partial answer into a clear one, and the check
+/// reads only the request — never a verdict — so it discloses nothing about
+/// any bug (I1/I2).
+fn too_many_ids(ids: &[u64]) -> Option<CallToolResult> {
+    let distinct = ids.iter().collect::<BTreeSet<_>>().len();
+    (distinct > Guard::MAX_ASSESS_IDS).then(|| {
+        err_text(format!(
+            "At most {} bug ids may be named in one call, got {distinct}",
+            Guard::MAX_ASSESS_IDS
+        ))
+    })
+}
+
 /// Project a bug object to the requested field set, preserving the
 /// `_redacted` marker when present.
 fn project_fields(bug: &Value, fields: &BTreeSet<String>) -> Value {
@@ -151,7 +168,7 @@ fn default_limit() -> u32 {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct BugInfoParams {
-    /// Bug ids to fetch.
+    /// Bug ids to fetch. At most 25 distinct ids per call.
     pub bug_ids: Vec<u64>,
 }
 
@@ -458,6 +475,9 @@ impl BugWarden {
             .collect();
         if ids.is_empty() {
             return Ok(err_text("At least one bug id must be provided"));
+        }
+        if let Some(refusal) = too_many_ids(&ids) {
+            return Ok(refusal);
         }
 
         let assessments = self.assess(&key, &ids).await;
@@ -866,6 +886,9 @@ impl BugWarden {
         }
         let mut seen = BTreeSet::new();
         ids.retain(|id| seen.insert(*id));
+        if let Some(refusal) = too_many_ids(&ids) {
+            return Ok(refusal);
+        }
 
         let key = self.api_key(&ctx)?;
         let assessments = self.assess(&key, &ids).await;
@@ -1302,6 +1325,33 @@ impl ServerHandler for BugWarden {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn id_cap_counts_distinct_ids_and_reads_only_the_request() {
+        // The refusal must depend on how many DISTINCT bugs were named and on
+        // nothing else — never on which bugs they are (I1/I2).
+        let at_cap: Vec<u64> = (1..=Guard::MAX_ASSESS_IDS as u64).collect();
+        assert!(
+            too_many_ids(&at_cap).is_none(),
+            "exactly the bound is allowed"
+        );
+
+        let over: Vec<u64> = (1..=Guard::MAX_ASSESS_IDS as u64 + 1).collect();
+        let refusal = too_many_ids(&over).expect("over the bound must be refused");
+        let text = format!("{:?}", refusal.content);
+        assert!(
+            text.contains(&Guard::MAX_ASSESS_IDS.to_string()),
+            "refusal states the limit: {text}"
+        );
+
+        // Repeats cost one fetch, so they must not count towards the bound.
+        let repeated = vec![7u64; Guard::MAX_ASSESS_IDS * 4];
+        assert!(
+            too_many_ids(&repeated).is_none(),
+            "naming one bug many times is one bug"
+        );
+        assert!(too_many_ids(&[]).is_none());
+    }
     use super::*;
     use bugwarden_core::policy::Policy;
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -223,10 +223,24 @@ impl Guard {
     /// Exact I2 text.
     pub fn denial(id: u64) -> String; // format!("Bug {id} is not accessible through this server")
 
-    /// Fetch CLASSIFY_FIELDS for ids in one batch; if the batch call fails,
-    /// retry each id individually; any id still failing or absent from the
-    /// response => (Access::Denied{rule:"unavailable".into()}, Value::Null).
+    /// Fetch CLASSIFY_FIELDS with exactly ONE request per DISTINCT id,
+    /// sequentially, whatever each answer turns out to be: the upstream
+    /// request count is a function of the requested ids alone, never of the
+    /// verdicts (I2). No batching — Bugzilla signals a nonexistent id by
+    /// failing the whole request but a withheld one by omitting it from a
+    /// success, so any batch-failure reaction spends different work on "no
+    /// such bug" than on "hidden bug". Per-id also makes batch poisoning
+    /// impossible, which is what the former retry existed to repair.
+    /// A response is credited to an id only when the SERVER labels it with
+    /// that id. Any id failing or absent from its own response =>
+    /// (Access::Denied{rule:"unavailable".into()}, Value::Null).
     /// Every requested id has an entry in the returned map (fail closed, I4).
+    /// Bounded by Guard::MAX_ASSESS_IDS (25): ids past the bound are denied
+    /// without being fetched, so a caller that forgets to check cannot turn
+    /// one call into an unbounded run of requests. Tools refuse over-long id
+    /// lists outright (server::too_many_ids) rather than answering partially.
+    pub const MAX_ASSESS_IDS: usize;
+
     pub async fn assess(&self, bz: &crate::client::BugzillaClient, key: &str, ids: &[u64])
         -> std::collections::BTreeMap<u64, (Access, serde_json::Value)>;
 
@@ -386,7 +400,9 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   read_only strips write caps; default deny; summary redaction; comment
   filtering; validation errors (unknown TOML keys, restrict without caps).
 - Integration tests (crates/bugwarden-core/tests/guard_wiremock.rs, wiremock):
-  assess() deny for embargoed group; min-age deny; batch failure => per-id
+  assess() deny for embargoed group; min-age deny; one request per distinct
+  id whatever the answer (nonexistent vs withheld cost the same), repeated
+  ids fetched once, no batch to poison; per-id
   fallback fail closed; comment privacy; error mapping; API key absent from
   error text (I12).
 - CI: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,


### PR DESCRIPTION
## The hole

`Guard::assess` fetched every id in one batch and retried per id when that
batch failed. Bugzilla signals the two "you don't get this bug" cases
differently: a **nonexistent** id fails the whole request, a bug the key
**may not see** is silently omitted from a successful one. So the retry fired
for the first and not the second — identical bytes returned, ~1+N upstream
requests versus ~1.

A client could name one id alongside twenty known-good ones and read the
answer off the clock, which is exactly what invariant **I2** (a hidden bug is
indistinguishable from one that does not exist) forbids. The single-id path
had already been equalised for this reason; the batch path reopened it.

## The fix

Every distinct id gets exactly one request, always, and the retry is gone.
Classification work is now a function of the requested ids and nothing else.
Two things come free: batch poisoning becomes impossible instead of being
repaired afterwards (which is all the retry did), and the "only trust a body
the server labels with this id" check — previously only on the retry path —
now covers every id.

## Bounding what that costs

An id now costs a whole request, so the id count is a multiplier a client
controls. `MAX_ASSESS_IDS = 25` lives in `bugwarden-core`, next to the loop it
bounds, **not** in the binary: `assess` is public API of a published crate and
must not hand an out-of-tree caller an unbounded run of requests. Past the
bound nothing is fetched and the excess is denied (fail closed); tools refuse
an over-long list outright rather than answering partially, and the limit is
stated in the `bug_ids` schema so a client sees it before being refused.

Sequential, not concurrent, because some deployments drop parallel
connections — the same reason `server_info` fetches sequentially.

## Verification

133 tests (+4). The one that matters puts all three cases side by side —
served, nonexistent, withheld — and pins one request each by mock
construction, so the property holds by construction rather than coincidence.
Others pin the bounded fan-out, that repeats are fetched once, that one bad id
cannot poison the others, and that a body is never credited to the wrong id.

## Scope

Two things this deliberately does not fix, both getting their own PR:

- `bug_info` still classifies one fetch and returns a **second**, and per-id
  classification widens that window. The next PR re-classifies the body it
  serves.
- That second fetch is batched and its error text is forwarded to the client
  verbatim, which can carry Bugzilla's own "Bug #N does not exist." wording —
  an I2 leak that predates this change and belongs with the `bug_info` work.