### PR TITLE
fix: paginate bugs_quicksearch over the bugs a client may see

### DIFF
--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -47,6 +47,25 @@ pub struct Guard {
     pub policy: Policy,
 }
 
+/// A quicksearch as the client asked for it.
+///
+/// `limit`/`offset` address the bugs the client may SEE — see
+/// [`Guard::quicksearch_window`], which is what makes that true.
+#[derive(Debug, Clone, Copy)]
+pub struct SearchRequest<'a> {
+    /// Bugzilla quicksearch expression.
+    pub query: &'a str,
+    /// Status filter prepended to the expression ("ALL" for none).
+    pub status: &'a str,
+    /// Comma-separated projection; callers must include the classification
+    /// fields or the guard cannot judge what it is filtering.
+    pub include_fields: &'a str,
+    /// How many visible bugs to return.
+    pub limit: u32,
+    /// How many visible bugs to skip.
+    pub offset: u32,
+}
+
 impl Guard {
     /// The uniform denial text (invariant I2).
     ///
@@ -170,6 +189,150 @@ impl Guard {
             out.insert(id, entry);
         }
         out
+    }
+
+    /// Largest `offset + limit` a search may address.
+    ///
+    /// Paging past this truncates rather than scanning forever; the client
+    /// sees the same thing it sees at the genuine end of a result set.
+    pub const MAX_SEARCH_WINDOW: u32 = 1_000;
+
+    /// Rows requested from Bugzilla per scan step.
+    const SEARCH_SCAN_CHUNK: u32 = 200;
+
+    /// Ceiling on upstream rows examined for one search, i.e. at most
+    /// `SEARCH_SCAN_MAX / SEARCH_SCAN_CHUNK` sequential requests.
+    const SEARCH_SCAN_MAX: u32 = 2_000;
+
+    /// Run a search whose `limit`/`offset` address the bugs the client may
+    /// actually SEE, not the rows Bugzilla happens to return.
+    ///
+    /// Filtering a page after Bugzilla has already applied `limit`/`offset`
+    /// leaves a hole exactly where a hidden bug sat: the page comes back
+    /// short while the next offset still yields results, which says "a bug
+    /// exists here that you may not see". Because quicksearch matches summary
+    /// text, that hole is a probe — append a word to the query, see whether
+    /// the hole survives, and the hidden bug's title can be reconstructed one
+    /// word at a time. Uniform denials (I2) and silent filtering (I3) are
+    /// worth nothing while the window itself reports what was removed.
+    ///
+    /// So pagination is applied AFTER the guard: scan the upstream result
+    /// from row 0, classify each chunk, and keep going until enough visible
+    /// bugs have accumulated to fill the requested window. A hidden bug now
+    /// costs nothing but a row of upstream scanning — it never shortens a
+    /// page and never contradicts a later offset.
+    ///
+    /// Scanning from row 0 every time is not laziness: a visible-space offset
+    /// cannot be mapped onto an upstream offset without first classifying
+    /// everything before it, and how many bugs that is, is exactly what the
+    /// client must not learn.
+    ///
+    /// The bugs returned are the objects that were classified, so no second
+    /// fetch can serve something the verdict never saw.
+    ///
+    /// Bounds: at most [`Guard::MAX_SEARCH_WINDOW`] addressable, and at most
+    /// `SEARCH_SCAN_MAX` upstream rows examined. Hitting either truncates the
+    /// page, which is indistinguishable from running out of results — the
+    /// safe direction, since it hides more rather than less.
+    ///
+    /// Residual, and deliberately accepted: filling a window of VISIBLE bugs
+    /// takes more upstream rows when bugs are hidden, so the request count
+    /// cannot be made independent of hidden-bug density without either
+    /// scanning the worst case on every search or letting pages go short
+    /// again. What a stopwatch can still learn is one bit per scanned block —
+    /// "this block was not entirely visible" — because the scan target is
+    /// quantised to whole chunks; without that quantisation the client could
+    /// binary-search `limit` and recover the exact hidden count of every
+    /// block, which is why it is there. A long way from reconstructing a
+    /// title, which is what this replaces.
+    pub async fn quicksearch_window(
+        &self,
+        bz: &BugzillaClient,
+        key: &str,
+        req: &SearchRequest<'_>,
+    ) -> anyhow::Result<Vec<Value>> {
+        let SearchRequest {
+            query,
+            status,
+            include_fields,
+            limit,
+            offset,
+        } = *req;
+        let needed = offset.saturating_add(limit).min(Self::MAX_SEARCH_WINDOW);
+        if limit == 0 || needed == 0 {
+            return Ok(Vec::new());
+        }
+
+        // Scan for a whole number of chunks' worth of visible bugs rather
+        // than for exactly `needed`. Stopping the moment the window is full
+        // makes the stopping point a function of the client's `limit` AND of
+        // how many bugs were hidden, and a client can binary-search `limit`
+        // against the clock to recover the hidden count of each block
+        // exactly. Quantising collapses that: every limit inside a block asks
+        // for the same work, so the timing says at most "this block was not
+        // entirely visible" instead of how many went missing. Costs nothing
+        // in the common case — an unfiltered chunk already fills the target.
+        let target = needed
+            .div_ceil(Self::SEARCH_SCAN_CHUNK)
+            .saturating_mul(Self::SEARCH_SCAN_CHUNK);
+
+        let mut visible: Vec<Value> = Vec::new();
+        let mut seen: BTreeSet<u64> = BTreeSet::new();
+        let mut scanned: u32 = 0;
+        let mut dropped_total = 0usize;
+
+        while (visible.len() as u32) < target && scanned < Self::SEARCH_SCAN_MAX {
+            let chunk = Self::SEARCH_SCAN_CHUNK.min(Self::SEARCH_SCAN_MAX - scanned);
+            let envelope = bz
+                .quicksearch(key, query, status, include_fields, chunk, scanned)
+                .await?;
+            let rows: Vec<Value> = envelope
+                .get("bugs")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            let returned = rows.len() as u32;
+
+            // Relevance ordering is not stable between calls, so chunks can
+            // overlap; dedupe on the id the server reported. A row without a
+            // readable id cannot be classified and is dropped (I4).
+            let fresh: Vec<Value> = rows
+                .into_iter()
+                .filter(|b| {
+                    b.get("id")
+                        .and_then(Value::as_u64)
+                        .is_some_and(|id| seen.insert(id))
+                })
+                .collect();
+            let (kept, dropped) = self.filter_bug_list(fresh);
+            dropped_total += dropped;
+            visible.extend(kept);
+            scanned += returned;
+
+            if returned < chunk {
+                break; // upstream has no more rows
+            }
+        }
+
+        if dropped_total > 0 {
+            // Server-side only, never a count to the client (I3).
+            tracing::debug!(
+                dropped = dropped_total,
+                scanned,
+                "quicksearch: withheld policy-denied bugs"
+            );
+        }
+
+        // `start` is clamped to `end`, not merely to the length. The window
+        // stops at MAX_SEARCH_WINDOW but the scan overshoots it whenever a
+        // chunk yields fewer visible bugs than it holds — which happens only
+        // when bugs WERE hidden. An unclamped start would therefore panic
+        // exactly when something was hidden past the window, answering the
+        // one question this whole function exists to refuse (and taking the
+        // session down with it).
+        let end = (needed as usize).min(visible.len());
+        let start = (offset as usize).min(end);
+        Ok(visible[start..end].to_vec())
     }
 
     /// Project a bug object down to [`SUMMARY_FIELDS`] and add a

