### PR TITLE
feat(policy): deny security groups by name in the example policy

### DIFF
--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -1641,6 +1641,99 @@ products = ["NoView*"]
     }
 
     #[test]
+    fn shipped_example_policy_denies_security_named_groups_on_their_own() {
+        // The example stacks two rules over security-group bugs: the broad
+        // "group-restricted" (any group at all) and "security-groups" (the
+        // names, by glob). The second is the backstop the file promises: an
+        // operator who narrows or removes the broad rule — as its own
+        // comment invites — must not thereby expose security-group bugs.
+        // Pin both layers on a bug carrying NO other deniable signal: no
+        // marker in the summary, no keywords, empty whiteboard, years past
+        // every freshness window.
+        let path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/policy.toml");
+        let toml = std::fs::read_to_string(path).expect("example policy must exist in-repo");
+        let bug = BugMeta::from_json(&json!({
+            "id": 42,
+            "summary": "kernel oops when unplugging a USB dock",
+            "groups": ["team-security"],
+            "keywords": [],
+            "whiteboard": "",
+            "product": "Base System",
+            "component": "Kernel",
+            "status": "NEW",
+            "severity": "major",
+            "priority": "P2",
+            "creation_time": "2020-01-01T00:00:00Z",
+        }));
+
+        // The shipped file as-is: denied (the broad rule reaches it first).
+        let full = policy(&toml);
+        assert!(
+            matches!(full.classify(&bug, Utc::now()), Access::Denied { .. }),
+            "shipped policy must deny a security-group bug"
+        );
+
+        // Excise the whole group-restricted rule (everything up to the next
+        // [[rule]] header) and classify again: still denied, and by the
+        // named-group rule itself — proof the backstop carries its weight.
+        let start = toml
+            .find("[[rule]]\nname = \"group-restricted\"")
+            .expect("the broad rule must exist in the example");
+        let after = start + "[[rule]]".len();
+        let end = after
+            + toml[after..]
+                .find("[[rule]]")
+                .expect("a rule must follow the broad rule");
+        let narrowed = policy(&format!("{}{}", &toml[..start], &toml[end..]));
+        match narrowed.classify(&bug, Utc::now()) {
+            Access::Denied { rule } => assert_eq!(
+                rule, "security-groups",
+                "the named-group rule itself must be the one denying"
+            ),
+            Access::Granted { .. } => {
+                panic!("removing the broad rule must not expose security-group bugs")
+            }
+        }
+
+        // A restricted-but-not-security bug is exactly what an operator
+        // removes the broad rule FOR: under the narrowed policy it falls
+        // through to default_action and becomes visible.
+        let partner = BugMeta::from_json(&json!({
+            "id": 43,
+            "summary": "invoice import fails for partner deployments",
+            "groups": ["partnerconfidential"],
+            "keywords": [],
+            "whiteboard": "",
+            "product": "Base System",
+            "component": "Billing",
+            "status": "NEW",
+            "severity": "major",
+            "priority": "P2",
+            "creation_time": "2020-01-01T00:00:00Z",
+        }));
+        assert!(
+            matches!(full.classify(&partner, Utc::now()), Access::Denied { .. }),
+            "shipped policy hides every restricted bug"
+        );
+        assert!(
+            matches!(
+                narrowed.classify(&partner, Utc::now()),
+                Access::Granted { .. }
+            ),
+            "narrowing is meant to expose non-security restricted bugs"
+        );
+
+        // Creation stays refused under the narrowed file too: the backstop
+        // still consults the group list, which is unknowable pre-creation.
+        let g = Guard { policy: narrowed };
+        assert!(
+            !g.may_create(&create_request("openSUSE")),
+            "narrowed policy must still refuse all creation"
+        );
+    }
+
+    #[test]
     fn may_create_group_rules_ruled_out_by_other_criteria_do_not_block() {
         // Forcing groups to unknown must not turn every group-consulting
         // rule into a blanket refusal: a rule some OTHER criterion already

--- a/examples/policy.toml
+++ b/examples/policy.toml
@@ -6,6 +6,9 @@
 #   * undisclosed (embargoed) security bugs are completely invisible, always;
 #   * so is every bug that is not world-readable — see rule 1, which is
 #     deliberately broader than "security" and can be narrowed;
+#   * bugs in groups NAMED like security groups are invisible in their own
+#     right — see "security-groups", which keeps denying them even after
+#     rule 1 is narrowed or removed;
 #   * bugs labelled "security" are invisible while they are fresher than
 #     5 days (the window in which details are typically still unreviewed);
 #   * every other bug is shown to the user in full;
@@ -97,9 +100,36 @@ action = "deny"
 #
 # This is deliberately broad: it also hides non-security bugs that happen to
 # be group-restricted (partner-confidential reports, internal-only products).
-# To hide only the security groups instead, replace this rule with a glob on
-# the names your instance actually uses, e.g. groups = ["*security*"].
+# If that is more than you want, narrow this rule (replace
+# `group_restricted = true` with a `groups = [...]` glob list) or drop it —
+# but FIRST check the "security-groups" rule below against the group names
+# your instance actually uses. It keeps hiding security groups by name only
+# where its globs match; names built from other stems ("infosec", "psirt",
+# "secteam", ...) must be added to its list before this rule stops covering
+# them.
 group_restricted = true
+
+[[rule]]
+name = "security-groups"
+description = "Bugs in security/internal-named groups are invisible"
+action = "deny"
+[rule.match]
+# Backstop for the rule above, and redundant only as long as that rule keeps
+# its full breadth: "group-restricted" already hides these bugs, but it hides
+# every other restricted bug too, and the moment an operator narrows or
+# deletes it (say, to let partner-confidential bugs through) the security
+# groups must not slip out with them. This rule names them, so it keeps
+# denying entirely on its own.
+#
+# Matches if ANY of the bug's groups matches ANY of these globs. The three
+# stems cover the names instances commonly build their sensitive groups
+# from: the security team's own groups ("security", "corp-security",
+# "Security Internal"), groups named for the embargo state, and groups named
+# for internality rather than security ("internal-only"). Group vocabularies
+# are per-instance, though: check the names your instance actually uses and
+# extend the list. Erring broad is safe here — an extra match only hides a
+# bug; a missed name is what the rule above exists to catch.
+groups = ["*security*", "*embargo*", "*internal*"]
 
 [[rule]]
 name = "undisclosed-marker"


### PR DESCRIPTION
## What

Adds a dedicated `security-groups` deny rule to `examples/policy.toml`, matching group names by glob (`*security*`, `*embargo*`, `*internal*`), placed directly below the broad `group-restricted` rule, plus a test pinning the shipped file's behaviour. Header scenario and the broad rule's narrowing advice updated to match.

## Why

The example hid a security-internal bug only through rules incidental to "security": `group-restricted` (matches ANY group) and `undisclosed-marker` (an "embargo" substring in the title). The file's own comment invites operators to narrow the broad rule to their instance's group names — and an operator who followed that advice, or dropped the rule to make partner-confidential bugs visible, ended up with no rule naming the security groups at all. A security-group bug whose title carries no marker would then be served in full.

The new rule is redundant while `group-restricted` keeps its full breadth (first match wins, so it is simply never reached) and becomes load-bearing the moment that rule is narrowed or removed. The three stems cover the common naming families for sensitive groups — the security team's own groups, embargo-state groups, and internality-named groups — and the comment tells operators that group vocabularies are per-instance and to check theirs. Over-matching only hides more (safe direction); a missed name is what the broad rule exists to catch.

## Adversarial review against DESIGN.md invariants

- The rule is `action = "deny"` with no capabilities: it can only remove access, never grant it, so it cannot weaken any existing guarantee.
- It consults `groups`, which is unknowable for a not-yet-created bug, so the file's documented refuse-all-creation property now survives removal of the broad rule too (I4 fail-closed, unknown-metadata tri-state).
- No engine change: `any`-glob-`any` group matching, first-match-wins, and Unknown⇒deny already behave as required; this is defence in depth at the shipped-default layer only.

## Considered but not changed: security *products* at any age

Under a narrowed rule 1, a world-readable bug in a security-named *product* is visible unless a `fresh-security-*` rule holds it back — and those rules match keywords and whiteboard tags, not products, so an unlabelled one is visible at any age (this was already true before this change). I deliberately did not add a product-based always-deny: the example's stated scenario is that security-labelled bugs become visible after their freshness window, and a bug that is world-readable on the instance, unmarked, unkeyworded, and past the window is disclosed by the instance itself — hiding it forever would contradict the file's documented 5-day disclosure model without adding confidentiality. The dangerous case (an incident that must stay hidden) is characterised precisely by its group restriction, which is what the new rule pins by name. Operators with a stricter stance can add a `products = ["*security*"]` deny themselves.

## Verification

- New test `shipped_example_policy_denies_security_named_groups_on_their_own`: a bug in a security-named group with no other deniable signal (no marker, no keywords, empty whiteboard, years old) is denied by the shipped file; after excising the whole `group-restricted` rule from the policy text it is still denied, and `Access::Denied { rule }` proves `security-groups` itself decides; a restricted non-security bug becomes visible under the narrowed policy, which is what narrowing is for.
- Mutation check: with the `security-groups` rule additionally deleted from the policy text, that test fails ("removing the broad rule must not expose security-group bugs").
- `cargo test --workspace --locked` (195 passed), `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo fmt --check`, `typos` — all clean.
