### PR TITLE
feat(server): add create_bug and add_attachment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ touched or data is returned.
 
 - **Complete Bugzilla tool surface**: bug details, history, comments,
   attachment metadata and content, quicksearch, comment/status/field/
-  assignee/CC/dependency updates, duplicate marking, server info, quicksearch
-  syntax docs, and a bug-summarization prompt tool.
+  assignee/CC/dependency updates, duplicate marking, bug filing, attachment
+  upload, server info, quicksearch syntax docs, and a bug-summarization
+  prompt tool.
 - **Guard policy engine**: per-bug `allow` / `deny` / `restrict` decisions
   matched on product, component, group, keyword, status, severity, priority,
-  whiteboard, and bug age — with a fine-grained 11-capability vocabulary for
+  whiteboard, and bug age — with a fine-grained 13-capability vocabulary for
   `restrict`.
 - **No existence oracle**: a policy-denied bug is indistinguishable from a
   nonexistent one.
@@ -289,7 +290,19 @@ metacharacters. Examples: `embargo*`, `*security*`, `SUSE *`.
 
 #### Capabilities
 
-Eleven capabilities exist. `read` implies `summary`; nothing else is implied.
+Thirteen capabilities exist. `read` implies `summary`; nothing else is
+implied.
+
+> **Upgrading from a version without `create`/`attach`:** the capability set
+> grew from eleven to thirteen, and `allow` (rules and
+> `default_action = "allow"` alike) always grants the **full** set. A policy
+> written before these capabilities existed therefore starts permitting bug
+> filing and attachment upload the moment the server is upgraded, with no
+> change to the policy file. To keep the old behaviour, either add
+> `disabled_tools = ["create_bug", "add_attachment"]` under `[global]`, or
+> replace `allow` grants with `restrict` rules listing exactly the
+> capabilities you mean. Read-only deployments are unaffected (both new
+> capabilities are writes).
 
 | Capability | Kind | Grants |
 |------------|------|--------|
@@ -304,9 +317,11 @@ Eleven capabilities exist. `read` implies `summary`; nothing else is implied.
 | `assign` | write | changing the assignee |
 | `cc` | write | modifying the CC list |
 | `deps` | write | changing blocks/depends_on |
+| `create` | write | filing a new bug — judged against the bug *as requested*, so a rule that hides a product by name also refuses filing into it. The request's `groups` claim is never trusted (Bugzilla adds mandatory groups server-side), so **a policy whose rules consult `groups` or `group_restricted` refuses all bug filing** |
+| `attach` | write | uploading an attachment to a bug |
 
-When the server is read-only (policy or CLI), the six write capabilities are
-stripped from every grant, including from `allow` rules and the default
+When the server is read-only (policy or CLI), the eight write capabilities
+are stripped from every grant, including from `allow` rules and the default
 action.
 
 ## Tool reference
@@ -327,6 +342,8 @@ action.
 | `update_bug_dependencies` | Add/remove blocks and depends_on entries | `deps` |
 | `add_cc_to_bug` | Add an email to the CC list | `cc` |
 | `mark_as_duplicate` | Close a bug as DUPLICATE of another | `status` on the bug **and** at least `summary` on the duplicate target |
+| `create_bug` | File a new bug; the request is policy-checked *as described* before anything is created. A policy refusal and a Bugzilla-side failure return the same refusal text at the same cost, so a failed create never says which of the two refused, or why | `create` on the bug as requested |
+| `add_attachment` | Upload a base64-encoded attachment to a bug, capped by `max_attachment_bytes` (decoded size) | `attach` on the target bug |
 | `bug_url` | Compute `{server}/show_bug.cgi?id={id}` locally | none (contacts nothing) |
 | `bugzilla_server_info` | Bugzilla version, extensions, timezone, time, parameters | none |
 | `quicksearch_syntax` | Bugzilla's quicksearch syntax documentation (HTML) | none |

--- a/crates/bugwarden-core/src/client.rs
+++ b/crates/bugwarden-core/src/client.rs
@@ -255,6 +255,21 @@ impl BugzillaClient {
         self.get_json(key, "/bug", &params).await
     }
 
+    /// POST `/rest/bug` — file a new bug, returning the response envelope
+    /// (`{"id": N}` on success).
+    pub async fn create_bug(&self, key: &str, payload: Value) -> Result<Value> {
+        self.send_json_body(reqwest::Method::POST, key, "/bug", &payload)
+            .await
+    }
+
+    /// POST `/rest/bug/{id}/attachment` — upload an attachment, returning the
+    /// response envelope (`{"ids": [N]}` on success).
+    pub async fn add_attachment(&self, key: &str, id: u64, payload: Value) -> Result<Value> {
+        let path = format!("/bug/{id}/attachment");
+        self.send_json_body(reqwest::Method::POST, key, &path, &payload)
+            .await
+    }
+
     /// PUT `/rest/bug/{id}` with a caller-built payload (the caller adds
     /// `"comment": {"body": ..}` when a comment is wanted) — returns the
     /// response envelope.

--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -688,6 +688,59 @@ impl Guard {
             .collect()
     }
 
+    /// Whether a bug MAY BE FILED as described.
+    ///
+    /// There is no bug to classify yet, so the bug as requested is
+    /// classified instead: the same rules that decide whether an existing bug
+    /// may be seen decide whether one may be created looking like that. A
+    /// policy that hides a product by NAME therefore also refuses to let
+    /// bugs be filed into it, without needing a second vocabulary.
+    ///
+    /// The request is only evidence for fields Bugzilla will take verbatim.
+    /// For product, component, summary, version, severity, priority,
+    /// keywords and the rest, the created bug either carries exactly the
+    /// requested value or creation fails upstream — so the claim is sound to
+    /// classify on. `groups` is different in kind: Bugzilla UNIONS the
+    /// product's mandatory groups into whatever the request named, so the
+    /// created bug can belong to groups the request never mentioned (the
+    /// canonical `security-*` embargo setup works exactly this way). A
+    /// client-claimed group list must therefore never decide the verdict —
+    /// claiming `groups: []` would otherwise defeat a group deny rule that
+    /// omitting `groups` correctly trips. The group list of a prospective
+    /// bug is forced to UNKNOWN, whatever the payload said, and unknown
+    /// fails closed (I4). Consequence, deliberate: a policy whose applicable
+    /// rules consult `groups` or `group_restricted` refuses ALL creation,
+    /// because the answer cannot be known before the bug exists.
+    ///
+    /// The prospective bug is dated NOW, so an age rule (`younger_than_days`,
+    /// `min_bug_age_days`) refuses creation wherever it would immediately
+    /// hide the result. Filing a bug nobody may then read is not a service.
+    pub fn may_create(&self, requested: &Value) -> bool {
+        let mut meta = BugMeta::from_json(requested);
+        meta.creation_time = Some(Utc::now());
+        // Bugzilla augments the group list server-side on creation; the
+        // request's claim about it is not knowledge (see above).
+        meta.groups = None;
+        // Every other field the request does not mention is unknown, not
+        // empty, and classification fails closed on it (I4).
+        self.policy
+            .classify(&meta, Utc::now())
+            .allows(Capability::Create)
+    }
+
+    /// The refusal for a bug that was not filed.
+    ///
+    /// Says only that the server did not do it: which rule tripped — or
+    /// whether it was Bugzilla, not the policy, that refused — stays
+    /// server-side (I1/I2). Callers must return this SAME text for a policy
+    /// refusal and for an upstream failure: two texts would let a client
+    /// send an always-invalid request (a bogus `version`, say) and read the
+    /// policy off which refusal came back, creating nothing and paying
+    /// nothing.
+    pub fn create_denial() -> String {
+        "Filing this bug is not permitted through this server".to_string()
+    }
+
     /// Project a bug object down to [`SUMMARY_FIELDS`] and add a
     /// `"_redacted": true` marker so clients (and tests) can tell a summary
     /// view from a full bug. Fields absent from the input are simply omitted.
@@ -1490,6 +1543,164 @@ products = ["NoView*"]
                 .global
                 .max_attachment_bytes,
             2 * 1024 * 1024
