### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bugwarden"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "bugwarden-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Martin Pluskal <martin@pluskal.org>"]

--- a/crates/bugwarden-core/Cargo.toml
+++ b/crates/bugwarden-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bugwarden-core"
-version = "0.1.0"
+version = "0.2.0"
 description = "Guard policy engine and async Bugzilla REST client for the bugwarden MCP server"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["command-line-utilities", "web-programming::http-server"]
 workspace = true
 
 [dependencies]
-bugwarden-core = { path = "../bugwarden-core", version = "0.1.0" }
+bugwarden-core = { path = "../bugwarden-core", version = "0.2.0" }
 
 rmcp = { version = "2.2", features = [
     "server",


### PR DESCRIPTION
Version bump for the 0.2.0 release. Since 0.1.0: server-side search pagination, per-id classification, body re-verification, denied-id scrubbing (I14), quicksearch id-list steering, and the create_bug/add_attachment tools.