--- a/crates/bugwarden-core/tests/guard_wiremock.rs
+++ b/crates/bugwarden-core/tests/guard_wiremock.rs
@@ -7,7 +7,7 @@
 //! and the summary view carrying no sensitive fields.
 
 use bugwarden_core::client::BugzillaClient;
-use bugwarden_core::guard::Guard;
+use bugwarden_core::guard::{Guard, SearchRequest};
 use bugwarden_core::policy::{Access, Capability, Policy};
 use serde_json::json;
 use wiremock::matchers::{method, path, query_param};
@@ -490,4 +490,346 @@ capabilities = ["summary"]
             "summary view must not contain {hidden:?}: {view}"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// quicksearch_window: limit/offset address VISIBLE bugs (I2/I3)
+// ---------------------------------------------------------------------------
+
+/// A policy hiding anything in an embargo group.
+const EMBARGO_POLICY: &str = concat!(
+    "default_action = \"allow\"\n",
+    "[[rule]]\nname = \"embargo\"\naction = \"deny\"\n",
+    "[rule.match]\ngroups = [\"embargo*\"]\n",
+);
+
+/// Serve `total` bugs, every id in `hidden` carrying an embargo group, and
+/// answer any offset/limit the way Bugzilla would.
+async fn corpus(server: &MockServer, total: u64, hidden: &[u64]) {
+    let hidden: std::collections::BTreeSet<u64> = hidden.iter().copied().collect();
+    let all: Vec<serde_json::Value> = (1..=total)
+        .map(|id| {
+            let groups: &[&str] = if hidden.contains(&id) {
+                &["embargo-security"]
+            } else {
+                &[]
+            };
+            bug(id, groups, OLD)
+        })
+        .collect();
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(move |req: &Request| {
+            let q: std::collections::HashMap<_, _> = req.url.query_pairs().collect();
+            let get = |k: &str| q.get(k).and_then(|v| v.parse::<usize>().ok());
+            let offset = get("offset").unwrap_or(0);
+            let limit = get("limit").unwrap_or(all.len());
+            let page: Vec<_> = all.iter().skip(offset).take(limit).cloned().collect();
+            ResponseTemplate::new(200).set_body_json(json!({ "bugs": page }))
+        })
+        .mount(server)
+        .await;
+}
+
+/// A search request with the fixture defaults.
+fn search(query: &str, limit: u32, offset: u32) -> SearchRequest<'_> {
+    SearchRequest {
+        query,
+        status: "ALL",
+        include_fields: "id",
+        limit,
+        offset,
+    }
+}
+
+/// Like [`corpus`], but the mock records how many requests it served.
+async fn corpus_counted(server: &MockServer, total: u64, hidden: &[u64]) {
+    corpus(server, total, hidden).await;
+}
+
+/// How many requests the server has received.
+async fn requests_to(server: &MockServer) -> usize {
+    server
+        .received_requests()
+        .await
+        .map(|r| r.len())
+        .unwrap_or(0)
+}
+
+fn ids_of(bugs: &[serde_json::Value]) -> Vec<u64> {
+    bugs.iter()
+        .map(|b| b["id"].as_u64().expect("bug has an id"))
+        .collect()
+}
+
+#[tokio::test]
+async fn quicksearch_window_pages_have_no_holes_when_bugs_are_hidden() {
+    // The oracle: hidden bugs used to be cut from an already-paginated page,
+    // so a page came back short while the next offset still had results — the
+    // gap marking exactly where a hidden bug sat. Every page must now be full
+    // whenever visible bugs remain.
+    let server = MockServer::start().await;
+    corpus(&server, 30, &[2, 3, 4, 11, 12, 20]).await; // 24 visible
+    let g = guard(EMBARGO_POLICY);
+    let bz = client(&server);
+
+    let mut seen = Vec::new();
+    for page in 0..4u32 {
+        let got = g
+            .quicksearch_window(&bz, KEY, &search("q", 5, page * 5))
+            .await
+            .expect("search succeeds");
+        assert_eq!(
+            got.len(),
+            5,
+            "page {page} is short while visible bugs remain: {:?}",
+            ids_of(&got)
+        );
+        seen.extend(ids_of(&got));
+    }
+    assert_eq!(
+        seen,
+        vec![1, 5, 6, 7, 8, 9, 10, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26]
+    );
+    for id in [2, 3, 4, 11, 12, 20] {
+        assert!(!seen.contains(&id), "hidden bug {id} surfaced");
+    }
+}
+
+#[tokio::test]
+async fn quicksearch_window_pages_are_disjoint_and_gapless() {
+    // Consecutive pages must tile the visible sequence exactly against a
+    // STABLE upstream order, which is what this mock provides. Real relevance
+    // ordering is not stable: a row that moves backwards past an already
+    // scanned offset is missed by every chunk and appears on no page at all.
+    // Dedup catches the forward case, nothing catches the backward one — it
+    // hides more rather than less, so it is a correctness wart, not a leak.
+    let server = MockServer::start().await;
+    corpus(&server, 40, &[5, 6, 7, 8, 9, 10, 30, 31]).await;
+    let g = guard(EMBARGO_POLICY);
+    let bz = client(&server);
+
+    let mut paged = Vec::new();
+    for page in 0..8u32 {
+        let got = g
+            .quicksearch_window(&bz, KEY, &search("q", 4, page * 4))
+            .await
+            .expect("search succeeds");
+        paged.extend(ids_of(&got));
+    }
+    let whole = g
+        .quicksearch_window(&bz, KEY, &search("q", 32, 0))
+        .await
+        .expect("search succeeds");
+    assert_eq!(
+        paged,
+        ids_of(&whole),
+        "paging must tile the visible sequence"
+    );
+    let unique: std::collections::BTreeSet<_> = paged.iter().collect();
+    assert_eq!(unique.len(), paged.len(), "a bug appeared on two pages");
+}
+
+#[tokio::test]
+async fn quicksearch_window_page_is_identical_whether_or_not_bugs_are_hidden() {
+    // The strongest form: the visible bugs a client gets must not depend on
+    // whether hidden bugs are interleaved among them.
+    // The hidden bugs must sit BEFORE and INSIDE the requested window, where
+    // they can actually shift it — hidden bugs past the window would prove
+    // nothing.
+    let server_clean = MockServer::start().await;
+    corpus(&server_clean, 12, &[]).await;
+    let server_mixed = MockServer::start().await;
+    corpus(&server_mixed, 12, &[2, 4, 7]).await;
+
+    let g = guard(EMBARGO_POLICY);
+    let clean = g
+        .quicksearch_window(&client(&server_clean), KEY, &search("q", 4, 2))
+        .await
+        .expect("search succeeds");
+    let mixed = g
+        .quicksearch_window(&client(&server_mixed), KEY, &search("q", 4, 2))
+        .await
+        .expect("search succeeds");
+    // Clean: visible are 1..12, so offset 2 limit 4 => 3,4,5,6.
+    assert_eq!(ids_of(&clean), vec![3, 4, 5, 6]);
+    // Mixed: visible are 1,3,5,6,8,9,10,11,12 => offset 2 limit 4 => 5,6,8,9.
+    // Same SHAPE — four bugs, none hidden, no hole — which is what the client
+    // can observe. Sameness of ids is impossible once bugs are removed; what
+    // must not differ is that the page is full and the sequence contiguous.
+    assert_eq!(ids_of(&mixed), vec![5, 6, 8, 9]);
+    assert_eq!(
+        clean.len(),
+        mixed.len(),
+        "a hidden bug must not shorten a page"
+    );
+}
+
+#[tokio::test]
+async fn quicksearch_window_runs_out_like_a_normal_end_of_results() {
+    // Past the end the page is short and then empty — the ordinary signal,
+    // and the only one a truncated scan is allowed to look like.
+    let server = MockServer::start().await;
+    corpus(&server, 7, &[3]).await; // 6 visible
+    let g = guard(EMBARGO_POLICY);
+    let bz = client(&server);
+
+    let tail = g
+        .quicksearch_window(&bz, KEY, &search("q", 10, 4))
+        .await
+        .expect("search succeeds");
+    assert_eq!(ids_of(&tail), vec![6, 7]);
+    let past = g
+        .quicksearch_window(&bz, KEY, &search("q", 10, 50))
+        .await
+        .expect("search succeeds");
+    assert!(past.is_empty());
+}
+
+#[tokio::test]
+async fn quicksearch_window_scan_is_bounded() {
+    // A query whose results are almost entirely hidden must terminate rather
+    // than scan forever. Counting the requests is the point: asserting only
+    // that the page is empty passes just as well with no bound at all.
+    let server = MockServer::start().await;
+    let hidden: Vec<u64> = (1..=5_000).collect();
+    corpus_counted(&server, 5_000, &hidden).await;
+    let g = guard(EMBARGO_POLICY);
+
+    let got = g
+        .quicksearch_window(&client(&server), KEY, &search("q", 50, 0))
+        .await
+        .expect("search succeeds");
+    assert!(got.is_empty(), "everything was hidden");
+    assert_eq!(
+        requests_to(&server).await,
+        10,
+        "2000 rows / 200 per chunk — the scan must stop at the bound"
+    );
+}
+
+#[tokio::test]
+async fn quicksearch_window_deep_offset_is_empty_whether_or_not_bugs_are_hidden() {
+    // Past the addressable window the answer is an empty page — and it must
+    // be the SAME empty page whether or not bugs were hidden earlier. When
+    // the slice bounds were computed independently this case panicked, and
+    // only when something had been hidden: a cleaner oracle than the one the
+    // windowing removed, plus a way to kill the session.
+    for hidden in [vec![], vec![7u64]] {
+        let server = MockServer::start().await;
+        corpus(&server, 1_400, &hidden).await;
+        let g = guard(EMBARGO_POLICY);
+        for offset in [1_001u32, 1_010, 1_200, u32::MAX] {
+            let got = g
+                .quicksearch_window(&client(&server), KEY, &search("q", 1, offset))
+                .await
+                .expect("a deep offset is not an error");
+            assert!(
+                got.is_empty(),
+                "offset {offset} with hidden={hidden:?} must be an empty page"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn quicksearch_window_scan_target_does_not_track_the_requested_limit() {
+    // The timing channel: if the scan stopped the instant the window filled,
+    // the request count would flip at limit == visible-in-first-chunk, and a
+    // client could binary-search `limit` against the clock to recover the
+    // exact number of bugs hidden in each block. Quantising the target means
+    // every limit within a block costs the same.
+    let mut counts = Vec::new();
+    for limit in [1u32, 50, 150, 199, 200] {
+        let server = MockServer::start().await;
+        // 60 of the first 200 rows hidden, so the first chunk yields 140.
+        let hidden: Vec<u64> = (1..=60).collect();
+        corpus_counted(&server, 1_000, &hidden).await;
+        let g = guard(EMBARGO_POLICY);
+        let _ = g
+            .quicksearch_window(&client(&server), KEY, &search("q", limit, 0))
+            .await
+            .expect("search succeeds");
+        counts.push(requests_to(&server).await);
+    }
+    assert!(
+        counts.iter().all(|c| *c == counts[0]),
+        "request count must not vary with limit inside a chunk: {counts:?}"
+    );
+}
+
+#[tokio::test]
+async fn quicksearch_window_drops_rows_without_a_readable_id() {
+    // A row that cannot be classified cannot be served (I4), and it must not
+    // occupy a slot in the window either.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "bugs": [
+                bug(1, &[], OLD),
+                json!({ "summary": "no id here", "groups": [] }),
+                bug(2, &[], OLD),
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let g = guard(EMBARGO_POLICY);
+    let got = g
+        .quicksearch_window(&client(&server), KEY, &search("q", 10, 0))
+        .await
+        .expect("search succeeds");
+    assert_eq!(ids_of(&got), vec![1, 2]);
+}
+
+#[tokio::test]
+async fn quicksearch_window_dedupes_rows_repeated_across_chunks() {
+    // Relevance ordering is not stable between calls, so the same bug can
+    // come back in two chunks. It must be served once.
+    let server = MockServer::start().await;
+    let page: Vec<serde_json::Value> = (1..=200).map(|id| bug(id, &[], OLD)).collect();
+    // Every chunk returns the same 200 rows, whatever the offset.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": page })))
+        .mount(&server)
+        .await;
+
+    let g = guard(EMBARGO_POLICY);
+    let got = g
+        .quicksearch_window(&client(&server), KEY, &search("q", 400, 0))
+        .await
+        .expect("search succeeds");
+    let ids = ids_of(&got);
+    let unique: std::collections::BTreeSet<_> = ids.iter().collect();
+    assert_eq!(unique.len(), ids.len(), "a bug was served twice: {ids:?}");
+    assert_eq!(ids.len(), 200, "only the 200 distinct bugs exist");
+}
+
+#[tokio::test]
+async fn quicksearch_window_zero_limit_touches_nothing() {
+    let server = MockServer::start().await;
+    // No mock is mounted: any upstream request would fail the call.
+    let g = guard(EMBARGO_POLICY);
+    let got = g
+        .quicksearch_window(&client(&server), KEY, &search("q", 0, 0))
+        .await
+        .expect("zero limit is not an error");
+    assert!(got.is_empty());
+}
+
+#[tokio::test]
+async fn quicksearch_window_returns_the_classified_objects() {
+    // What is returned must be what was judged — no second fetch can slip a
+    // different body past the verdict.
+    let server = MockServer::start().await;
+    corpus(&server, 3, &[2]).await;
+    let g = guard(EMBARGO_POLICY);
+    let got = g
+        .quicksearch_window(&client(&server), KEY, &search("q", 10, 0))
+        .await
+        .expect("search succeeds");
+    assert_eq!(ids_of(&got), vec![1, 3]);
+    assert_eq!(got[0]["summary"], json!("test bug"), "full object returned");
 }

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use bugwarden_core::client::{BugzillaClient, CLASSIFY_FIELDS};
-use bugwarden_core::guard::Guard;
+use bugwarden_core::guard::{Guard, SearchRequest};
 use bugwarden_core::policy::{Access, Action, Capability};
 use chrono::{DateTime, Utc};
 use rmcp::{
@@ -668,25 +668,30 @@ impl BugWarden {
         fetch.extend(CLASSIFY_FIELDS.split(',').map(|f| f.trim().to_string()));
         let fetch_fields = fetch.into_iter().collect::<Vec<_>>().join(",");
 
-        let envelope = match self
-            .bz
-            .quicksearch(&key, &p.query, &p.status, &fetch_fields, p.limit, p.offset)
+        // limit/offset address the bugs the client may see; the guard scans
+        // and filters upstream rows to fill that window (I2/I3).
+        let kept = match self
+            .guard
+            .quicksearch_window(
+                &self.bz,
+                &key,
+                &SearchRequest {
+                    query: &p.query,
+                    status: &p.status,
+                    include_fields: &fetch_fields,
+                    limit: p.limit,
+                    offset: p.offset,
+                },
+            )
             .await
         {
-            Ok(v) => v,
-            Err(e) => return Ok(err_text(format!("Search failed: {e}"))),
+            Ok(kept) => kept,
+            // Uniform: a failing search never says which bug or why (I2).
+            Err(e) => {
+                tracing::warn!(error = %e, "bugs_quicksearch: upstream search failed");
+                return Ok(err_text("Search failed"));
+            }
         };
-        let bugs = envelope
-            .get("bugs")
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default();
-
-        let (kept, dropped) = self.guard.filter_bug_list(bugs);
-        if dropped > 0 {
-            // Server-side logging only — never reported to the client (I3).
-            tracing::debug!(dropped, "bugs_quicksearch: dropped policy-denied bugs");
-        }
         let projected: Vec<Value> = kept
             .iter()
             .map(|bug| project_fields(bug, &requested))

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -241,6 +241,15 @@ impl Guard {
     /// lists outright (server::too_many_ids) rather than answering partially.
     pub const MAX_ASSESS_IDS: usize;
 
+    // limit/offset address VISIBLE bugs: scan upstream from row 0 in chunks,
+    // classify, fill the window from survivors. Bounded by MAX_SEARCH_WINDOW
+    // (1000 addressable) and 2000 scanned rows; truncation looks like the end
+    // of results. Returns the classified objects themselves.
+    pub struct SearchRequest<'a> { query, status, include_fields: &'a str, limit, offset: u32 }
+    pub const MAX_SEARCH_WINDOW: u32;
+    pub async fn quicksearch_window(&self, bz: &BugzillaClient, key: &str,
+        req: &SearchRequest<'_>) -> anyhow::Result<Vec<serde_json::Value>>;
+
     pub async fn assess(&self, bz: &crate::client::BugzillaClient, key: &str, ids: &[u64])
         -> std::collections::BTreeMap<u64, (Access, serde_json::Value)>;
 
@@ -338,7 +347,7 @@ constraints the model must know.
 | bug_info | bug_ids: Vec<u64> | per-id: Read => full, else Summary => redacted, else restricted entry | envelope `{"bugs":[..], "restricted":[{"id":N,"note":denial(N)}]}`; full fetch only for Read-granted ids. Every fetched body is RE-CLASSIFIED before it is served (assemble_bug_info): the verdict came from the classification fetch and the body from a later request, so a bug embargoed in between must not be served on the stale verdict (TOCTOU; same reason download_attachment re-checks). Costs no request — the body is a superset of CLASSIFY_FIELDS — and a body that now earns only summary is served as the summary view, one that earns nothing becomes the uniform restricted entry. A failed body fetch is logged server-side ONLY and leaves those ids restricted: Bugzilla's message names the bug and says whether it exists, so forwarding it would undo I2 |
 | bug_history | id, new_since?: DateTime<Utc> | history | |
 | bug_comments | id, include_private: bool = false, new_since? | comments | filter_comments applied (I5) |
-| bugs_quicksearch | query, status: String = "ALL", include_fields: String = "id,product,component,assigned_to,status,resolution,summary,last_change_time", limit: u32 = 50, offset: u32 = 0 | post-filter | fetch include_fields = requested ∪ CLASSIFY_FIELDS; after filter, project kept bugs to requested fields (keep `_redacted` marker); envelope `{"bugs":[..]}` only (I3) |
+| bugs_quicksearch | query, status: String = "ALL", include_fields: String = "id,product,component,assigned_to,status,resolution,summary,last_change_time", limit: u32 = 50, offset: u32 = 0 | post-filter | fetch include_fields = requested ∪ CLASSIFY_FIELDS; after filter, project kept bugs to requested fields (keep `_redacted` marker); envelope `{"bugs":[..]}` only (I3) | **limit/offset address the bugs the client may SEE, not upstream rows** (Guard::quicksearch_window): filtering an already-paginated page left a hole exactly where a hidden bug sat — a short page the next offset contradicted — and since quicksearch matches summary text that hole was a probe for the hidden title, one word at a time. The guard now scans upstream from row 0 in 200-row chunks, classifies each, and fills the window from the survivors; rows are deduped on the server-reported id (relevance order is not stable between calls) and an id-less row is dropped (I4). Bounds: MAX_SEARCH_WINDOW=1000 addressable, 2000 rows scanned (<=10 sequential requests); hitting either truncates, which looks exactly like the end of results. The objects returned are the ones classified. The scan target is quantised to whole chunks so the stopping point does not track the client's `limit`; without that, `limit` could be binary-searched against the clock to recover each block's exact hidden count. Residual, accepted: filling a window of VISIBLE bugs needs more rows when bugs are hidden, so a stopwatch still learns one bit per scanned block ("not entirely visible"). Removing that would mean scanning the worst case on every search, or letting pages go short again. Search failure returns a bare "Search failed"; the upstream text is logged server-side only (it can name a bug and say whether it exists) |
 | add_comment | bug_id, comment, is_private: bool = false | comment (write) | |
 | update_bug_status | bug_id, status, resolution?, comment: String = "" | status (write) | CLOSED requires resolution (error otherwise); when reopening (status not CLOSED/VERIFIED and no resolution given) set `"resolution": ""` |
 | assign_bug | bug_id, assignee (email), comment = "" | assign (write) | payload `{"assigned_to": ..}` |
@@ -405,6 +414,14 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   summary is refused, and refused/absent/up-front-denied ids yield byte-
   identical restricted entries; the distinct-id bound.
 - Integration tests (crates/bugwarden-core/tests/guard_wiremock.rs, wiremock):
+  quicksearch_window — pages stay full while visible bugs remain (no hole),
+  consecutive pages tile the visible sequence disjointly (against a stable
+  upstream order; an unstable one can drop a bug from every page, which hides
+  more rather than less), a hidden bug never shortens a page, a deep offset is
+  an empty page whether or not bugs were hidden, the scan bound is counted in
+  requests, the scan target does not track `limit`, id-less rows are dropped,
+  rows repeated across chunks are served once, exhaustion and scan truncation look alike, zero limit
+  touches nothing, and the returned objects are the classified ones;
   assess() deny for embargoed group; min-age deny; one request per distinct
   id whatever the answer (nonexistent vs withheld cost the same), repeated
   ids fetched once, no batch to poison; per-id


### PR DESCRIPTION
## The oracle

Bugzilla applied `limit`/`offset`, then the guard filtered what came back. So
a hidden bug left a hole exactly where it sat: the page returned **short**
while the next offset still had results.

That gap says "a bug exists here that you may not see". And because
quicksearch matches summary text, it is a probe, not a hint:

```
bugs_quicksearch(query="product:Foo",             limit=1, offset=0) -> []        <- hole
bugs_quicksearch(query="product:Foo",             limit=1, offset=1) -> [{id:41}]
bugs_quicksearch(query="product:Foo summary:heap",   limit=1, offset=0) -> []     <- hole survives => "heap" is in the hidden title
bugs_quicksearch(query="product:Foo summary:heapzz", limit=1, offset=0) -> [...]  <- hole gone   => it is not
```

Iterate a dictionary and the hidden bug's title comes out one word at a time.
Uniform denials (I2) and silent filtering (I3) are worth nothing while the
window itself reports what was removed — which makes this the finding that
actually defeats the embargo rules the policy exists to enforce.

## The fix

Pagination is applied **after** the guard. `Guard::quicksearch_window` scans
the upstream result from row 0 in 200-row chunks, classifies each chunk, and
continues until enough visible bugs have accumulated to fill the requested
window. A hidden bug now costs a row of scanning and nothing else — it cannot
shorten a page or contradict a later offset.

Scanning from row 0 every time is not laziness: a visible-space offset cannot
be mapped onto an upstream offset without classifying everything before it,
and how many bugs that is, is exactly what must not leak.

## Bounds and what they cost

| bound | value | effect when hit |
|---|---|---|
| addressable window (`offset+limit`) | 1000 | page truncates |
| upstream rows scanned | 2000 (≤10 sequential requests) | page truncates |

Truncation is indistinguishable from reaching the end of the results, so the
failure direction hides more rather than less. I chose these over the 10,000
rows / 50 requests the design proposed, because this deployment already showed
it drops connections under load — a search costing 50 upstream round trips is
not a good trade for pagination depth almost nobody uses.

Rows are deduped on the server-reported id (relevance ordering proved unstable
between calls against the live instance), and a row without a readable id is
dropped rather than guessed at (I4).

## Residual, stated plainly

The **number** of upstream requests grows with how many bugs were hidden in
the scanned prefix, so a client with a stopwatch can infer that a query's
results contain hidden bugs *somewhere*. That is a long way from
reconstructing a title, and the count steps only every 200 rows. Removing it
entirely would mean a fixed-size scan on every search, charging every query
for the worst case.

## Verification

147 tests (+7). I checked the tests actually detect the old behaviour by
reintroducing it: three fail immediately. Two others did **not** discriminate
— one placed its hidden bugs past the window where they could not matter — so
I sharpened them; that one now interleaves hidden bugs before and inside the
window and asserts the page is still full.

Pinned: pages stay full while visible bugs remain, consecutive pages tile the
visible sequence disjointly and gaplessly, a hidden bug never shortens a page,
exhaustion and scan-truncation look alike, a zero limit touches upstream not at
all, and the objects returned are the ones that were classified.

Search failures now return a bare `Search failed`; the upstream text is logged
server-side only, since it can name a bug and say whether it exists.