+        );
+    }
+
+    // ---------- may_create ----------
+
+    /// A minimal well-formed create request, as `create_bug` builds one.
+    fn create_request(product: &str) -> Value {
+        json!({
+            "product": product,
+            "component": "core",
+            "summary": "crash on start",
+            "version": "1.0",
+        })
+    }
+
+    #[test]
+    fn may_create_refuses_the_products_the_policy_hides() {
+        // The same rule that hides a product refuses filing into it.
+        let g = Guard {
+            policy: policy(concat!(
+                "[[rule]]\nname = \"hide-security\"\naction = \"deny\"\n",
+                "[rule.match]\nproducts = [\"Security*\"]\n",
+            )),
+        };
+        assert!(!g.may_create(&create_request("Security Response")));
+        assert!(g.may_create(&create_request("openSUSE")));
+    }
+
+    #[test]
+    fn may_create_never_lets_the_claimed_group_list_decide() {
+        // Bugzilla UNIONS the product's mandatory groups into whatever the
+        // request named, so the created bug can be in groups the request
+        // never mentioned. A group deny rule therefore refuses creation
+        // whatever the payload claims: omitting `groups`, claiming `[]`, and
+        // claiming a non-matching list must all be refused alike — if
+        // `groups: []` were taken as fact it would be strictly MORE
+        // permissive than omitting the field, and the canonical security-*
+        // embargo pattern would be filed straight through.
+        let g = Guard {
+            policy: policy(concat!(
+                "[[rule]]\nname = \"embargo\"\naction = \"deny\"\n",
+                "[rule.match]\ngroups = [\"embargo*\"]\n",
+            )),
+        };
+        let mut req = create_request("openSUSE");
+        assert!(!g.may_create(&req), "absent groups must fail closed");
+        req["groups"] = json!([]);
+        assert!(
+            !g.may_create(&req),
+            "a claimed empty group list is not knowledge: Bugzilla adds \
+             mandatory groups the request cannot disclaim"
+        );
+        req["groups"] = json!(["harmless"]);
+        assert!(!g.may_create(&req), "a non-matching claim decides nothing");
+        req["groups"] = json!(["embargo-security"]);
+        assert!(!g.may_create(&req));
+    }
+
+    #[test]
+    fn may_create_group_restricted_policies_refuse_all_creation() {
+        // The example policy's first rule: deny anything group-restricted.
+        // Whether the created bug will be group-restricted cannot be known
+        // in advance, so every create request is refused (I4) — including
+        // one that claims to be world-readable.
+        let g = Guard {
+            policy: policy(concat!(
+                "[[rule]]\nname = \"group-restricted\"\naction = \"deny\"\n",
+                "[rule.match]\ngroup_restricted = true\n",
+            )),
+        };
+        let mut req = create_request("openSUSE");
+        assert!(!g.may_create(&req));
+        req["groups"] = json!([]);
+        assert!(!g.may_create(&req));
+    }
+
+    #[test]
+    fn shipped_example_policy_parses_and_refuses_all_creation() {
+        // examples/policy.toml documents, in its header, that filing bugs is
+        // impossible under it: its first rule consults the group list, which
+        // is unknowable for a not-yet-created bug. Pin that the shipped file
+        // parses and behaves as its own comments claim. Read at runtime (not
+        // include_str!) so the core crate stays packageable without the file.
+        let path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/policy.toml");
+        let toml = std::fs::read_to_string(path).expect("example policy must exist in-repo");
+        let g = Guard {
+            policy: policy(&toml),
+        };
+        let mut req = create_request("openSUSE");
+        assert!(!g.may_create(&req), "omitted groups: refused");
+        req["groups"] = json!([]);
+        assert!(!g.may_create(&req), "claimed empty groups: refused");
+        req["groups"] = json!(["security-team"]);
+        assert!(!g.may_create(&req), "claimed groups: refused");
+    }
+
+    #[test]
+    fn may_create_group_rules_ruled_out_by_other_criteria_do_not_block() {
+        // Forcing groups to unknown must not turn every group-consulting
+        // rule into a blanket refusal: a rule some OTHER criterion already
+        // ruled out (definitive No) cannot apply either way, and evaluation
+        // moves on.
+        let g = Guard {
+            policy: policy(concat!(
+                "[[rule]]\nname = \"secret-embargo\"\naction = \"deny\"\n",
+                "[rule.match]\nproducts = [\"Secret*\"]\ngroups = [\"embargo*\"]\n",
+            )),
+        };
+        assert!(g.may_create(&create_request("openSUSE")));
+        assert!(!g.may_create(&create_request("SecretSauce")));
+    }
+
+    #[test]
+    fn may_create_dates_the_request_now() {
+        // An age gate that would immediately hide the new bug refuses its
+        // creation — and a creation_time CLAIMED by the payload must not
+        // defeat that: the prospective bug is dated NOW, whatever the
+        // request says.
+        let g = Guard {
+            policy: policy("[global]\nmin_bug_age_days = 1\n"),
+        };
+        let mut req = create_request("openSUSE");
+        assert!(!g.may_create(&req));
+        req["creation_time"] = json!("2000-01-01T00:00:00Z");
+        assert!(!g.may_create(&req));
+    }
+
+    #[test]
+    fn may_create_restrict_grants_only_the_named_products() {
+        // Pins the operator-facing TOML spelling "create" along the way.
+        let g = Guard {
+            policy: policy(concat!(
+                "default_action = \"deny\"\n",
+                "[[rule]]\nname = \"filers\"\naction = \"restrict\"\n",
+                "capabilities = [\"create\"]\n",
+                "[rule.match]\nproducts = [\"openSUSE*\"]\n",
+            )),
+        };
+        assert!(g.may_create(&create_request("openSUSE Tumbleweed")));
+        assert!(!g.may_create(&create_request("Internal Tools")));
+    }
+
+    #[test]
+    fn may_create_refuses_everything_in_read_only() {
+        let g = Guard {
+            policy: policy("[global]\nread_only = true\n"),
+        };
+        assert!(!g.may_create(&create_request("openSUSE")));
+    }
+
+    #[test]
+    fn create_denial_is_uniform_and_names_nothing() {
+        // One fixed text whatever tripped the refusal: no rule name, no
+        // criterion, no product (I1).
+        assert_eq!(
+            Guard::create_denial(),
+            "Filing this bug is not permitted through this server"
         );
     }
 }

--- a/crates/bugwarden-core/src/policy.rs
+++ b/crates/bugwarden-core/src/policy.rs
@@ -78,11 +78,26 @@ pub enum Capability {
     Cc,
     /// Write: change blocks/depends_on.
     Deps,
+    /// Write: file a NEW bug.
+    ///
+    /// Judged against the bug as REQUESTED — product, component, summary and
+    /// so on are classified exactly as an existing bug's would be, so a rule
+    /// that hides a product by name also refuses to let bugs be filed into
+    /// it. The one exception is `groups`: Bugzilla augments the group list
+    /// server-side on creation, so the request's claim about it is ignored
+    /// and a policy consulting groups refuses creation outright (see
+    /// `Guard::may_create`).
+    Create,
+    /// Write: upload a new attachment to a bug.
+    ///
+    /// Distinct from [`Capability::Attachments`], which is the read side
+    /// (listing metadata and downloading content).
+    Attach,
 }
 
 impl Capability {
     /// Every capability, in declaration order. Used to expand `allow` grants.
-    pub const ALL: [Capability; 11] = [
+    pub const ALL: [Capability; 13] = [
         Capability::Read,
         Capability::Summary,
         Capability::Comments,
@@ -94,6 +109,8 @@ impl Capability {
         Capability::Assign,
         Capability::Cc,
         Capability::Deps,
+        Capability::Create,
+        Capability::Attach,
     ];
 
     /// Whether this capability permits mutating Bugzilla state.
@@ -110,6 +127,8 @@ impl Capability {
                 | Capability::Assign
                 | Capability::Cc
                 | Capability::Deps
+                | Capability::Create
+                | Capability::Attach
         )
     }
 }
@@ -899,10 +918,10 @@ mod tests {
     // ---------- Capability ----------
 
     #[test]
-    fn capability_all_lists_eleven_unique() {
-        assert_eq!(Capability::ALL.len(), 11);
+    fn capability_all_lists_thirteen_unique() {
+        assert_eq!(Capability::ALL.len(), 13);
         let set: BTreeSet<_> = Capability::ALL.iter().copied().collect();
-        assert_eq!(set.len(), 11);
+        assert_eq!(set.len(), 13);
     }
 
     #[test]
@@ -921,6 +940,8 @@ mod tests {
                 Capability::Assign,
                 Capability::Cc,
                 Capability::Deps,
+                Capability::Create,
+                Capability::Attach,
             ]
         );
         for c in [
@@ -1536,7 +1557,7 @@ products = ["SUSE*"]
         match &access {
             Access::Granted { caps, rule } => {
                 assert_eq!(rule, "default");
-                assert_eq!(caps.len(), 11);
+                assert_eq!(caps.len(), 13);
             }
             other => panic!("expected grant, got {other:?}"),
         }
@@ -1804,6 +1825,54 @@ capabilities = ["summary", "comment", "status"]
             Access::Granted { caps, .. } => assert_eq!(caps.len(), 1),
             other => panic!("expected grant, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn read_only_strips_create_and_attach() {
+        // Named explicitly (not via is_write) so a miscategorised capability
+        // cannot make this vacuously true: filing bugs and uploading
+        // attachments are writes, and read-only must strip them.
+        let p = Policy::from_toml_str("[global]\nread_only = true\n").unwrap();
+        let access = p.classify(&meta(), now());
+        assert!(!access.allows(Capability::Create));
+        assert!(!access.allows(Capability::Attach));
+        // Their read-side counterpart survives.
+        assert!(access.allows(Capability::Attachments));
+    }
+
+    #[test]
+    fn restrict_comment_grants_neither_create_nor_attach() {
+        // Commenting on existing bugs is not filing new ones and not
+        // uploading files: no implication exists between any of these.
+        let s = r#"
+[[rule]]
+name = "comment-only"
+action = "restrict"
+capabilities = ["comment"]
+"#;
+        let p = Policy::from_toml_str(s).unwrap();
+        let access = p.classify(&meta(), now());
+        assert!(access.allows(Capability::Comment));
+        assert!(!access.allows(Capability::Create));
+        assert!(!access.allows(Capability::Attach));
+        assert!(!access.allows(Capability::Attachments));
+    }
+
+    #[test]
+    fn restrict_can_grant_create_and_attach_by_name() {
+        // Pins the operator-facing TOML spelling of the two capabilities.
+        let s = r#"
+[[rule]]
+name = "filers"
+action = "restrict"
+capabilities = ["summary", "create", "attach"]
+"#;
+        let p = Policy::from_toml_str(s).unwrap();
+        let access = p.classify(&meta(), now());
+        assert!(access.allows(Capability::Create));
+        assert!(access.allows(Capability::Attach));
+        assert!(!access.allows(Capability::Read));
+        assert!(!access.allows(Capability::Attachments));
     }
 
     #[test]

--- a/crates/bugwarden-core/tests/guard_wiremock.rs
+++ b/crates/bugwarden-core/tests/guard_wiremock.rs
@@ -435,6 +435,50 @@ async fn auth_header_mode_sends_bearer_and_no_query_key() {
 }
 
 #[tokio::test]
+async fn client_create_bug_posts_the_payload_to_rest_bug() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 42 })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let bz = client(&server);
+    let payload = json!({
+        "product": "openSUSE",
+        "component": "Kernel",
+        "summary": "boom",
+        "version": "1.0",
+    });
+    let v = bz.create_bug(KEY, payload.clone()).await.unwrap();
+    assert_eq!(v["id"], json!(42));
+
+    // The payload travels as the POST body, untouched.
+    let reqs = server.received_requests().await.expect("recording enabled");
+    let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).expect("json body");
+    assert_eq!(body, payload);
+}
+
+#[tokio::test]
+async fn client_add_attachment_posts_to_the_bug_attachment_path() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/7/attachment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "ids": [9] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let bz = client(&server);
+    let v = bz
+        .add_attachment(KEY, 7, json!({ "ids": [7], "data": "Zm9v" }))
+        .await
+        .unwrap();
+    assert_eq!(v["ids"], json!([9]));
+}
+
+#[tokio::test]
 async fn summary_view_strips_sensitive_fields_after_fetch() {
     let server = MockServer::start().await;
     // A bug loaded with everything the redacted view must strip.

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -37,3 +37,10 @@ clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+# The integration tests drive the tools through a real MCP session over an
+# in-memory duplex transport, so the client half of rmcp is needed here.
+rmcp = { version = "2.2", features = ["client"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-util"] }
+wiremock = "0.6"

--- a/crates/bugwarden/src/lib.rs
+++ b/crates/bugwarden/src/lib.rs
@@ -1,0 +1,12 @@
+//! bugwarden — MCP server for Bugzilla with operator-controlled security
+//! guards.
+//!
+//! This library target exists so the MCP tool surface can be driven end to
+//! end by integration tests (`tests/`): the binary (`main.rs`) is a thin
+//! transport wrapper around [`server::BugWarden`], and a binary-only crate
+//! would leave the tool gates — the code that calls the guard — untestable
+//! as a unit. The supported product remains the `bugwarden` binary; this
+//! API carries no stability promise of its own.
+
+pub mod config;
+pub mod server;

--- a/crates/bugwarden/src/main.rs
+++ b/crates/bugwarden/src/main.rs
@@ -1,12 +1,14 @@
 //! bugwarden — Rust MCP server for Bugzilla with operator-controlled
 //! security guards.
-
-mod config;
-mod server;
+//!
+//! The binary is a thin transport wrapper; the CLI and the MCP tool surface
+//! live in the `bugwarden` library crate (`config`, `server`) so integration
+//! tests can drive the tools without a process boundary.
 
 use std::sync::Arc;
 
 use anyhow::{bail, Context};
+use bugwarden::{config, server};
 use bugwarden_core::{client::BugzillaClient, guard::Guard, policy::Policy};
 use clap::Parser;
 use rmcp::{
@@ -20,7 +22,7 @@ use rmcp::{
 };
 use tracing_subscriber::EnvFilter;
 
-use crate::config::{Cli, Transport};
+use config::{Cli, Transport};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -34,6 +34,8 @@ pub const WRITE_TOOLS: &[&str] = &[
     "update_bug_dependencies",
     "add_cc_to_bug",
     "mark_as_duplicate",
+    "create_bug",
+    "add_attachment",
 ];
 
 /// Success result: ONE text block containing pretty-printed JSON.
@@ -147,7 +149,9 @@ fn project_fields(bug: &Value, fields: &BTreeSet<String>) -> Value {
     Value::Object(out)
 }
 
-/// Add `"comment": {"body": ...}` to an update payload when a comment is set.
+/// Add `"comment": {"body": ...}` to a `Bug.update` payload when a comment is
+/// set. This is the UPDATE shape only — `Bug.add_attachment` takes `comment`
+/// as a plain string and must not use this helper.
 fn attach_comment(payload: &mut serde_json::Map<String, Value>, comment: &str) {
     if !comment.is_empty() {
         payload.insert("comment".to_string(), json!({ "body": comment }));
@@ -189,6 +193,20 @@ fn decoded_len(blob: &str) -> u64 {
     let full = chars / 4 * 3;
     let tail = (chars % 4).saturating_sub(1);
     (full + tail).saturating_sub(padding)
+}
+
+/// Upload-side size gate: `Some(refusal)` when the DECODED size of a base64
+/// payload exceeds a non-zero cap.
+///
+/// The same ceiling `download_attachment` enforces, applied to what comes IN:
+/// an operator who capped what may leave has not agreed to unbounded uploads
+/// through the same server. Measured on the decoded size, so base64 expansion
+/// cannot shrink the cap by a third. The refusal says the payload is too big
+/// but not by how much: `max_attachment_bytes` is not I1-disclosable, on this
+/// path exactly as on the download path.
+fn upload_size_refusal(cap: u64, data: &str) -> Option<String> {
+    (cap > 0 && decoded_len(data) > cap)
+        .then(|| "Attachment exceeds the size limit of this server".to_string())
 }
 
 /// Whether attachment content of this media type may be returned as MCP
@@ -267,6 +285,62 @@ pub struct QuicksearchParams {
     /// Offset into the result list (for pagination).
     #[serde(default)]
     pub offset: u32,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct CreateBugParams {
+    /// Product to file against.
+    pub product: String,
+    /// Component within the product.
+    pub component: String,
+    /// One-line summary.
+    pub summary: String,
+    /// Version of the product the bug is against.
+    pub version: String,
+    /// Longer description; becomes the first comment.
+    #[serde(default)]
+    pub description: String,
+    /// Severity (instance-specific vocabulary, e.g. "normal").
+    #[serde(default)]
+    pub severity: Option<String>,
+    /// Priority (instance-specific vocabulary, e.g. "P3").
+    #[serde(default)]
+    pub priority: Option<String>,
+    /// Operating system the bug applies to.
+    #[serde(default)]
+    pub op_sys: Option<String>,
+    /// Platform/architecture the bug applies to.
+    #[serde(default)]
+    pub platform: Option<String>,
+    /// Keywords to set on the new bug.
+    #[serde(default)]
+    pub keywords: Vec<String>,
+    /// Groups to restrict the new bug to.
+    #[serde(default)]
+    pub groups: Vec<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct AddAttachmentParams {
+    /// Bug id to attach to.
+    pub bug_id: u64,
+    /// Attachment content, base64-encoded.
+    pub data: String,
+    /// File name shown in Bugzilla.
+    pub file_name: String,
+    /// Short description of the attachment.
+    pub summary: String,
+    /// MIME type, e.g. "text/plain".
+    pub content_type: String,
+    /// Comment to add alongside the attachment.
+    #[serde(default)]
+    pub comment: String,
+    /// Mark the attachment private.
+    #[serde(default)]
+    pub is_private: bool,
+    /// Mark the attachment as a patch.
+    #[serde(default)]
+    pub is_patch: bool,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -398,6 +472,9 @@ pub struct SummarizeBugParams {
     pub id: u64,
 }
 
+/// The MCP server: guard policy, Bugzilla client, and the pruned tool
+/// router (I13). Construct with [`BugWarden::new`]; serve over any rmcp
+/// transport.
 #[derive(Clone)]
 pub struct BugWarden {
     cfg: Arc<Cli>,
@@ -767,6 +844,144 @@ impl BugWarden {
         }
 
         Ok(ok_json(json!({ "bugs": projected })))
+    }
+
+    #[tool(
+        description = "File a new bug. The bug is checked against server policy AS DESCRIBED before it is created, so a product or component the policy withholds cannot be filed into either. Returns the new bug id on success.",
+        annotations(
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = true
+        )
+    )]
+    async fn create_bug(
+        &self,
+        Parameters(p): Parameters<CreateBugParams>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        tracing::info!(
+            product = %p.product,
+            component = %p.component,
+            "tool: create_bug"
+        );
+        let key = self.api_key(&ctx)?;
+
+        let mut payload = serde_json::Map::new();
+        payload.insert("product".to_string(), json!(p.product));
+        payload.insert("component".to_string(), json!(p.component));
+        payload.insert("summary".to_string(), json!(p.summary));
+        payload.insert("version".to_string(), json!(p.version));
+        if !p.description.is_empty() {
+            payload.insert("description".to_string(), json!(p.description));
+        }
+        for (field, value) in [
+            ("severity", p.severity),
+            ("priority", p.priority),
+            ("op_sys", p.op_sys),
+            ("platform", p.platform),
+        ] {
+            if let Some(v) = value {
+                payload.insert(field.to_string(), json!(v));
+            }
+        }
+        if !p.keywords.is_empty() {
+            payload.insert("keywords".to_string(), json!(p.keywords));
+        }
+        if !p.groups.is_empty() {
+            payload.insert("groups".to_string(), json!(p.groups));
+        }
+        let payload = Value::Object(payload);
+
+        // No bug exists yet, so the bug AS REQUESTED is what the policy
+        // judges: the rules that decide what may be seen decide what may be
+        // filed. The refusal names no rule (I1) and — crucially — is the
+        // SAME text, after the SAME single upstream request, whether the
+        // policy or Bugzilla refused. Two distinguishable refusals would be
+        // a free policy oracle: send a request Bugzilla is guaranteed to
+        // reject (an invalid `version`, say) and read the policy off which
+        // refusal comes back, with nothing created and nothing logged
+        // upstream. So the refused path burns one classification call
+        // against bug id 0 — which never exists and creates nothing —
+        // exactly as download_attachment pads its metadata-miss path, so
+        // both failure paths cost one upstream request. Honestly residual:
+        // a SUCCESSFUL create is still distinguishable (it returns the new
+        // bug id — that is the tool working), so a client willing to file a
+        // real, attributable bug in an allowed product can still confirm
+        // that product is allowed; and the padding equalizes the request
+        // COUNT, not the upstream handler's exact latency (a GET classify
+        // vs a rejected POST), the same residual the download path accepts.
+        if !self.guard.may_create(&payload) {
+            let _ = self.assess(&key, &[0]).await;
+            tracing::info!(product = %p.product, "guard denied bug creation");
+            return Ok(err_text(Guard::create_denial()));
+        }
+
+        match self.bz.create_bug(&key, payload).await {
+            Ok(v) => Ok(ok_json(v)),
+            Err(e) => {
+                // Uniform with the policy refusal above (see that comment);
+                // Bugzilla's message is logged server-side only — it can say
+                // whether a product or component exists.
+                tracing::warn!(error = %e, "create_bug: upstream refused");
+                Ok(err_text(Guard::create_denial()))
+            }
+        }
+    }
+
+    #[tool(
+        description = "Attach a file to a bug. Content must be base64-encoded. Subject to server policy on the target bug and to the server's attachment size limit.",
+        annotations(
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = true
+        )
+    )]
+    async fn add_attachment(
+        &self,
+        Parameters(p): Parameters<AddAttachmentParams>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        tracing::info!(
+            bug_id = p.bug_id,
+            file_name = %p.file_name,
+            is_private = p.is_private,
+            "tool: add_attachment"
+        );
+        let key = self.api_key(&ctx)?;
+        if let Some(denied) = self.deny_unless(&key, p.bug_id, Capability::Attach).await {
+            return Ok(denied);
+        }
+
+        let cap = self.guard.policy.global.max_attachment_bytes;
+        if let Some(refusal) = upload_size_refusal(cap, &p.data) {
+            return Ok(err_text(refusal));
+        }
+
+        let mut payload = serde_json::Map::new();
+        payload.insert("ids".to_string(), json!([p.bug_id]));
+        payload.insert("data".to_string(), json!(p.data));
+        payload.insert("file_name".to_string(), json!(p.file_name));
+        payload.insert("summary".to_string(), json!(p.summary));
+        payload.insert("content_type".to_string(), json!(p.content_type));
+        payload.insert("is_patch".to_string(), json!(p.is_patch));
+        payload.insert("is_private".to_string(), json!(p.is_private));
+        // Bug.add_attachment takes `comment` as a PLAIN string — unlike
+        // Bug.update's `{"comment": {"body": ...}}` shape, so the update
+        // helper (attach_comment) must not be reused here.
+        if !p.comment.is_empty() {
+            payload.insert("comment".to_string(), json!(p.comment));
+        }
+        let payload = Value::Object(payload);
+
+        match self.bz.add_attachment(&key, p.bug_id, payload).await {
+            Ok(v) => Ok(ok_json(v)),
+            Err(e) => {
+                tracing::warn!(bug_id = p.bug_id, error = %e, "add_attachment: upstream refused");
+                Ok(err_text("Failed to add attachment"))
+            }
+        }
     }
 
     #[tool(
@@ -1741,6 +1956,59 @@ mod tests {
             );
         }
         assert!(server.tool_router.has_route("bug_info"));
+    }
+
+    #[test]
+    fn read_only_delists_create_bug_and_add_attachment_i13() {
+        // The filing tools are writes: read-only mode must remove them from
+        // the LISTING — call-time capability stripping alone is not I13.
+        let (cfg, guard, bz) = parts("[global]\nread_only = true\n");
+        let server = BugWarden::new(cfg, guard, bz).expect("server builds");
+        assert!(!server.tool_router.has_route("create_bug"));
+        assert!(!server.tool_router.has_route("add_attachment"));
+        // A default build serves both.
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz).expect("server builds");
+        assert!(server.tool_router.has_route("create_bug"));
+        assert!(server.tool_router.has_route("add_attachment"));
+    }
+
+    #[test]
+    fn decoded_len_counts_decoded_bytes_exactly() {
+        assert_eq!(decoded_len(""), 0);
+        assert_eq!(decoded_len("YQ=="), 1); // "a"
+        assert_eq!(decoded_len("YWI="), 2); // "ab"
+        assert_eq!(decoded_len("YWJj"), 3); // "abc"
+        assert_eq!(decoded_len("YWJjZA"), 4); // "abcd", unpadded tail
+        assert_eq!(decoded_len("YWJj\nZGVm"), 6); // wrapped lines do not inflate
+    }
+
+    #[test]
+    fn upload_size_cap_measures_decoded_not_encoded_bytes() {
+        // 100 decoded bytes encode to 136 base64 chars: the cap must judge
+        // the former, or encoding overhead would shrink every operator cap
+        // by a third.
+        let data = "AAAA".repeat(33) + "AA==";
+        assert_eq!(data.len(), 136);
+        assert_eq!(decoded_len(&data), 100);
+        assert!(
+            upload_size_refusal(100, &data).is_none(),
+            "136 encoded chars must not count against a 100-byte cap"
+        );
+        assert!(upload_size_refusal(99, &data).is_some());
+    }
+
+    #[test]
+    fn upload_size_cap_zero_disables_and_refusal_names_no_number() {
+        let data = "AAAA".repeat(33) + "AA==";
+        assert!(upload_size_refusal(0, &data).is_none(), "0 removes the cap");
+        // The refusal must not disclose the configured cap or the payload's
+        // size — max_attachment_bytes is not I1-disclosable.
+        let refusal = upload_size_refusal(99, &data).expect("over the cap");
+        assert!(
+            !refusal.contains(|c: char| c.is_ascii_digit()),
+            "refusal leaks a number: {refusal}"
+        );
     }
 
     #[test]

--- a/crates/bugwarden/tests/tools_wiremock.rs
+++ b/crates/bugwarden/tests/tools_wiremock.rs
@@ -1,0 +1,408 @@
+//! End-to-end tests of the MCP tool surface against a mock Bugzilla.
+//!
+//! Each test builds a real [`BugWarden`] server, serves it over an
+//! in-memory duplex transport, and CALLS the tools through an rmcp MCP
+//! client — the same dispatch path a production client takes, including the
+//! tool router. This is what makes the guard calls inside the tool bodies
+//! testable at all: a helper-level test would keep passing if a tool simply
+//! stopped calling the helper.
+//!
+//! Coverage contract (each of these mutations must fail at least one test):
+//! - swapping `Capability::Attach` for `Capability::Attachments` at the
+//!   add_attachment gate;
+//! - deleting the `may_create` call from create_bug;
+//! - deleting the upload size-cap call from add_attachment.
+
+use std::sync::Arc;
+
+use bugwarden::config::Cli;
+use bugwarden::server::BugWarden;
+use bugwarden_core::client::BugzillaClient;
+use bugwarden_core::guard::Guard;
+use bugwarden_core::policy::Policy;
+use clap::Parser as _;
+use rmcp::model::{CallToolRequestParams, CallToolResult};
+use rmcp::service::{RoleClient, RunningService};
+use rmcp::ServiceExt as _;
+use serde_json::{json, Value};
+use wiremock::matchers::{body_partial_json, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// The uniform create refusal (`Guard::create_denial`), pinned by value so a
+/// wording change in either path breaks a test instead of passing silently.
+const CREATE_DENIAL: &str = "Filing this bug is not permitted through this server";
+
+/// Serve a [`BugWarden`] built from `policy` against `mock`, and connect an
+/// MCP client to it over an in-memory duplex transport.
+async fn client_for(policy: &str, mock: &MockServer) -> RunningService<RoleClient, ()> {
+    let cfg = Arc::new(Cli::parse_from([
+        "bugwarden",
+        "--bugzilla-server",
+        &mock.uri(),
+        "--transport",
+        "stdio",
+        "--api-key",
+        "test-key",
+    ]));
+    let guard = Arc::new(Guard {
+        policy: Policy::from_toml_str(policy).expect("test policy must parse"),
+    });
+    let bz = Arc::new(BugzillaClient::new(&mock.uri(), false).expect("client must build"));
+    let server = BugWarden::new(cfg, guard, bz).expect("server must build");
+
+    let (client_io, server_io) = tokio::io::duplex(1 << 16);
+    tokio::spawn(async move {
+        if let Ok(running) = server.serve(server_io).await {
+            let _ = running.waiting().await;
+        }
+    });
+    ().serve(client_io)
+        .await
+        .expect("MCP handshake must succeed")
+}
+
+/// Call `tool` with `args` over the MCP session.
+async fn call(client: &RunningService<RoleClient, ()>, tool: &str, args: Value) -> CallToolResult {
+    let Value::Object(args) = args else {
+        panic!("tool arguments must be a JSON object");
+    };
+    client
+        .call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(args))
+        .await
+        .expect("tool call must not be a protocol error")
+}
+
+/// All text blocks of a result, concatenated.
+fn text_of(result: &CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .filter_map(|c| c.as_text())
+        .map(|t| t.text.as_str())
+        .collect()
+}
+
+fn is_error(result: &CallToolResult) -> bool {
+    result.is_error == Some(true)
+}
+
+/// A classification response for one world-readable bug carrying every
+/// CLASSIFY field a rule could consult.
+fn world_readable_bug(id: u64) -> Value {
+    json!({
+        "id": id,
+        "summary": "a plain bug",
+        "product": "openSUSE",
+        "component": "Kernel",
+        "status": "NEW",
+        "severity": "normal",
+        "priority": "P3",
+        "keywords": [],
+        "groups": [],
+        "whiteboard": "",
+        "creation_time": "2020-01-01T00:00:00Z",
+    })
+}
+
+/// Mount the classification fetch for `bug`, expected exactly once.
+async fn mount_classify(mock: &MockServer, bug: Value) {
+    let id = bug["id"].as_u64().expect("bug fixture has an id");
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", id.to_string()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [bug] })))
+        .expect(1)
+        .mount(mock)
+        .await;
+}
+
+fn create_args(product: &str) -> Value {
+    json!({
+        "product": product,
+        "component": "core",
+        "summary": "crash on start",
+        "version": "1.0",
+    })
+}
+
+fn attachment_args(bug_id: u64, data: &str) -> Value {
+    json!({
+        "bug_id": bug_id,
+        "data": data,
+        "file_name": "log.txt",
+        "summary": "boot log",
+        "content_type": "text/plain",
+    })
+}
+
+// ---------- create_bug (HIGH-1 / HIGH-2) ----------
+
+#[tokio::test]
+async fn create_bug_policy_and_upstream_refusals_are_indistinguishable() {
+    // Policy refusal: nothing may be POSTed, and the refused path must still
+    // cost exactly ONE upstream request (the padding classify against bug id
+    // 0), so the request count cannot tell the two refusals apart either.
+    let denied = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .expect(1)
+        .mount(&denied)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 1 })))
+        .expect(0)
+        .mount(&denied)
+        .await;
+    let client = client_for(
+        concat!(
+            "[[rule]]\nname = \"hide-secret\"\naction = \"deny\"\n",
+            "[rule.match]\nproducts = [\"Secret*\"]\n",
+        ),
+        &denied,
+    )
+    .await;
+    let refused = call(&client, "create_bug", create_args("SecretSauce")).await;
+    assert!(is_error(&refused), "policy-denied filing must be refused");
+    let policy_text = text_of(&refused);
+    assert_eq!(policy_text, CREATE_DENIAL);
+    assert_eq!(
+        denied.received_requests().await.unwrap().len(),
+        1,
+        "a policy refusal must cost exactly one upstream request"
+    );
+
+    // Upstream refusal (e.g. an invalid version): byte-identical text, same
+    // single upstream request. Two texts — or 0 vs 1 requests — would be a
+    // free policy-enumeration oracle.
+    let upstream = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": true,
+            "message": "There is no version named '1.0' in the 'openSUSE' product."
+        })))
+        .expect(1)
+        .mount(&upstream)
+        .await;
+    let client = client_for("", &upstream).await;
+    let failed = call(&client, "create_bug", create_args("openSUSE")).await;
+    assert!(is_error(&failed), "an upstream refusal is still a refusal");
+    assert_eq!(
+        text_of(&failed),
+        policy_text,
+        "policy and upstream refusals must be byte-identical (I2)"
+    );
+    assert_eq!(
+        upstream.received_requests().await.unwrap().len(),
+        1,
+        "an upstream refusal costs the same one request"
+    );
+}
+
+#[tokio::test]
+async fn create_bug_success_reaches_bugzilla_untouched() {
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .and(body_partial_json(json!({
+            "product": "openSUSE",
+            "component": "core",
+            "summary": "crash on start",
+            "version": "1.0",
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 4242 })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let client = client_for("", &mock).await;
+    let result = call(&client, "create_bug", create_args("openSUSE")).await;
+    assert!(!is_error(&result), "an allowed create must go through");
+    assert!(text_of(&result).contains("4242"));
+}
+
+#[tokio::test]
+async fn create_bug_claimed_groups_never_defeat_a_group_rule() {
+    // The canonical embargo pattern: the policy denies on group names, and
+    // Bugzilla UNIONS the product's mandatory groups into whatever the
+    // request claimed. A claimed, non-matching group list must therefore be
+    // refused exactly like an omitted one — nothing may reach Bugzilla.
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .expect(2)
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 1 })))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    let client = client_for(
+        concat!(
+            "[[rule]]\nname = \"embargo\"\naction = \"deny\"\n",
+            "[rule.match]\ngroups = [\"embargo*\"]\n",
+        ),
+        &mock,
+    )
+    .await;
+
+    let mut args = create_args("openSUSE");
+    args["groups"] = json!(["totally-harmless"]);
+    let claimed = call(&client, "create_bug", args).await;
+    assert!(
+        is_error(&claimed),
+        "a client-claimed group list must not decide a group rule"
+    );
+    assert_eq!(text_of(&claimed), CREATE_DENIAL);
+
+    let omitted = call(&client, "create_bug", create_args("openSUSE")).await;
+    assert!(is_error(&omitted));
+    assert_eq!(text_of(&omitted), CREATE_DENIAL);
+}
+
+#[tokio::test]
+async fn create_bug_group_restricted_policy_refuses_all_creation() {
+    // The shipped example policy's first rule: whether the created bug will
+    // be group-restricted cannot be known before it exists, so creation is
+    // refused entirely under such a policy — documented behaviour.
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 1 })))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    let client = client_for(
+        concat!(
+            "[[rule]]\nname = \"group-restricted\"\naction = \"deny\"\n",
+            "[rule.match]\ngroup_restricted = true\n",
+        ),
+        &mock,
+    )
+    .await;
+    let result = call(&client, "create_bug", create_args("openSUSE")).await;
+    assert!(is_error(&result));
+    assert_eq!(text_of(&result), CREATE_DENIAL);
+}
+
+// ---------- add_attachment (HIGH-3 mutations a and c, LOW-2) ----------
+
+#[tokio::test]
+async fn add_attachment_requires_attach_not_the_read_side_attachments() {
+    // A grant carrying the READ capability `attachments` (and read) but not
+    // the WRITE capability `attach` must refuse the upload with the uniform
+    // bug denial, before anything is POSTed.
+    let mock = MockServer::start().await;
+    mount_classify(&mock, world_readable_bug(7)).await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/7/attachment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "ids": [1] })))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    let client = client_for(
+        concat!(
+            "default_action = \"deny\"\n",
+            "[[rule]]\nname = \"read-side\"\naction = \"restrict\"\n",
+            "capabilities = [\"read\", \"attachments\"]\n",
+        ),
+        &mock,
+    )
+    .await;
+    let result = call(&client, "add_attachment", attachment_args(7, "QUFB")).await;
+    assert!(
+        is_error(&result),
+        "attachments (read) must not permit upload"
+    );
+    assert_eq!(
+        text_of(&result),
+        "Bug 7 is not accessible through this server"
+    );
+}
+
+#[tokio::test]
+async fn add_attachment_attach_grant_uploads() {
+    // The write capability `attach` alone is what opens the gate.
+    let mock = MockServer::start().await;
+    mount_classify(&mock, world_readable_bug(7)).await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/7/attachment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "ids": [31] })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let client = client_for(
+        concat!(
+            "default_action = \"deny\"\n",
+            "[[rule]]\nname = \"uploader\"\naction = \"restrict\"\n",
+            "capabilities = [\"attach\"]\n",
+        ),
+        &mock,
+    )
+    .await;
+    let result = call(&client, "add_attachment", attachment_args(7, "QUFB")).await;
+    assert!(!is_error(&result), "attach grant must permit the upload");
+    assert!(text_of(&result).contains("31"));
+}
+
+#[tokio::test]
+async fn add_attachment_size_cap_blocks_before_any_upload() {
+    // 12 decoded bytes against an 8-byte cap: refused, and nothing POSTed.
+    let mock = MockServer::start().await;
+    mount_classify(&mock, world_readable_bug(7)).await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/7/attachment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "ids": [1] })))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    let client = client_for("[global]\nmax_attachment_bytes = 8\n", &mock).await;
+    let oversized = "QUFBQUFBQUFBQUFB"; // 12 bytes of 'A'
+    let result = call(&client, "add_attachment", attachment_args(7, oversized)).await;
+    assert!(is_error(&result), "an oversized upload must be refused");
+    assert_eq!(
+        text_of(&result),
+        "Attachment exceeds the size limit of this server"
+    );
+}
+
+#[tokio::test]
+async fn add_attachment_comment_travels_as_a_plain_string() {
+    // Bug.add_attachment documents `comment` as a plain string — NOT the
+    // `{"comment": {"body": ...}}` shape Bug.update uses. The body matcher
+    // pins the wire format: the object shape would not match and the test
+    // would fail on the resulting 404.
+    let mock = MockServer::start().await;
+    mount_classify(&mock, world_readable_bug(7)).await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/7/attachment"))
+        .and(body_partial_json(json!({
+            "ids": [7],
+            "data": "QUFB",
+            "file_name": "log.txt",
+            "comment": "see the boot log",
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "ids": [55] })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let client = client_for("", &mock).await;
+    let mut args = attachment_args(7, "QUFB");
+    args["comment"] = json!("see the boot log");
+    let result = call(&client, "add_attachment", args).await;
+    assert!(!is_error(&result), "result: {}", text_of(&result));
+    assert!(text_of(&result).contains("55"));
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -12,7 +12,14 @@ Cargo workspace, two crates:
 - `crates/bugwarden-core` — guard policy engine + async Bugzilla REST client.
   MUST NOT depend on rmcp, axum, clap, or any MCP/transport crate.
 - `crates/bugwarden` — the binary: clap CLI, rmcp 2.2 MCP server, stdio and
-  streamable-HTTP transports. Depends on `bugwarden-core`.
+  streamable-HTTP transports. Depends on `bugwarden-core`. The crate also
+  has a lib target (`lib.rs` re-exporting `config` and `server`) consumed by
+  `main.rs` and by the integration tests under `crates/bugwarden/tests/`,
+  which drive the MCP tools end to end; a binary-only crate would leave the
+  tool gates untestable (a mutation deleting a guard call from a tool body
+  survived every test while only the pure helpers were covered). The
+  supported product remains the binary; the lib API carries no stability
+  promise.
 
 Dependency direction: `bugwarden -> bugwarden-core`, never the reverse.
 
@@ -108,11 +115,32 @@ pub enum Capability {
     Assign,      // write: assignee
     Cc,          // write: CC list
     Deps,        // write: blocks/depends_on
+    Create,      // write: file a NEW bug (judged against the bug AS REQUESTED)
+    Attach,      // write: upload an attachment (read side is Attachments)
 }
 impl Capability {
-    pub const ALL: [Capability; 11];
-    pub fn is_write(self) -> bool; // Comment|Status|Fields|Assign|Cc|Deps
+    pub const ALL: [Capability; 13];
+    pub fn is_write(self) -> bool; // Comment|Status|Fields|Assign|Cc|Deps|Create|Attach
 }
+```
+
+**Upgrade hazard — Capability::ALL grew from 11 to 13.** `create` and
+`attach` joined `ALL`, and every `allow` rule and `default_action = "allow"`
+grants ALL: an existing deployment that upgrades WITHOUT touching its policy
+file silently starts permitting bug filing (`create_bug`) and attachment
+upload (`add_attachment`) wherever it previously granted `allow`. An
+operator who wants the pre-upgrade surface must either add
+`disabled_tools = ["create_bug", "add_attachment"]` under `[global]`
+(removes the tools from the listing outright, I13), or replace `allow`
+grants with `restrict` rules enumerating exactly the old eleven
+capabilities. `read_only` deployments are unaffected — both new
+capabilities are writes and stay stripped. This trade (new capabilities
+join `allow` automatically) is deliberate — `allow` means "everything this
+server can do", and a frozen enumeration would silently exclude every
+future capability instead — but it must be called out in release notes
+whenever ALL grows.
+
+```rust
 
 /// Case-insensitive glob; '*' matches any (possibly empty) substring.
 pub fn glob_match(pattern: &str, value: &str) -> bool;
@@ -314,6 +342,34 @@ impl Guard {
     /// max_attachment_bytes is not I1-disclosable). Returns
     /// Some(refusal_text) when blocked.
     pub fn attachment_gate(&self, attachment: &serde_json::Value, include_private: bool) -> Option<String>;
+
+    /// Create gate: classify the bug AS REQUESTED (BugMeta::from_json over
+    /// the create payload) and require Capability::Create. There is no bug
+    /// to fetch yet, so the request is what is judged — the same rules that
+    /// hide a product BY NAME refuse filing into it, with no second
+    /// vocabulary. A field the request does not carry is unknown, not
+    /// empty, and fails closed (I4). The request is evidence only for
+    /// fields Bugzilla takes verbatim (the created bug matches the claim or
+    /// creation fails upstream); `groups` is NOT one of them — Bugzilla
+    /// UNIONS the product's mandatory groups into whatever was claimed, so
+    /// the claimed group list is forced to unknown (None) whatever the
+    /// payload said. Taking `groups: []` as fact would make claiming a
+    /// field strictly MORE permissive than omitting it and file straight
+    /// past a group deny rule into a security-* embargo product.
+    /// Consequence, deliberate and documented: a policy whose applicable
+    /// rules consult `groups` or `group_restricted` refuses ALL creation —
+    /// the answer cannot be known before the bug exists. creation_time is
+    /// forced to NOW, whatever the payload claims, so an age rule refuses
+    /// creation wherever it would immediately hide the result.
+    pub fn may_create(&self, requested: &Value) -> bool;
+
+    /// Uniform refusal for a bug that was not filed: one fixed text, naming
+    /// no rule and no criterion (I1), whatever tripped it. Callers MUST
+    /// return this same text for a policy refusal AND an upstream failure —
+    /// two texts would let a client pair a guaranteed-invalid field with a
+    /// probe payload and read the policy off which refusal came back, free
+    /// and silent (see the create_bug tool row).
+    pub fn create_denial() -> String; // "Filing this bug is not permitted through this server"
 }
 ```
 
@@ -333,6 +389,8 @@ impl BugzillaClient {
     pub async fn bug_history(&self, key: &str, id: u64, new_since: Option<chrono::DateTime<chrono::Utc>>) -> anyhow::Result<serde_json::Value>;
     pub async fn bug_comments(&self, key: &str, id: u64, new_since: Option<chrono::DateTime<chrono::Utc>>) -> anyhow::Result<Vec<serde_json::Value>>;
     pub async fn add_comment(&self, key: &str, id: u64, comment: &str, is_private: bool) -> anyhow::Result<serde_json::Value>;
+    pub async fn create_bug(&self, key: &str, payload: serde_json::Value) -> anyhow::Result<serde_json::Value>;
+    pub async fn add_attachment(&self, key: &str, id: u64, payload: serde_json::Value) -> anyhow::Result<serde_json::Value>;
     pub async fn quicksearch(&self, key: &str, query: &str, status: &str, include_fields: &str, limit: u32, offset: u32) -> anyhow::Result<serde_json::Value>;
     pub async fn update_bug(&self, key: &str, id: u64, payload: serde_json::Value) -> anyhow::Result<serde_json::Value>;
     pub async fn attachments(&self, key: &str, id: u64) -> anyhow::Result<serde_json::Value>;
@@ -352,6 +410,8 @@ Endpoint mapping:
 | bug_history | GET /rest/bug/{id}/history[?new_since=%Y-%m-%dT%H:%M:%SZ] | `bugs[0].history` array as Value |
 | bug_comments | GET /rest/bug/{id}/comment[?new_since=..] | `bugs.{id}.comments` as Vec<Value> |
 | add_comment | POST /rest/bug/{id}/comment `{comment, is_private}` | envelope |
+| create_bug | POST /rest/bug with caller-built payload | envelope (`{"id": N}`) |
+| add_attachment | POST /rest/bug/{id}/attachment with caller-built payload (`ids` names the bug) | envelope (`{"ids": [..]}`) |
 | quicksearch | GET /rest/bug?quicksearch={status}+" "+{query}&include_fields=..&limit=..&offset=..&order=relevance | envelope |
 | update_bug | PUT /rest/bug/{id} with caller-built payload (caller adds `"comment": {"body": ..}` when set) | envelope |
 | attachments | GET /rest/bug/{id}/attachment?exclude_fields=data | `envelope.bugs.{id}` array as Value |
@@ -382,6 +442,8 @@ constraints the model must know.
 | bug_history | id, new_since?: DateTime<Utc> | history | |
 | bug_comments | id, include_private: bool = false, new_since? | comments | filter_comments applied (I5) |
 | bugs_quicksearch | query, status: String = "ALL", include_fields: String = "id,product,component,assigned_to,status,resolution,summary,last_change_time", limit: u32 = 50, offset: u32 = 0 | post-filter | fetch include_fields = requested ∪ CLASSIFY_FIELDS; after filter, project kept bugs to requested fields (keep `_redacted` marker); envelope `{"bugs":[..]}` only (I3) | **limit/offset address the bugs the client may SEE, not upstream rows** (Guard::quicksearch_window): filtering an already-paginated page left a hole exactly where a hidden bug sat — a short page the next offset contradicted — and since quicksearch matches summary text that hole was a probe for the hidden title, one word at a time. The guard now scans upstream from row 0 in 200-row chunks, classifies each, and fills the window from the survivors; rows are deduped on the server-reported id (relevance order is not stable between calls) and an id-less row is dropped (I4). Bounds: MAX_SEARCH_WINDOW=1000 addressable, 2000 rows scanned (<=10 sequential requests); hitting either truncates, which looks exactly like the end of results. The objects returned are the ones classified. The scan target is quantised to whole chunks so the stopping point does not track the client's `limit`; without that, `limit` could be binary-searched against the clock to recover each block's exact hidden count. Residual, accepted: filling a window of VISIBLE bugs needs more rows when bugs are hidden, so a stopwatch still learns one bit per scanned block ("not entirely visible"). Removing that would mean scanning the worst case on every search, or letting pages go short again. Search failure returns a bare "Search failed"; the upstream text is logged server-side only (it can name a bug and say whether it exists) |
+| create_bug | product, component, summary, version, description = "", severity?, priority?, op_sys?, platform?, keywords?: Vec<String>, groups?: Vec<String> | create (write), judged on the bug AS REQUESTED (Guard::may_create) | there is no bug id to assess, so the request itself is classified BEFORE any upstream call (I8): the rules that hide a product by name refuse filing into it, a field the request omits fails closed (I4), and a client-claimed `groups` list is never trusted — Bugzilla unions the product's mandatory groups in server-side, so may_create forces groups to unknown, which means a policy whose applicable rules consult groups/group_restricted refuses ALL creation. **Both refusals are one refusal**: a policy refusal and an upstream failure return the same fixed create_denial text after the same single upstream request — the refused path burns one classify call against bug id 0 (never a valid id, creates nothing; download_attachment's padding precedent) instead of the POST. Two texts, or 0 vs 1 requests, would be a free policy-enumeration oracle: send a guaranteed-invalid `version` plus a probe product and read the policy off which refusal (or which latency) comes back, with nothing created. Residual, accepted: a SUCCESSFUL create still confirms the product is allowed — that is the tool doing its job, and it costs a real, attributable bug; and the padding equalizes request count, not the upstream handler's exact latency (GET classify vs rejected POST). Bugzilla's failure message is logged server-side only (it can say whether a product/component exists) |
+| add_attachment | bug_id, data (base64), file_name, summary, content_type, comment = "", is_private = false, is_patch = false | attach (write) on bug_id | guard assessment before the upload (I8), uniform denial (I2); then global.max_attachment_bytes caps the DECODED size of `data` (0 = no cap) — the ceiling the operator set on downloads binds uploads through the same server too, measured after base64 expansion is stripped so encoding overhead cannot shrink it. The refusal names neither the payload's size nor the cap value (max_attachment_bytes is not I1-disclosable, exactly as on the download path). `comment` travels as a PLAIN string — Bug.add_attachment documents it so; the `{"comment": {"body": ..}}` shape belongs to Bug.update only |
 | add_comment | bug_id, comment, is_private: bool = false | comment (write) | |
 | update_bug_status | bug_id, status, resolution?, comment: String = "" | status (write) | CLOSED requires resolution (error otherwise); when reopening (status not CLOSED/VERIFIED and no resolution given) set `"resolution": ""` |
 | assign_bug | bug_id, assignee (email), comment = "" | assign (write) | payload `{"assigned_to": ..}` |
@@ -430,7 +492,8 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
 - `BugWarden::new` builds `Self::tool_router()` then `remove_route` for write
   tools when read-only and for every `global.disabled_tools` entry (I13).
   Write tool names: add_comment, update_bug_status, assign_bug,
-  update_bug_fields, update_bug_dependencies, add_cc_to_bug, mark_as_duplicate.
+  update_bug_fields, update_bug_dependencies, add_cc_to_bug, mark_as_duplicate,
+  create_bug, add_attachment.
 - API key resolution: stdio => `cfg.api_key`; http => `ctx.extensions.get::<axum::http::request::Parts>()`, then `parts.headers.get(lowercased_header_name)`.
 - HTTP serving: `StreamableHttpService::new(move || Ok(server.clone()), LocalSessionManager::default().into(), StreamableHttpServerConfig::default())`, `axum::Router::new().nest_service("/mcp", service)`, `tokio::net::TcpListener::bind`, graceful shutdown on ctrl_c.
 - Tracing to stderr always (stdout belongs to the stdio transport).
@@ -440,13 +503,24 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
 - Unit tests (#[cfg(test)] in policy.rs/guard.rs): glob matching; first-match
   ordering; embargo group deny; min_bug_age_days incl. missing creation_time
   (fail closed); younger_than_days matcher; restrict caps; read-implies-summary;
-  read_only strips write caps; default deny; summary redaction; comment
-  filtering; validation errors (unknown TOML keys, restrict without caps).
+  read_only strips write caps — create and attach named explicitly, and a
+  restrict grant of comment grants neither; default deny; summary redaction;
+  comment filtering; validation errors (unknown TOML keys, restrict without
+  caps); may_create — a hidden product refuses filing, an omitted field the
+  policy consults fails closed (I4), a claimed group list NEVER decides a
+  group rule (omitted, `[]`, and non-matching claims are all refused alike;
+  a group_restricted policy refuses all creation; a group rule ruled out by
+  another criterion does not block), a creation_time claimed by the payload
+  is ignored in favour of NOW, restrict must name "create", and the
+  create_denial text is fixed.
 - Unit tests (#[cfg(test)] in crates/bugwarden/src/server.rs): assemble_bug_info
   re-classification — a body embargoed after the verdict is refused, a body
   that now earns only summary is downgraded, a body granting neither read nor
   summary is refused, and refused/absent/up-front-denied ids yield byte-
-  identical restricted entries; the distinct-id bound.
+  identical restricted entries; the distinct-id bound; read-only delists
+  create_bug and add_attachment (I13); the upload size gate measures decoded
+  (never base64-encoded) bytes, is disabled at 0, and its refusal names no
+  number.
 - Integration tests (crates/bugwarden-core/tests/guard_wiremock.rs, wiremock):
   quicksearch_window — pages stay full while visible bugs remain (no hole),
   consecutive pages tile the visible sequence disjointly (against a stable
@@ -460,6 +534,20 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   id whatever the answer (nonexistent vs withheld cost the same), repeated
   ids fetched once, no batch to poison; per-id
   fallback fail closed; comment privacy; error mapping; API key absent from
-  error text (I12).
+  error text (I12); create_bug and add_attachment endpoint mapping (payload
+  travels untouched to POST /rest/bug and /rest/bug/{id}/attachment).
+- Integration tests (crates/bugwarden/tests/tools_wiremock.rs, wiremock +
+  rmcp client over an in-memory duplex transport): the tools are CALLED
+  through a real MCP session, so a tool that stops calling its guard fails
+  a test rather than only a helper suite. Minimum bar: create_bug policy
+  refusal and upstream refusal are byte-identical and each cost exactly one
+  upstream request (nothing POSTed on the refused path, which instead burns
+  a classify call against bug id 0); a claimed `groups` list never defeats
+  a group deny rule and a group_restricted policy refuses all creation;
+  an allowed create reaches POST /rest/bug; add_attachment refuses on a
+  grant carrying `attachments` (read) without `attach` (write) and uploads
+  on `attach`; the upload size cap refuses before anything is POSTed; and
+  the attachment `comment` travels as a plain string (Bug.add_attachment
+  API shape), pinned by a wiremock body matcher.
 - CI: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
   `cargo test --workspace --locked`, `cargo deny check`.

--- a/examples/policy.toml
+++ b/examples/policy.toml
@@ -8,7 +8,10 @@
 #     deliberately broader than "security" and can be narrowed;
 #   * bugs labelled "security" are invisible while they are fresher than
 #     5 days (the window in which details are typically still unreviewed);
-#   * every other bug is shown to the user in full.
+#   * every other bug is shown to the user in full;
+#   * filing new bugs is refused entirely: rule 1 depends on the group
+#     list, and a not-yet-created bug's groups cannot be known — see the
+#     note before the commented-out "reporters" rule below.
 #
 # The policy is read once at server startup (--policy / BUGWARDEN_POLICY) and
 # is never visible to the MCP client. Parsing is strict: unknown keys anywhere
@@ -59,7 +62,8 @@ read_only = false
 
 # Largest attachment (decoded bytes) download_attachment may return; the
 # content is embedded base64 in the tool result and consumes model context.
-# 0 removes the cap. Default: 2 MiB.
+# The same ceiling caps what add_attachment may UPLOAD, also measured on the
+# decoded bytes. 0 removes the cap. Default: 2 MiB.
 #max_attachment_bytes = 2097152
 
 # ---------------------------------------------------------------------------
@@ -161,9 +165,48 @@ younger_than_days = 5
 ## allow/deny rules. Full vocabulary, for reference:
 ##   read summary comments history attachments   (read capabilities)
 ##   comment status fields assign cc deps        (write capabilities)
+##   create attach                               (write: file new bugs, upload attachments)
 #capabilities = ["summary", "comment"]
 #[rule.match]
 #products = ["Security*"]
+
+# Filing new bugs ("create") and uploading attachments ("attach") are
+# capabilities like any other. A create request has no bug id yet, so the
+# policy judges the bug AS DESCRIBED by the request — the deny rules above
+# therefore also refuse filing into anything they hide by name, with no
+# extra configuration. A request that omits a field a rule asks about is
+# refused (unknown, not empty), and the request's OWN claim about `groups`
+# is never trusted: Bugzilla unions the product's mandatory groups into
+# whatever was claimed, so what groups the created bug would end up in
+# cannot be known before it exists.
+#
+# BE AWARE: under THIS policy, filing bugs is impossible — deliberately.
+# Rule 1 ("group-restricted") consults the group list, the group list of a
+# not-yet-created bug is unknowable (see above), and unknown fails closed.
+# Every create request is therefore refused before Bugzilla is contacted,
+# and a rule granting "create" placed BELOW rule 1 — like the example
+# below — can never be reached by a create request. The same holds for any
+# policy whose applicable rules use `groups` or `group_restricted`.
+#
+# To actually accept new bugs, a create-granting rule must come BEFORE
+# every group-consulting rule and match on fields the request does carry
+# (products, components, summary, keywords, ...). First match wins, so
+# such a rule then also decides access to EXISTING bugs it matches —
+# grant it "create" alone (as below) and matched existing bugs stay
+# unreadable; add read capabilities to it and you have re-opened the
+# group-restricted bugs of those products, which is exactly what rule 1
+# exists to prevent. Weigh that trade before moving it up.
+#
+# "attach" is judged against the target bug like every other write (the
+# bug exists, so its real group list is fetched and rule 1 applies
+# normally), and the upload is capped by max_attachment_bytes above.
+#[[rule]]
+#name = "reporters"
+#description = "Desktop products accept new bug reports"
+#action = "restrict"
+#capabilities = ["create"]
+#[rule.match]
+#products = ["GNOME*", "KDE*"]
 
 # Every remaining match criterion, in one rule.
 #[[rule]]


### PR DESCRIPTION
Two write tools the server did not have: filing a bug, and uploading an
attachment to one.

## Filing needed a gate the guard had no shape for

Every existing check asks *may this client touch that bug?* — a bug being filed
does not exist yet. So the bug **as requested** is classified against the same
rules, with one exception that decides how much the mechanism is worth.

**Bugzilla augments what the request asks for.** It unions the product's
mandatory groups into the new bug, so a client's claim about `groups` can only
ever under-state the result. Trusting it inverted the guard:

| payload | old behaviour |
|---|---|
| `groups` omitted | Unknown → denied (fail closed, correct) |
| `groups: ["security-embargo"]` | denied |
| `groups: ["partner"]` | **allowed** — then Bugzilla adds `security-*` and the bug is one the policy hides |

Supplying a field was strictly *more permissive* than omitting it. `may_create`
now treats groups as unknown whatever the payload says. The consequence is
stated plainly rather than engineered around: **a policy whose rules consult
groups refuses all creation**, because what the bug will look like cannot be
known before it exists. Every other create field is taken verbatim by Bugzilla
or the create fails upstream, so those claims are evidence and are trusted.

The prospective bug is dated **now**, so an age rule refuses creation wherever
it would immediately hide the result.

## Both refusals are indistinguishable

Guard refusal and upstream refusal return the same text and cost the same one
upstream request — the refused path burns a classify against bug id 0, the
padding precedent `download_attachment` already sets. Without it, a client
could send a deliberately invalid `version` so upstream always errored, and
read the policy off which refusal came back — field by field, creating nothing.
A *successful* create is still distinguishable, which is the tool working, and
it costs a real attributable bug.

## Uploading

Gated by a new `Attach` capability, **separate** from the read-side
`Attachments`: an operator who lets a client read attachments has not agreed to
let it write them. Both new capabilities are writes, so `read_only` strips them
and delists both tools (I13). Uploads are held to the same
`max_attachment_bytes` ceiling as downloads, measured on the **decoded** length;
the refusal names no number, since the cap is policy (I1).

## Upgrade note

`Capability::ALL` went 11 → 13, and an `allow` rule grants all of them — so
every existing deployment that allows anything gains bug filing and attachment
upload on upgrade. To keep the old behaviour: `disabled_tools = ["create_bug",
"add_attachment"]`, or convert `allow` rules to enumerated `restrict`.
Read-only deployments are unaffected. Documented in README and DESIGN.md.

## The tests that were missing

The binary crate had **no lib target**, so nothing could drive a tool — and
three mutations that gut both gates (swapping the write capability for the read
one, dropping the `may_create` call, dropping the size check) passed the entire
suite. There is a lib target now, plus integration tests that stand up a real
server over an in-memory transport and call the tools through an MCP client
against wiremock, so a tool that stops calling its guard fails a test.

187 tests. Every fix mutation-verified, and I re-ran the two most important
mutations independently after the fixes: both now die.

Also fixed: `add_attachment` was sending `Bug.update`'s `{"comment":{"body":…}}`
shape, but `Bug.add_attachment` documents `comment` as a plain string. And the
shipped `examples/policy.toml` advertised creation while its first rule made it
impossible — it now says so, and a test parses the shipped file to keep that
true.