### PR TITLE
feat(server): wire the audit stream into every MCP request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bugwarden"
 version = "0.2.0"
 dependencies = [
@@ -180,6 +189,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokio",
@@ -246,7 +256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core",
 ]
 
@@ -318,11 +328,30 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -376,6 +405,16 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -523,6 +562,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1427,6 +1476,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,6 +1887,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +1944,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", features = ["chrono04"] }
 chrono = { version = "0.4", features = ["serde"] }
+sha2 = "0.10"
 thiserror = "2"
 toml = "1.1"
 

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -28,8 +28,8 @@
 //! every enum is a fixed vocabulary, and no dedicated field exists for
 //! the Bugzilla API key, incoming request headers, or free-text bug
 //! content (summaries, comments, attachments). The one open field is
-//! [`RequestInfo::params`]: it is fed exclusively through a per-tool
-//! allowlist of client-authored values at the recording call site, and
+//! [`RequestInfo::params`]: it is fed exclusively through an allowlist
+//! of client-authored parameter keys at the recording call site, and
 //! data fetched from Bugzilla never passes through it. [`AuditError`]
 //! follows the same rule — it names the failed
 //! operation and carries the underlying I/O error, never the record that
@@ -72,6 +72,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
 
 /// The audit record schema version stamped into every event (`v`).
 pub const SCHEMA_VERSION: u32 = 1;
@@ -101,8 +102,9 @@ pub enum FailMode {
     /// are lost to the record. Availability over accountability.
     Open,
     /// Reads the guard fully allows still proceed unaudited; write
-    /// operations and any call where the guard suppressed or denied
-    /// something are refused until their record can be persisted again.
+    /// operations and any call where the guard suppressed, denied, or
+    /// refused something are refused until their record can be persisted
+    /// again.
     ClosedWritesDenials,
     /// Every tool call is refused until its record can be persisted.
     /// Accountability over availability: an unmonitored full disk turns
@@ -388,11 +390,11 @@ pub struct RequestInfo {
     /// JSON-RPC request id, when the transport exposes one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-    /// CLIENT-authored request parameters, passed through a per-tool
-    /// allowlist by the recording call site: identifiers, projections,
-    /// switches — parameters whose values the client chose. Bug content
-    /// fetched from Bugzilla must never be placed here; a tool result is
-    /// not a parameter.
+    /// CLIENT-authored request parameters, passed through an allowlist
+    /// by the recording call site: identifiers, projections, switches —
+    /// parameters whose values the client chose. Bug content fetched
+    /// from Bugzilla must never be placed here; a tool result is not a
+    /// parameter.
     pub params: BTreeMap<String, serde_json::Value>,
 }
 
@@ -838,9 +840,31 @@ impl AuditSink {
         }
     }
 
-    /// Test-only fault injection; see the `fail_writes` field.
+    /// Whether the sink is currently in failure: at least one record has
+    /// been dropped since the last successful write. The request path
+    /// consults this before dispatching a tool call, so a sink that is
+    /// already down can hold back further unaudited work under the closed
+    /// fail modes instead of discovering the outage one record at a time.
+    pub fn failing(&self) -> bool {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .dropped
+            > 0
+    }
+
+    /// Whether records may carry suppressed bug ids
+    /// ([`AuditConfig::suppressed_ids`]); the recording call site enforces
+    /// the flag when building [`GuardInfo`].
+    pub fn suppressed_ids(&self) -> bool {
+        self.cfg.suppressed_ids
+    }
+
+    /// Test-only fault injection; see the `fail_writes` field. Crate
+    /// visibility: the request-path fail-mode tests in `server.rs` drive
+    /// a real sink into failure through this same hook.
     #[cfg(test)]
-    fn set_fail_writes(&self, fail: bool) {
+    pub(crate) fn set_fail_writes(&self, fail: bool) {
         self.fail_writes
             .store(fail, std::sync::atomic::Ordering::Relaxed);
     }
@@ -877,6 +901,226 @@ fn rotated_path(live: &Path, n: u32) -> PathBuf {
     let mut os = live.as_os_str().to_os_string();
     os.push(format!(".{n}"));
     PathBuf::from(os)
+}
+
+// ---------------------------------------------------------------------------
+// Request-path wiring
+// ---------------------------------------------------------------------------
+
+impl FailMode {
+    /// The fail mode in force: the operator's explicit choice when the
+    /// configuration sets one, else the transport-derived default.
+    pub fn resolve(explicit: Option<FailMode>, transport: TransportKind) -> FailMode {
+        explicit.unwrap_or_else(|| FailMode::default_for(transport))
+    }
+
+    /// The default fail mode for a transport, used when the audit
+    /// configuration leaves `fail_mode` unset: `stdio` (a local,
+    /// single-operator session) defaults to `open` — availability for a
+    /// single user; `http` (remote clients) defaults to `closed_all` —
+    /// accountability for a fleet.
+    pub fn default_for(transport: TransportKind) -> FailMode {
+        match transport {
+            TransportKind::Stdio => FailMode::Open,
+            TransportKind::Http => FailMode::ClosedAll,
+        }
+    }
+}
+
+/// Everything the request path needs to write audit records: the open
+/// sink, the resolved fail mode, and the startup-computed identifiers
+/// records carry. Built once at startup, shared behind an `Arc`.
+#[derive(Debug)]
+pub struct AuditState {
+    /// The open sink; every record goes through it.
+    pub sink: AuditSink,
+    /// What happens to tool calls while records cannot be persisted.
+    /// Already resolved ([`FailMode::resolve`]): the explicit configured
+    /// value, else the transport default.
+    pub fail_mode: FailMode,
+    /// `sha256:<hex>` digest of the policy file in force, stamped into
+    /// [`GuardInfo::policy_hash`]. `None` when the built-in default
+    /// policy applies (there is no file to hash).
+    pub policy_hash: Option<String>,
+    /// Session id stamped into stdio records. One process is one stdio
+    /// session, so `<pid>-<unix epoch secs at startup>` anchors those
+    /// records the way the `mcp-session-id` header anchors http ones.
+    pub stdio_session_id: String,
+}
+
+/// The `sha256:<hex>` digest of a policy document's bytes — the value
+/// [`AuditState::policy_hash`] holds and [`GuardInfo::policy_hash`]
+/// carries. The digest is over the raw file bytes, not any parsed form,
+/// so a record ties to the exact document the operator deployed.
+pub fn policy_hash_of(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+impl AuditState {
+    /// Assemble the request-path state around an open sink.
+    pub fn new(sink: AuditSink, fail_mode: FailMode, policy_hash: Option<String>) -> AuditState {
+        let epoch_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        AuditState {
+            sink,
+            fail_mode,
+            policy_hash,
+            stdio_session_id: format!("{}-{epoch_secs}", std::process::id()),
+        }
+    }
+}
+
+/// Severity of a verdict for the worst-wins merge:
+/// `Denied > Refused > ServedFiltered > Served`.
+fn verdict_rank(verdict: Verdict) -> u8 {
+    match verdict {
+        Verdict::Served => 0,
+        Verdict::ServedFiltered => 1,
+        Verdict::Refused => 2,
+        Verdict::Denied => 3,
+    }
+}
+
+#[derive(Debug, Default)]
+struct CellState {
+    verdict: Option<Verdict>,
+    rule: Option<String>,
+    suppressed_ids: std::collections::BTreeSet<u64>,
+    /// Suppressions that have no bug id (private comments or attachment
+    /// metadata filtered out): counted, never named.
+    suppressed_extra: u64,
+    redacted_fields: std::collections::BTreeSet<String>,
+    upstream: Option<UpstreamInfo>,
+}
+
+/// Per-request enrichment cell for one tool call's audit record.
+///
+/// The wrapper that owns the record inserts one cell into the request's
+/// extensions before dispatch; the guard call sites inside the tool note
+/// what was decided; the wrapper drains the cell into [`GuardInfo`] after
+/// the tool returns. A tool that never touches the cell (it performs no
+/// guard assessment) yields no `GuardInfo` at all. Multi-id calls note
+/// once per id and the cell merges: ONE record per call, worst verdict,
+/// with suppression carrying the per-id detail.
+///
+/// Interior mutability via a `Mutex` with the same poison posture as the
+/// sink: a panicked noter loses nothing worth dropping enrichment over.
+#[derive(Debug, Default)]
+pub struct AuditCell {
+    state: Mutex<CellState>,
+}
+
+impl AuditCell {
+    fn lock(&self) -> std::sync::MutexGuard<'_, CellState> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Worst-wins verdict merge. The rule follows the deciding verdict: a
+    /// strict upgrade replaces the stored rule with the new one (present
+    /// or not — a default-decided verdict has none), an equally severe
+    /// verdict may only fill an empty slot (first rule recorded wins),
+    /// and a less severe verdict changes nothing.
+    fn merge(&self, verdict: Verdict, rule: Option<&str>) {
+        let mut state = self.lock();
+        match state.verdict {
+            None => {
+                state.verdict = Some(verdict);
+                state.rule = rule.map(str::to_owned);
+            }
+            Some(current) if verdict_rank(verdict) > verdict_rank(current) => {
+                state.verdict = Some(verdict);
+                state.rule = rule.map(str::to_owned);
+            }
+            Some(current) if verdict_rank(verdict) == verdict_rank(current) => {
+                if state.rule.is_none() {
+                    state.rule = rule.map(str::to_owned);
+                }
+            }
+            Some(_) => {}
+        }
+    }
+
+    /// Note a verdict with no deciding rule (the policy default, or a
+    /// refusal that never consulted a rule).
+    pub fn note_verdict(&self, verdict: Verdict) {
+        self.merge(verdict, None);
+    }
+
+    /// Note a verdict together with the rule that decided it.
+    pub fn note_verdict_rule(&self, verdict: Verdict, rule: &str) {
+        self.merge(verdict, Some(rule));
+    }
+
+    /// Note bug ids the guard hid in this call (unions across notes).
+    /// Suppression implies at least a filtered serve, so the verdict is
+    /// upgraded to `ServedFiltered` through the worst-wins merge — a
+    /// record can never claim a clean `Served` while carrying
+    /// suppressions.
+    pub fn note_suppressed(&self, ids: impl IntoIterator<Item = u64>) {
+        self.merge(Verdict::ServedFiltered, None);
+        self.lock().suppressed_ids.extend(ids);
+    }
+
+    /// Note `n` suppressions that carry no bug id (private comments or
+    /// attachment metadata filtered out). Adds across notes; upgrades the
+    /// verdict exactly as [`AuditCell::note_suppressed`] does.
+    pub fn note_suppressed_count(&self, n: u64) {
+        if n == 0 {
+            return;
+        }
+        self.merge(Verdict::ServedFiltered, None);
+        let mut state = self.lock();
+        state.suppressed_extra = state.suppressed_extra.saturating_add(n);
+    }
+
+    /// Note a field (or view marker) the guard redacted from served
+    /// bugs. Upgrades the verdict to `ServedFiltered`.
+    pub fn note_redacted(&self, field: &str) {
+        self.merge(Verdict::ServedFiltered, None);
+        self.lock().redacted_fields.insert(field.to_owned());
+    }
+
+    /// Note the Bugzilla side of the call, where the caller has it.
+    pub fn note_upstream(&self, upstream: UpstreamInfo) {
+        self.lock().upstream = Some(upstream);
+    }
+
+    /// Take the noted upstream info, if any.
+    pub fn take_upstream(&self) -> Option<UpstreamInfo> {
+        self.lock().upstream.take()
+    }
+
+    /// Drain the cell into the record's [`GuardInfo`]. `None` when no
+    /// verdict was ever noted — the tool performed no guard assessment.
+    /// When `suppressed_ids_cfg` is `false` the ids are dropped and only
+    /// the count ships ([`AuditConfig::suppressed_ids`]). The count is
+    /// the larger of the id set and the id-less counter, so it can only
+    /// ever under-name, never under-count.
+    pub fn into_guard_info(
+        &self,
+        policy_hash: Option<&str>,
+        suppressed_ids_cfg: bool,
+    ) -> Option<GuardInfo> {
+        let state = std::mem::take(&mut *self.lock());
+        let verdict = state.verdict?;
+        let suppressed_count = (state.suppressed_ids.len() as u64).max(state.suppressed_extra);
+        Some(GuardInfo {
+            verdict,
+            rule: state.rule,
+            policy_hash: policy_hash.map(str::to_owned),
+            suppressed_count,
+            suppressed_ids: if suppressed_ids_cfg {
+                state.suppressed_ids.into_iter().collect()
+            } else {
+                Vec::new()
+            },
+            redacted_fields: state.redacted_fields.into_iter().collect(),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -1575,6 +1819,154 @@ mod tests {
         assert!(
             !contents.contains(CANARY),
             "the API key canary leaked into the audit file"
+        );
+    }
+
+    // ---------- request-path wiring ----------
+
+    #[test]
+    fn fail_mode_transport_defaults_bind_the_documented_wording() {
+        // The documented derivation: stdio (a local, single-operator
+        // session) defaults to open — availability for a single user;
+        // http (remote clients) defaults to closed_all — accountability
+        // for a fleet.
+        assert_eq!(FailMode::default_for(TransportKind::Stdio), FailMode::Open);
+        assert_eq!(
+            FailMode::default_for(TransportKind::Http),
+            FailMode::ClosedAll
+        );
+        // An explicit configured value wins over both derivations.
+        for transport in [TransportKind::Stdio, TransportKind::Http] {
+            assert_eq!(
+                FailMode::resolve(Some(FailMode::ClosedWritesDenials), transport),
+                FailMode::ClosedWritesDenials
+            );
+        }
+        assert_eq!(
+            FailMode::resolve(None, TransportKind::Stdio),
+            FailMode::Open
+        );
+        assert_eq!(
+            FailMode::resolve(None, TransportKind::Http),
+            FailMode::ClosedAll
+        );
+    }
+
+    #[test]
+    fn audit_state_session_id_is_pid_dash_epoch() {
+        let dir = tempfile::tempdir().unwrap();
+        let sink = AuditSink::open(test_cfg(dir.path().join("audit.jsonl"))).unwrap();
+        let state = AuditState::new(sink, FailMode::Open, None);
+        let (pid, epoch) = state
+            .stdio_session_id
+            .split_once('-')
+            .expect("session id is <pid>-<epoch>");
+        assert_eq!(pid, std::process::id().to_string());
+        assert!(epoch.parse::<u64>().is_ok(), "epoch part is seconds");
+    }
+
+    #[test]
+    fn cell_verdict_merge_keeps_the_worst_and_its_rule() {
+        let cell = AuditCell::default();
+        cell.note_verdict_rule(Verdict::Served, "allow-most");
+        cell.note_verdict_rule(Verdict::Denied, "embargo");
+        // A lesser verdict after the worst changes nothing.
+        cell.note_verdict_rule(Verdict::ServedFiltered, "peek");
+        let info = cell.into_guard_info(None, true).expect("verdict noted");
+        assert_eq!(info.verdict, Verdict::Denied);
+        assert_eq!(info.rule.as_deref(), Some("embargo"));
+    }
+
+    #[test]
+    fn cell_upgrade_by_a_default_decision_clears_the_rule() {
+        // The rule names the DECIDING rule of the worst verdict: when a
+        // default-decided denial outranks a rule-decided serve, no rule
+        // may stay attached.
+        let cell = AuditCell::default();
+        cell.note_verdict_rule(Verdict::Served, "allow-most");
+        cell.note_verdict(Verdict::Denied);
+        let info = cell.into_guard_info(None, true).expect("verdict noted");
+        assert_eq!(info.verdict, Verdict::Denied);
+        assert_eq!(info.rule, None);
+    }
+
+    #[test]
+    fn cell_first_rule_wins_at_equal_severity() {
+        let cell = AuditCell::default();
+        cell.note_verdict(Verdict::Served);
+        cell.note_verdict_rule(Verdict::Served, "first");
+        cell.note_verdict_rule(Verdict::Served, "second");
+        let info = cell.into_guard_info(None, true).expect("verdict noted");
+        assert_eq!(info.rule.as_deref(), Some("first"));
+    }
+
+    #[test]
+    fn cell_suppression_implies_a_filtered_serve() {
+        let cell = AuditCell::default();
+        cell.note_verdict_rule(Verdict::Served, "allow-most");
+        cell.note_suppressed([1290040, 1290041, 1290040]);
+        let info = cell.into_guard_info(Some("sha256:ab"), true).unwrap();
+        assert_eq!(info.verdict, Verdict::ServedFiltered);
+        assert_eq!(info.suppressed_ids, vec![1290040, 1290041]);
+        assert_eq!(info.suppressed_count, 2);
+        assert_eq!(info.policy_hash.as_deref(), Some("sha256:ab"));
+    }
+
+    #[test]
+    fn cell_suppressed_count_is_max_of_ids_and_counter() {
+        let cell = AuditCell::default();
+        cell.note_suppressed([7]);
+        cell.note_suppressed_count(2);
+        cell.note_suppressed_count(1);
+        let info = cell.into_guard_info(None, true).unwrap();
+        assert_eq!(info.suppressed_count, 3, "id-less counter adds up");
+        assert_eq!(info.suppressed_ids, vec![7]);
+    }
+
+    #[test]
+    fn cell_suppressed_ids_config_ships_the_count_only() {
+        let cell = AuditCell::default();
+        cell.note_suppressed([40, 41]);
+        let info = cell.into_guard_info(None, false).unwrap();
+        assert!(info.suppressed_ids.is_empty(), "ids elided by config");
+        assert_eq!(info.suppressed_count, 2, "the count still ships");
+    }
+
+    #[test]
+    fn cell_untouched_yields_no_guard_info() {
+        let cell = AuditCell::default();
+        assert_eq!(cell.into_guard_info(Some("sha256:ab"), true), None);
+        // Upstream info alone is not a guard verdict. It is taken FIRST:
+        // into_guard_info drains the whole cell.
+        let cell = AuditCell::default();
+        cell.note_upstream(UpstreamInfo {
+            requests: 1,
+            status: Some(200),
+            latency_ms: 3,
+        });
+        assert!(cell.take_upstream().is_some());
+        assert_eq!(cell.into_guard_info(None, true), None);
+    }
+
+    #[test]
+    fn cell_redaction_is_recorded_and_upgrades_the_verdict() {
+        let cell = AuditCell::default();
+        cell.note_verdict(Verdict::Served);
+        cell.note_redacted("summary_view");
+        cell.note_redacted("summary_view");
+        let info = cell.into_guard_info(None, true).unwrap();
+        assert_eq!(info.verdict, Verdict::ServedFiltered);
+        assert_eq!(info.redacted_fields, vec!["summary_view".to_string()]);
+    }
+
+    #[test]
+    fn policy_hash_of_digests_the_given_bytes() {
+        // The FIPS 180-2 test vector for sha256("abc"), precomputed:
+        // recomputing the expectation with sha2 here would only prove the
+        // function calls sha2, not that it hashes the bytes it was given.
+        assert_eq!(
+            policy_hash_of(b"abc"),
+            "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
         );
     }
 }

--- a/crates/bugwarden/src/config.rs
+++ b/crates/bugwarden/src/config.rs
@@ -71,4 +71,10 @@ pub struct Cli {
     /// policy is used.
     #[arg(long, env = "BUGWARDEN_POLICY")]
     pub policy: Option<PathBuf>,
+
+    /// Path to the audit configuration TOML file (see examples/audit.toml).
+    /// Environment variable BUGWARDEN_AUDIT_CONFIG can also be used.
+    /// Without it no audit stream is written.
+    #[arg(long, env = "BUGWARDEN_AUDIT_CONFIG")]
+    pub audit_config: Option<PathBuf>,
 }

--- a/crates/bugwarden/src/main.rs
+++ b/crates/bugwarden/src/main.rs
@@ -8,6 +8,9 @@
 use std::sync::Arc;
 
 use anyhow::{bail, Context};
+use bugwarden::audit::{
+    policy_hash_of, AuditConfig, AuditSink, AuditState, FailMode, TransportKind,
+};
 use bugwarden::{config, server};
 use bugwarden_core::{client::BugzillaClient, guard::Guard, policy::Policy};
 use clap::Parser;
@@ -72,8 +75,54 @@ async fn main() -> anyhow::Result<()> {
     );
     let guard = Arc::new(Guard { policy });
     let cfg = Arc::new(cli);
+
+    // Audit stream, when configured. The fail mode falls back to the
+    // transport-derived default; the policy digest ties every record to
+    // the policy document in force.
+    let audit = match &cfg.audit_config {
+        Some(path) => {
+            let audit_cfg = AuditConfig::load(path)?;
+            let transport = match cfg.transport {
+                Transport::Stdio => TransportKind::Stdio,
+                Transport::Http => TransportKind::Http,
+            };
+            let fail_mode = FailMode::resolve(audit_cfg.fail_mode, transport);
+            // The digest re-reads the file Policy::load parsed above
+            // (load also owns the unix permission warning, so it stays
+            // the one parse path). A rewrite between the two reads could
+            // hash different bytes than were parsed; the window is
+            // operator-local and harmless — the operator who swaps the
+            // policy mid-startup gets the digest of what is on disk.
+            let policy_hash = match &cfg.policy {
+                Some(policy_path) => {
+                    let bytes = std::fs::read(policy_path).with_context(|| {
+                        format!(
+                            "failed to read guard policy from {} for the audit digest",
+                            policy_path.display()
+                        )
+                    })?;
+                    Some(policy_hash_of(&bytes))
+                }
+                None => None,
+            };
+            let sink = AuditSink::open(audit_cfg).context("failed to open the audit sink")?;
+            Some(Arc::new(AuditState::new(sink, fail_mode, policy_hash)))
+        }
+        None => None,
+    };
+    if audit.is_none() && cfg.transport == Transport::Http {
+        tracing::warn!(
+            "auditing is OFF: remote tool calls over http will leave no audit \
+             record — pass --audit-config / BUGWARDEN_AUDIT_CONFIG to enable it"
+        );
+    }
+
     let server = server::BugWarden::new(cfg.clone(), guard, bz)
         .context("failed to build the MCP server from the guard policy")?;
+    let server = match audit {
+        Some(audit) => server.with_audit(audit),
+        None => server,
+    };
 
     match cfg.transport {
         Transport::Stdio => {
@@ -98,12 +147,17 @@ async fn main() -> anyhow::Result<()> {
             let tcp_listener = tokio::net::TcpListener::bind(&addr)
                 .await
                 .with_context(|| format!("failed to bind {addr}"))?;
-            axum::serve(tcp_listener, router)
-                .with_graceful_shutdown(async move {
-                    let _ = tokio::signal::ctrl_c().await;
-                    ct.cancel();
-                })
-                .await?;
+            // Connect-info makes the remote peer address available in the
+            // request extensions, where the audit session info reads it.
+            axum::serve(
+                tcp_listener,
+                router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .with_graceful_shutdown(async move {
+                let _ = tokio::signal::ctrl_c().await;
+                ct.cancel();
+            })
+            .await?;
         }
     }
 

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -8,20 +8,22 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
+use std::time::Instant;
 
 use bugwarden_core::client::{BugzillaClient, CLASSIFY_FIELDS};
 use bugwarden_core::guard::{Guard, SearchRequest};
 use bugwarden_core::policy::{Access, Action, Capability};
 use chrono::{DateTime, Utc};
 use rmcp::{
-    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    handler::server::{router::tool::ToolRouter, tool::ToolCallContext, wrapper::Parameters},
     model::*,
     schemars,
     service::RequestContext,
-    tool, tool_handler, tool_router, ErrorData as McpError, RoleServer, ServerHandler,
+    tool, tool_router, ErrorData as McpError, RoleServer, ServerHandler,
 };
 use serde_json::{json, Value};
 
+use crate::audit::{self, AuditCell, AuditState, FailMode, TransportKind, Verdict};
 use crate::config::{Cli, Transport};
 
 /// Names of the tools that modify bug state. These routes are removed from
@@ -54,6 +56,204 @@ fn action_name(action: Action) -> &'static str {
         Action::Allow => "allow",
         Action::Deny => "deny",
         Action::Restrict => "restrict",
+    }
+}
+
+/// The name of the policy rule that decided an assessment; both variants
+/// carry one.
+fn access_rule(access: &Access) -> &str {
+    match access {
+        Access::Denied { rule } | Access::Granted { rule, .. } => rule,
+    }
+}
+
+/// The request's audit enrichment cell, when auditing is on. The audit
+/// wrapper inserts one before dispatch; with auditing off (or a caller
+/// outside the wrapper) there is none and every note is a no-op at the
+/// call site — enrichment can never change what a tool returns.
+fn audit_cell(ctx: &RequestContext<RoleServer>) -> Option<Arc<AuditCell>> {
+    ctx.extensions.get::<Arc<AuditCell>>().cloned()
+}
+
+/// Note a `Refused` verdict on the request's audit cell. Mechanical
+/// companion for the `return Ok(err_text(..))` refusal sites that answer
+/// from the request alone.
+fn note_refused(ctx: &RequestContext<RoleServer>) {
+    if let Some(cell) = audit_cell(ctx) {
+        cell.note_verdict(Verdict::Refused);
+    }
+}
+
+/// Whether the pre-dispatch audit gate holds `tool` back while the sink is
+/// already failing: `Open` never gates, `ClosedWritesDenials` gates the
+/// write tools only, `ClosedAll` gates everything.
+fn gate_applies(fail_mode: FailMode, tool: &str) -> bool {
+    match fail_mode {
+        FailMode::Open => false,
+        FailMode::ClosedWritesDenials => WRITE_TOOLS.contains(&tool),
+        FailMode::ClosedAll => true,
+    }
+}
+
+/// The refusal text for a tool call refused because its audit record
+/// cannot be persisted (the closed fail modes). One fixed text per TOOL —
+/// each tool's EXISTING generic failure wording, so an audit outage looks
+/// like the failure the client already knows and is not a new fingerprint;
+/// tools without a generic failure text get a pattern-consistent one. The
+/// text depends on the tool name alone, never on anything the guard
+/// decided. `None` only for names outside the tool surface — the map must
+/// be total over the full router (tested), and every routed tool must
+/// have its own entry here before it can ship.
+fn audit_refusal_text(tool: &str) -> Option<String> {
+    let text = match tool {
+        "bug_info" => "Failed to fetch bug information".to_string(),
+        "bug_history" => "Failed to fetch bug history".to_string(),
+        "bug_comments" => "Failed to fetch bug comments".to_string(),
+        "bugs_quicksearch" => "Search failed".to_string(),
+        "summarize_bug" => "Summarize Comments Failed".to_string(),
+        "list_attachments" => "Failed to fetch bug attachments".to_string(),
+        "download_attachment" => "Failed to fetch attachment".to_string(),
+        "bugzilla_server_info" => "Failed to fetch bugzilla server info".to_string(),
+        "quicksearch_syntax" => "Failed to fetch quicksearch documentation".to_string(),
+        "bug_url" => "Failed to compute the bug url".to_string(),
+        "mcp_server_info" => "Failed to compute server info".to_string(),
+        // Write tools: the first line of their existing failure text,
+        // without the upstream detail — truthfully so: nothing upstream
+        // happened when the gate refused before dispatch.
+        "add_comment" => "Failed to create a comment".to_string(),
+        "update_bug_status" => "Failed to update bug status".to_string(),
+        "assign_bug" => "Failed to assign bug".to_string(),
+        "update_bug_fields" => "Failed to update bug fields".to_string(),
+        "update_bug_dependencies" => "Failed to update bug dependencies".to_string(),
+        "add_cc_to_bug" => "Failed to add CC".to_string(),
+        "add_attachment" => "Failed to add attachment".to_string(),
+        "mark_as_duplicate" => "Failed to mark as duplicate".to_string(),
+        "create_bug" => Guard::create_denial(),
+        _ => return None,
+    };
+    Some(text)
+}
+
+/// The uniform fail-closed refusal for `tool`. Unknown names fall back to
+/// a generic text; unreachable for routed tools (see
+/// [`audit_refusal_text`]) — the fallback exists so the map is total.
+fn audit_refusal(tool: &str) -> CallToolResult {
+    err_text(audit_refusal_text(tool).unwrap_or_else(|| "Request failed".to_string()))
+}
+
+/// Keys of client-authored tool parameters whose VALUES may enter an audit
+/// record. The bar: identifiers, projections and routing/vocabulary fields
+/// yes; free text no. `comment`, `summary`, `description`, `data`
+/// (attachment bytes) and `custom_fields` (operator-defined values) never
+/// appear by value — a non-allowlisted key is recorded as
+/// `{"_len": <serialized byte length>}`, so presence and size are loggable
+/// while content is not. Allowlisted string values are truncated to 1024
+/// characters.
+const PARAM_ALLOWLIST: &[&str] = &[
+    "assignee",
+    "attachment_id",
+    "blocks_add",
+    "blocks_remove",
+    "bug_id",
+    "bug_ids",
+    "cc_email",
+    "component",
+    "content_type",
+    "depends_on_add",
+    "depends_on_remove",
+    "duplicate_of",
+    "file_name",
+    "groups",
+    "id",
+    "include_fields",
+    "include_private",
+    "is_patch",
+    "is_private",
+    "keywords",
+    "limit",
+    "new_since",
+    "offset",
+    "op_sys",
+    "platform",
+    "priority",
+    "product",
+    "query",
+    "resolution",
+    "severity",
+    "status",
+    "version",
+];
+
+/// Cap on recorded string values; see [`PARAM_ALLOWLIST`].
+const PARAM_VALUE_MAX_CHARS: usize = 1024;
+
+/// An allowlisted value with every string (top level or inside a list)
+/// truncated to [`PARAM_VALUE_MAX_CHARS`] characters. No marker is
+/// appended; the cap is documented at the allowlist.
+fn truncated(value: &Value) -> Value {
+    match value {
+        // A string of at most 1024 BYTES has at most 1024 chars; the
+        // cheap length check skips the char walk for the common case.
+        Value::String(s) if s.len() > PARAM_VALUE_MAX_CHARS => {
+            let capped: String = s.chars().take(PARAM_VALUE_MAX_CHARS).collect();
+            Value::String(capped)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(truncated).collect()),
+        other => other.clone(),
+    }
+}
+
+/// Project a tool call's arguments through [`PARAM_ALLOWLIST`] into the
+/// audit record's `params` map.
+fn allowlisted(params: Option<&JsonObject>) -> BTreeMap<String, Value> {
+    let Some(params) = params else {
+        return BTreeMap::new();
+    };
+    params
+        .iter()
+        .map(|(key, value)| {
+            let recorded = if PARAM_ALLOWLIST.contains(&key.as_str()) {
+                truncated(value)
+            } else {
+                let len = serde_json::to_vec(value).map(|b| b.len()).unwrap_or(0);
+                json!({ "_len": len })
+            };
+            (key.clone(), recorded)
+        })
+        .collect()
+}
+
+/// The calling client as it introduced itself in the handshake, for an
+/// audit record. Self-declared, therefore untrusted; `principal` stays
+/// `None` (reserved for a future authenticated identity).
+fn client_of(ctx: &RequestContext<RoleServer>) -> audit::ClientInfo {
+    let peer = ctx.peer.peer_info();
+    audit::ClientInfo {
+        name: peer.as_ref().map(|p| p.client_info.name.clone()),
+        version: peer.as_ref().map(|p| p.client_info.version.clone()),
+        principal: None,
+    }
+}
+
+/// Total elapsed milliseconds since `started`, saturating.
+fn elapsed_ms(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+/// Persist one audit record without blocking the async worker: the sink
+/// is synchronous by design (that is what makes "persisted before the
+/// response is returned" a guarantee), so the write moves to the blocking
+/// pool and is awaited — the response still cannot overtake it. A
+/// panicked write counts as a failed one.
+async fn record_event(
+    audit: &Arc<AuditState>,
+    kind: audit::AuditEventKind,
+    session: audit::SessionInfo,
+) -> Result<u64, ()> {
+    let state = Arc::clone(audit);
+    match tokio::task::spawn_blocking(move || state.sink.record(kind, session)).await {
+        Ok(Ok(seq)) => Ok(seq),
+        Ok(Err(_)) | Err(_) => Err(()),
     }
 }
 
@@ -552,6 +752,8 @@ pub struct BugWarden {
     guard: Arc<Guard>,
     bz: Arc<BugzillaClient>,
     tool_router: ToolRouter<Self>,
+    /// Audit wiring; `None` runs the exact pre-audit request path.
+    audit: Option<Arc<AuditState>>,
 }
 
 impl BugWarden {
@@ -596,7 +798,51 @@ impl BugWarden {
             guard,
             bz,
             tool_router,
+            audit: None,
         })
+    }
+
+    /// Enable auditing. Separate from [`BugWarden::new`] so existing
+    /// construction sites (and the tests that rely on them) stay valid
+    /// with auditing off.
+    pub fn with_audit(mut self, audit: Arc<AuditState>) -> Self {
+        self.audit = Some(audit);
+        self
+    }
+
+    /// The session an audit record belongs to. http: the server-assigned
+    /// `mcp-session-id` header and, when the listener was built with
+    /// connect-info, the remote peer address — both from the HTTP request
+    /// parts rmcp copies into the request extensions. stdio: the
+    /// process-scoped session id from [`AuditState`].
+    fn session_info(
+        &self,
+        ctx: &RequestContext<RoleServer>,
+        audit: &AuditState,
+    ) -> audit::SessionInfo {
+        match self.cfg.transport {
+            Transport::Stdio => audit::SessionInfo {
+                id: Some(audit.stdio_session_id.clone()),
+                transport: TransportKind::Stdio,
+                remote: None,
+            },
+            Transport::Http => {
+                let parts = ctx.extensions.get::<axum::http::request::Parts>();
+                audit::SessionInfo {
+                    id: parts
+                        .and_then(|p| p.headers.get("mcp-session-id"))
+                        .and_then(|v| v.to_str().ok())
+                        .map(str::to_owned),
+                    transport: TransportKind::Http,
+                    remote: parts
+                        .and_then(|p| {
+                            p.extensions
+                                .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+                        })
+                        .map(|ci| ci.0.to_string()),
+                }
+            }
+        }
     }
 
     /// Resolve the Bugzilla API key for the current request.
@@ -642,12 +888,30 @@ impl BugWarden {
     }
 
     /// Assess a single bug id and require `cap`. Returns `Some(denial)` when
-    /// the operation must be refused; the denial text is uniform (I2).
-    async fn deny_unless(&self, key: &str, id: u64, cap: Capability) -> Option<CallToolResult> {
+    /// the operation must be refused; the denial text is uniform (I2). The
+    /// verdict — either way — and its deciding rule are noted on the
+    /// request's audit cell; noting changes nothing the client sees.
+    async fn deny_unless(
+        &self,
+        key: &str,
+        id: u64,
+        cap: Capability,
+        ctx: &RequestContext<RoleServer>,
+    ) -> Option<CallToolResult> {
         let assessments = self.assess(key, &[id]).await;
-        let allowed = assessments
-            .get(&id)
-            .is_some_and(|(access, _)| access.allows(cap));
+        let entry = assessments.get(&id);
+        let allowed = entry.is_some_and(|(access, _)| access.allows(cap));
+        if let Some(cell) = audit_cell(ctx) {
+            let verdict = if allowed {
+                Verdict::Served
+            } else {
+                Verdict::Denied
+            };
+            match entry {
+                Some((access, _)) => cell.note_verdict_rule(verdict, access_rule(access)),
+                None => cell.note_verdict(verdict),
+            }
+        }
         if allowed {
             None
         } else {
@@ -680,9 +944,11 @@ impl BugWarden {
             .filter(|id| seen.insert(*id))
             .collect();
         if ids.is_empty() {
+            note_refused(&ctx);
             return Ok(err_text("At least one bug id must be provided"));
         }
         if let Some(refusal) = too_many_ids(&ids) {
+            note_refused(&ctx);
             return Ok(refusal);
         }
 
@@ -760,6 +1026,56 @@ impl BugWarden {
                 Guard::scrub_bug_links(bug, base_url, &allowed);
             }
         }
+        if let Some(cell) = audit_cell(&ctx) {
+            // One record for the whole call: per-id verdicts merge worst-
+            // wins. The envelope is the truth (a re-check flip lands a
+            // granted id under `restricted`); rules come from the
+            // assessments where the variant matches the outcome. A
+            // `restricted` entry is a Denied the client was told about;
+            // the suppressed set is the scrubbed LINK ids — the ones the
+            // client cannot see at all (I14).
+            if let Some(bugs) = envelope.get("bugs").and_then(Value::as_array) {
+                for bug in bugs {
+                    let redacted = bug.get("_redacted").is_some();
+                    let verdict = if redacted {
+                        Verdict::ServedFiltered
+                    } else {
+                        Verdict::Served
+                    };
+                    let rule = bug
+                        .get("id")
+                        .and_then(Value::as_u64)
+                        .and_then(|id| assessments.get(&id));
+                    match rule {
+                        Some((Access::Granted { rule, .. }, _)) => {
+                            cell.note_verdict_rule(verdict, rule);
+                        }
+                        _ => cell.note_verdict(verdict),
+                    }
+                    if redacted {
+                        cell.note_redacted("summary_view");
+                    }
+                }
+            }
+            if let Some(restricted) = envelope.get("restricted").and_then(Value::as_array) {
+                for entry in restricted {
+                    let rule = entry
+                        .get("id")
+                        .and_then(Value::as_u64)
+                        .and_then(|id| assessments.get(&id));
+                    match rule {
+                        Some((Access::Denied { rule }, _)) => {
+                            cell.note_verdict_rule(Verdict::Denied, rule);
+                        }
+                        _ => cell.note_verdict(Verdict::Denied),
+                    }
+                }
+            }
+            let hidden_links: Vec<u64> = named.difference(&allowed).copied().collect();
+            if !hidden_links.is_empty() {
+                cell.note_suppressed(hidden_links);
+            }
+        }
         Ok(ok_json(envelope))
     }
 
@@ -774,7 +1090,10 @@ impl BugWarden {
     ) -> Result<CallToolResult, McpError> {
         tracing::info!(id = p.id, new_since = ?p.new_since, "tool: bug_history");
         let key = self.api_key(&ctx)?;
-        if let Some(denied) = self.deny_unless(&key, p.id, Capability::History).await {
+        if let Some(denied) = self
+            .deny_unless(&key, p.id, Capability::History, &ctx)
+            .await
+        {
             return Ok(denied);
         }
         match self.bz.bug_history(&key, p.id, p.new_since).await {
@@ -785,6 +1104,12 @@ impl BugWarden {
                 let base_url = self.bz.base_url();
                 let named = Guard::history_bug_ids(&history, base_url);
                 let disclosable = self.guard.disclosable(&self.bz, &key, &named).await;
+                if let Some(cell) = audit_cell(&ctx) {
+                    let hidden: Vec<u64> = named.difference(&disclosable).copied().collect();
+                    if !hidden.is_empty() {
+                        cell.note_suppressed(hidden);
+                    }
+                }
                 Ok(ok_json(Guard::scrub_history(
                     history,
                     base_url,
@@ -814,17 +1139,30 @@ impl BugWarden {
             "tool: bug_comments"
         );
         let key = self.api_key(&ctx)?;
-        if let Some(denied) = self.deny_unless(&key, p.id, Capability::Comments).await {
+        if let Some(denied) = self
+            .deny_unless(&key, p.id, Capability::Comments, &ctx)
+            .await
+        {
             return Ok(denied);
         }
         match self.bz.bug_comments(&key, p.id, p.new_since).await {
             Ok(comments) => {
+                let total = comments.len();
                 let filtered = self.guard.filter_comments(comments, p.include_private);
                 // Bugzilla writes "*** Bug N has been marked as a duplicate
                 // of this bug ***" itself, so a hidden bug can name itself in
                 // the comments of one the client may read (I2).
                 let named = Guard::duplicate_marker_ids(&filtered);
                 let disclosable = self.guard.disclosable(&self.bz, &key, &named).await;
+                if let Some(cell) = audit_cell(&ctx) {
+                    // Dropped private comments have no bug id: count only.
+                    // Scrubbed duplicate-marker ids are the hidden bugs.
+                    cell.note_suppressed_count((total - filtered.len()) as u64);
+                    let hidden: Vec<u64> = named.difference(&disclosable).copied().collect();
+                    if !hidden.is_empty() {
+                        cell.note_suppressed(hidden);
+                    }
+                }
                 let scrubbed = Guard::scrub_duplicate_markers(filtered, &disclosable);
                 Ok(ok_json(Value::Array(scrubbed)))
             }
@@ -913,6 +1251,22 @@ impl BugWarden {
         for bug in projected.iter_mut() {
             Guard::scrub_bug_links(bug, base_url, &allowed);
         }
+        if let Some(cell) = audit_cell(&ctx) {
+            // The window's own drops happen inside the guard scan and are
+            // not surfaced here; what this site sees is the served
+            // projection — redacted rows and the linked ids I14 scrubbed
+            // out of them.
+            cell.note_verdict(Verdict::Served);
+            for bug in &projected {
+                if bug.get("_redacted").is_some() {
+                    cell.note_redacted("summary_view");
+                }
+            }
+            let hidden: Vec<u64> = named.difference(&allowed).copied().collect();
+            if !hidden.is_empty() {
+                cell.note_suppressed(hidden);
+            }
+        }
 
         let mut envelope = json!({ "bugs": projected });
         // Steering only, computed from the request the client itself sent
@@ -992,7 +1346,12 @@ impl BugWarden {
         if !self.guard.may_create(&payload) {
             let _ = self.assess(&key, &[0]).await;
             tracing::info!(product = %p.product, "guard denied bug creation");
+            note_refused(&ctx);
             return Ok(err_text(Guard::create_denial()));
+        }
+        if let Some(cell) = audit_cell(&ctx) {
+            // may_create judges the request as a whole and names no rule.
+            cell.note_verdict(Verdict::Served);
         }
 
         match self.bz.create_bug(&key, payload).await {
@@ -1028,12 +1387,16 @@ impl BugWarden {
             "tool: add_attachment"
         );
         let key = self.api_key(&ctx)?;
-        if let Some(denied) = self.deny_unless(&key, p.bug_id, Capability::Attach).await {
+        if let Some(denied) = self
+            .deny_unless(&key, p.bug_id, Capability::Attach, &ctx)
+            .await
+        {
             return Ok(denied);
         }
 
         let cap = self.guard.policy.global.max_attachment_bytes;
         if let Some(refusal) = upload_size_refusal(cap, &p.data) {
+            note_refused(&ctx);
             return Ok(err_text(refusal));
         }
 
@@ -1083,7 +1446,10 @@ impl BugWarden {
             "tool: add_comment"
         );
         let key = self.api_key(&ctx)?;
-        if let Some(denied) = self.deny_unless(&key, p.bug_id, Capability::Comment).await {
+        if let Some(denied) = self
+            .deny_unless(&key, p.bug_id, Capability::Comment, &ctx)
+            .await
+        {
             return Ok(denied);
         }
         match self
@@ -1118,12 +1484,16 @@ impl BugWarden {
         );
         let has_resolution = p.resolution.as_deref().is_some_and(|r| !r.is_empty());
         if p.status == "CLOSED" && !has_resolution {
+            note_refused(&ctx);
             return Ok(err_text(
                 "Resolution is required when setting status to CLOSED (e.g., FIXED, WONTFIX, NOTABUG, DUPLICATE)",
             ));
         }
         let key = self.api_key(&ctx)?;
-        if let Some(denied) = self.deny_unless(&key, p.bug_id, Capability::Status).await {
+        if let Some(denied) = self
+            .deny_unless(&key, p.bug_id, Capability::Status, &ctx)
+            .await
+        {
             return Ok(denied);
         }
 
@@ -1163,7 +1533,10 @@ impl BugWarden {
     ) -> Result<CallToolResult, McpError> {
         tracing::info!(bug_id = p.bug_id, assignee = %p.assignee, "tool: assign_bug");
         let key = self.api_key(&ctx)?;
-        if let Some(denied) = self.deny_unless(&key, p.bug_id, Capability::Assign).await {
+        if let Some(denied) = self
+            .deny_unless(&key, p.bug_id, Capability::Assign, &ctx)
+            .await
+        {
             return Ok(denied);
         }
         let mut payload = serde_json::Map::new();
@@ -1217,6 +1590,7 @@ impl BugWarden {
             // without calling Bugzilla otherwise.
             for k in custom_fields.keys() {
                 if !k.starts_with("cf_") {
+                    note_refused(&ctx);
                     return Ok(err_text(format!(
                         "Invalid custom field '{k}': custom field names must start with 'cf_'"
                     )));
@@ -1227,12 +1601,16 @@ impl BugWarden {
             }
         }
         if payload.is_empty() {
+            note_refused(&ctx);
             return Ok(err_text("At least one field must be specified"));
         }
         attach_comment(&mut payload, &p.comment);
 
         let key = self.api_key(&ctx)?;
-        if let Some(denied) = self.deny_unless(&key, p.bug_id, Capability::Fields).await {
+        if let Some(denied) = self
+            .deny_unless(&key, p.bug_id, Capability::Fields, &ctx)
+            .await
+        {
             return Ok(denied);
         }
         match self
@@ -1278,6 +1656,7 @@ impl BugWarden {
             payload.insert("depends_on".to_string(), depends_on);
         }
         if payload.is_empty() {
+            note_refused(&ctx);
             return Ok(err_text("At least one dependency change must be specified"));
         }
         attach_comment(&mut payload, &p.comment);
@@ -1304,16 +1683,27 @@ impl BugWarden {
         let mut seen = BTreeSet::new();
         ids.retain(|id| seen.insert(*id));
         if let Some(refusal) = too_many_ids(&ids) {
+            note_refused(&ctx);
             return Ok(refusal);
         }
 
         let key = self.api_key(&ctx)?;
+        let cell = audit_cell(&ctx);
         let assessments = self.assess(&key, &ids).await;
+        let note = |id: u64, verdict: Verdict| {
+            if let Some(cell) = &cell {
+                match assessments.get(&id) {
+                    Some((access, _)) => cell.note_verdict_rule(verdict, access_rule(access)),
+                    None => cell.note_verdict(verdict),
+                }
+            }
+        };
         let deps_ok = assessments
             .get(&p.bug_id)
             .is_some_and(|(access, _)| access.allows(Capability::Deps));
         if !deps_ok {
             tracing::info!(bug_id = p.bug_id, "guard denied operation");
+            note(p.bug_id, Verdict::Denied);
             return Ok(err_text(Guard::denial(p.bug_id)));
         }
         for &id in ids.iter().filter(|&&id| id != p.bug_id) {
@@ -1322,9 +1712,11 @@ impl BugWarden {
                 .is_some_and(|(access, _)| access.allows(Capability::Summary));
             if !target_ok {
                 tracing::info!(bug_id = id, "guard denied dependency target");
+                note(id, Verdict::Denied);
                 return Ok(err_text(Guard::denial(id)));
             }
         }
+        note(p.bug_id, Verdict::Served);
 
         match self
             .bz
@@ -1352,7 +1744,7 @@ impl BugWarden {
     ) -> Result<CallToolResult, McpError> {
         tracing::info!(bug_id = p.bug_id, cc_email = %p.cc_email, "tool: add_cc_to_bug");
         let key = self.api_key(&ctx)?;
-        if let Some(denied) = self.deny_unless(&key, p.bug_id, Capability::Cc).await {
+        if let Some(denied) = self.deny_unless(&key, p.bug_id, Capability::Cc, &ctx).await {
             return Ok(denied);
         }
         let payload = json!({ "cc": { "add": [p.cc_email] } });
@@ -1389,19 +1781,31 @@ impl BugWarden {
         } else {
             vec![p.bug_id, p.duplicate_of]
         };
+        let cell = audit_cell(&ctx);
         let assessments = self.assess(&key, &ids).await;
+        let note = |id: u64, verdict: Verdict| {
+            if let Some(cell) = &cell {
+                match assessments.get(&id) {
+                    Some((access, _)) => cell.note_verdict_rule(verdict, access_rule(access)),
+                    None => cell.note_verdict(verdict),
+                }
+            }
+        };
         let status_ok = assessments
             .get(&p.bug_id)
             .is_some_and(|(access, _)| access.allows(Capability::Status));
         if !status_ok {
+            note(p.bug_id, Verdict::Denied);
             return Ok(err_text(Guard::denial(p.bug_id)));
         }
         let duplicate_ok = assessments
             .get(&p.duplicate_of)
             .is_some_and(|(access, _)| access.allows(Capability::Summary));
         if !duplicate_ok {
+            note(p.duplicate_of, Verdict::Denied);
             return Ok(err_text(Guard::denial(p.duplicate_of)));
         }
+        note(p.bug_id, Verdict::Served);
 
         let comment = if p.comment.is_empty() {
             format!("Marking as duplicate of bug {}", p.duplicate_of)
@@ -1440,7 +1844,7 @@ impl BugWarden {
         );
         let key = self.api_key(&ctx)?;
         if let Some(denied) = self
-            .deny_unless(&key, p.bug_id, Capability::Attachments)
+            .deny_unless(&key, p.bug_id, Capability::Attachments, &ctx)
             .await
         {
             return Ok(denied);
@@ -1456,7 +1860,13 @@ impl BugWarden {
                     // than passing unfiltered metadata through.
                     _ => Vec::new(),
                 };
+                let total = items.len();
                 let filtered = self.guard.filter_attachments(items, p.include_private);
+                if let Some(cell) = audit_cell(&ctx) {
+                    // Filtered private attachments have no bug id of
+                    // their own: count only.
+                    cell.note_suppressed_count((total - filtered.len()) as u64);
+                }
                 Ok(ok_json(Value::Array(filtered)))
             }
             Err(e) => Ok(err_text(format!(
@@ -1513,6 +1923,23 @@ impl BugWarden {
         let allowed = assessments
             .get(&assess_id)
             .is_some_and(|(access, _)| access.allows(Capability::Attachments));
+        if let Some(cell) = audit_cell(&ctx) {
+            // Every uniform-denial path below upgrades this to Denied;
+            // the padding assessment against bug id 0 decides nothing,
+            // so no rule is attached there.
+            match assessments.get(&assess_id) {
+                _ if assess_id == 0 => cell.note_verdict(Verdict::Denied),
+                Some((access, _)) => cell.note_verdict_rule(
+                    if allowed {
+                        Verdict::Served
+                    } else {
+                        Verdict::Denied
+                    },
+                    access_rule(access),
+                ),
+                None => cell.note_verdict(Verdict::Denied),
+            }
+        }
 
         let Some(meta) = meta.filter(|_| allowed && assess_id != 0) else {
             // Missing metadata, missing bug id, or a denied owning bug: one
@@ -1520,7 +1947,16 @@ impl BugWarden {
             // reused — it would confirm which bug owns the attachment.
             return Ok(err_text(Guard::attachment_denial(p.attachment_id)));
         };
+        // Withheld content after a granted assessment is still the guard
+        // deciding: every refusal below upgrades the noted verdict to
+        // Denied (the note changes no response byte).
+        let note_denied = || {
+            if let Some(cell) = audit_cell(&ctx) {
+                cell.note_verdict(Verdict::Denied);
+            }
+        };
         if let Some(refusal) = self.guard.attachment_gate(&meta, p.include_private) {
+            note_denied();
             return Ok(err_text(refusal));
         }
 
@@ -1529,13 +1965,17 @@ impl BugWarden {
             // A failed blob fetch gets the same uniform denial as an unknown
             // id: the upstream status and message would otherwise distinguish
             // the two and disclose server detail.
-            Ok(None) => return Ok(err_text(Guard::attachment_denial(p.attachment_id))),
+            Ok(None) => {
+                note_denied();
+                return Ok(err_text(Guard::attachment_denial(p.attachment_id)));
+            }
             Err(e) => {
                 tracing::debug!(
                     attachment_id = p.attachment_id,
                     error = %e,
                     "attachment data fetch failed"
                 );
+                note_denied();
                 return Ok(err_text(Guard::attachment_denial(p.attachment_id)));
             }
         };
@@ -1544,9 +1984,11 @@ impl BugWarden {
         // owning bug, so an attachment that turns private (or moves to another
         // bug) between the two calls cannot be served.
         if attachment.get("bug_id").and_then(Value::as_u64) != Some(assess_id) {
+            note_denied();
             return Ok(err_text(Guard::attachment_denial(p.attachment_id)));
         }
         if let Some(refusal) = self.guard.attachment_gate(&attachment, p.include_private) {
+            note_denied();
             return Ok(err_text(refusal));
         }
 
@@ -1555,6 +1997,7 @@ impl BugWarden {
             .and_then(Value::as_str)
             .map(str::to_owned)
         else {
+            note_refused(&ctx);
             return Ok(err_text("Attachment has no data"));
         };
         // Defense in depth: the size gate trusted the upstream-REPORTED size;
@@ -1564,6 +2007,7 @@ impl BugWarden {
         // so the cap stays inclusive, matching the metadata gate.
         let cap = self.guard.policy.global.max_attachment_bytes;
         if cap > 0 && decoded_len(&blob) > cap {
+            note_denied();
             return Ok(err_text(format!(
                 "Attachment {} exceeds the size limit of this server",
                 p.attachment_id
@@ -1689,7 +2133,10 @@ impl BugWarden {
     ) -> Result<CallToolResult, McpError> {
         tracing::info!(id = p.id, "tool: summarize_bug");
         let key = self.api_key(&ctx)?;
-        if let Some(denied) = self.deny_unless(&key, p.id, Capability::Comments).await {
+        if let Some(denied) = self
+            .deny_unless(&key, p.id, Capability::Comments, &ctx)
+            .await
+        {
             return Ok(denied);
         }
         let comments = match self.bz.bug_comments(&key, p.id, None).await {
@@ -1698,11 +2145,19 @@ impl BugWarden {
                 return Ok(err_text(format!("Summarize Comments Failed\nReason: {e}")));
             }
         };
+        let total = comments.len();
         let comments = self.guard.filter_comments(comments, false);
         // Same scrub as bug_comments: otherwise a client that would be
         // scrubbed there just asks for a summary instead (I14).
         let named = Guard::duplicate_marker_ids(&comments);
         let disclosable = self.guard.disclosable(&self.bz, &key, &named).await;
+        if let Some(cell) = audit_cell(&ctx) {
+            cell.note_suppressed_count((total - comments.len()) as u64);
+            let hidden: Vec<u64> = named.difference(&disclosable).copied().collect();
+            if !hidden.is_empty() {
+                cell.note_suppressed(hidden);
+            }
+        }
         let comments = Guard::scrub_duplicate_markers(comments, &disclosable);
         let comments_json =
             serde_json::to_string_pretty(&comments).unwrap_or_else(|_| "[]".to_string());
@@ -1721,11 +2176,202 @@ impl BugWarden {
     }
 }
 
-// `router = self.tool_router` is load-bearing: the instance router has the
-// write tools / disabled tools removed (I13). The macro default,
-// `Self::tool_router()`, would rebuild an unpruned router.
-#[tool_handler(router = self.tool_router)]
+// Hand-written handler impl. `call_tool`, `list_tools` and `get_tool` keep
+// the exact semantics the `#[tool_handler]` macro would generate for them;
+// hand-writing exists so `call_tool` can own the audit record and
+// `initialize` the initialize record. Dispatch through `self.tool_router`
+// is load-bearing: the instance router has the write tools / disabled
+// tools removed (I13); the macro default, `Self::tool_router()`, would
+// rebuild an unpruned router. `list_tools` is not audited: no event kind
+// exists for a listing — deliberate for schema v1.
 impl ServerHandler for BugWarden {
+    async fn initialize(
+        &self,
+        request: InitializeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<InitializeResult, McpError> {
+        // The default handler's peer bookkeeping, replicated: the
+        // handshake info is stored so later calls (and their audit
+        // records) can read it back through `peer_info`.
+        context.peer.set_peer_info(request.clone());
+        if let Some(audit) = &self.audit {
+            // Every session start is recorded, unconditionally — no
+            // configuration knob: a stream that could omit session
+            // starts could not anchor its tool records to a client.
+            let event = audit::AuditEventKind::Initialize(audit::InitializeEvent {
+                client: audit::ClientInfo {
+                    name: Some(request.client_info.name.clone()),
+                    version: Some(request.client_info.version.clone()),
+                    principal: None,
+                },
+                protocol_version: Some(request.protocol_version.as_str().to_string()),
+            });
+            let session = self.session_info(&context, audit);
+            if record_event(audit, event, session).await.is_err()
+                && audit.fail_mode == FailMode::ClosedAll
+            {
+                // Only ClosedAll refuses the handshake: initialize is
+                // neither a write nor a guard verdict, so the other two
+                // modes proceed and let the gap marker account for the
+                // loss.
+                return Err(McpError::internal_error("audit unavailable", None));
+            }
+        }
+        // The default handler's version negotiation, replicated: echo a
+        // client-requested version this SDK knows, keep the server
+        // default otherwise.
+        let mut info = self.get_info();
+        if ProtocolVersion::KNOWN_VERSIONS.contains(&request.protocol_version) {
+            info.protocol_version = request.protocol_version;
+        } else {
+            tracing::warn!(
+                client_requested = %request.protocol_version,
+                server_fallback = %info.protocol_version,
+                "client requested unsupported protocol version; falling back to server default"
+            );
+        }
+        Ok(info)
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        mut context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        // Auditing off: byte-identical to the macro-generated dispatch.
+        let Some(audit) = self.audit.clone() else {
+            return self
+                .tool_router
+                .call(ToolCallContext::new(self, request, context))
+                .await;
+        };
+        let started = Instant::now();
+        let tool = request.name.to_string();
+        let session = self.session_info(&context, &audit);
+        let client = client_of(&context);
+        let request_id = Some(context.id.to_string());
+        // Allowlist BEFORE dispatch: the record needs the params after
+        // the router has consumed the request, and allowlisting first
+        // avoids cloning free-text and blob values that would be reduced
+        // to a byte length anyway.
+        let params = allowlisted(request.arguments.as_ref());
+
+        // Pre-dispatch gate: a sink already in failure holds back further
+        // unaudited work, scoped by the fail mode. The refusal is
+        // recorded best-effort — succeed or not, the call is refused:
+        // the gate exists to stop unaudited work, not to retry its way
+        // open. The refusal depends on the tool name alone, never on
+        // anything the guard decided (the guard never ran).
+        if audit.sink.failing() && gate_applies(audit.fail_mode, &tool) {
+            let event = audit::AuditEventKind::ToolCall(Box::new(audit::ToolCallEvent {
+                client,
+                trace: None,
+                request: audit::RequestInfo {
+                    tool: tool.clone(),
+                    id: request_id,
+                    params,
+                },
+                guard: Some(audit::GuardInfo {
+                    verdict: Verdict::Refused,
+                    rule: None,
+                    policy_hash: audit.policy_hash.clone(),
+                    suppressed_count: 0,
+                    suppressed_ids: Vec::new(),
+                    redacted_fields: Vec::new(),
+                }),
+                upstream: None,
+                outcome: audit::OutcomeInfo {
+                    class: audit::OutcomeClass::Refused,
+                    duration_ms: elapsed_ms(started),
+                },
+            }));
+            let _ = record_event(&audit, event, session).await;
+            return Ok(audit_refusal(&tool));
+        }
+
+        let cell = Arc::new(AuditCell::default());
+        context.extensions.insert(Arc::clone(&cell));
+        let result = self
+            .tool_router
+            .call(ToolCallContext::new(self, request, context))
+            .await;
+
+        // Exactly one record per call, whatever `result` is — including
+        // an unknown tool or another protocol error from the router.
+        let upstream = cell.take_upstream();
+        let guard = cell.into_guard_info(audit.policy_hash.as_deref(), audit.sink.suppressed_ids());
+        let guard_verdict = guard.as_ref().map(|g| g.verdict);
+        let class = match &result {
+            // A guard denial is a well-formed response (the uniform
+            // denial text): its `is_error` marker classifies the
+            // content, not the call, so the outcome stays `ok` and the
+            // denial lives in guard.verdict.
+            Ok(r) if r.is_error == Some(true) && guard_verdict != Some(Verdict::Denied) => {
+                audit::OutcomeClass::Refused
+            }
+            Ok(_) => audit::OutcomeClass::Ok,
+            Err(_) => audit::OutcomeClass::Error,
+        };
+        let event = audit::AuditEventKind::ToolCall(Box::new(audit::ToolCallEvent {
+            client,
+            trace: None,
+            request: audit::RequestInfo {
+                tool: tool.clone(),
+                id: request_id,
+                params,
+            },
+            guard,
+            upstream,
+            outcome: audit::OutcomeInfo {
+                class,
+                duration_ms: elapsed_ms(started),
+            },
+        }));
+        match record_event(&audit, event, session).await {
+            // Persisted before the response is returned.
+            Ok(_) => result,
+            Err(()) => match (audit.fail_mode, &result) {
+                // A protocol error from the router stands under every
+                // mode: the record was attempted, an unknown tool is
+                // unknown with or without auditing, and swapping the
+                // error for a tool-level refusal would CREATE a
+                // distinguisher that exists only during an audit outage.
+                (_, Err(_)) => result,
+                // The sink has rate-limit-logged the failure; the gap
+                // marker accounts for the loss after recovery.
+                (FailMode::Open, _) => result,
+                (FailMode::ClosedWritesDenials, _)
+                    if WRITE_TOOLS.contains(&tool.as_str())
+                        || matches!(
+                            guard_verdict,
+                            Some(Verdict::Denied | Verdict::Refused | Verdict::ServedFiltered)
+                        ) =>
+                {
+                    Ok(audit_refusal(&tool))
+                }
+                // A read the guard fully allowed serves unaudited.
+                (FailMode::ClosedWritesDenials, _) => result,
+                (FailMode::ClosedAll, _) => Ok(audit_refusal(&tool)),
+            },
+        }
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        Ok(ListToolsResult {
+            tools: self.tool_router.list_all(),
+            meta: None,
+            next_cursor: None,
+        })
+    }
+
+    fn get_tool(&self, name: &str) -> Option<Tool> {
+        self.tool_router.get(name).cloned()
+    }
+
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::from_build_env())
@@ -2107,6 +2753,28 @@ mod tests {
     }
 
     #[test]
+    fn get_tool_serves_the_pruned_instance_router_i13() {
+        // The definition lookup must consult the INSTANCE router `new`
+        // pruned, not a freshly built default one: a stripped tool has no
+        // definition to serve, exactly as it has no route to call.
+        let (cfg, guard, bz) =
+            parts("[global]\nread_only = true\ndisabled_tools = [\"bug_history\"]\n");
+        let server = BugWarden::new(cfg, guard, bz).expect("server builds");
+        assert!(
+            server.get_tool("add_comment").is_none(),
+            "a write tool stripped by read-only mode has no definition (I13)"
+        );
+        assert!(
+            server.get_tool("bug_history").is_none(),
+            "a policy-disabled tool has no definition (I13)"
+        );
+        assert!(
+            server.get_tool("bug_info").is_some(),
+            "a live tool keeps its definition"
+        );
+    }
+
+    #[test]
     fn decoded_len_counts_decoded_bytes_exactly() {
         assert_eq!(decoded_len(""), 0);
         assert_eq!(decoded_len("YQ=="), 1); // "a"
@@ -2156,5 +2824,384 @@ mod tests {
         assert!(!is_inline_image("application/octet-stream"));
         assert!(!is_inline_image("image/"));
         assert!(!is_inline_image("imagexpng"));
+    }
+
+    // ---------- audit wiring ----------
+
+    #[test]
+    fn audit_refusal_map_covers_every_tool_in_the_full_router() {
+        // Iterated over the FULL (unpruned) router on purpose: a new tool
+        // must get its uniform refusal text before it can ship, or an
+        // audit outage would answer it with the generic fallback — a
+        // brand-new fingerprint.
+        let tools = BugWarden::tool_router().list_all();
+        assert!(!tools.is_empty(), "the full router lists the tool surface");
+        for tool in tools {
+            assert!(
+                audit_refusal_text(&tool.name).is_some(),
+                "tool {} has no audit refusal mapping — add its uniform \
+                 failure text to audit_refusal_text",
+                tool.name
+            );
+        }
+        assert_eq!(
+            audit_refusal_text("no_such_tool"),
+            None,
+            "unknown names take the generic fallback"
+        );
+    }
+
+    #[test]
+    fn allowlist_reduces_free_text_to_length_only() {
+        let args = json!({
+            "bug_id": 7,
+            "is_private": true,
+            "comment": "definitely secret text",
+            "custom_fields": { "cf_fixed_in": "also withheld" },
+        });
+        let Value::Object(obj) = args else {
+            unreachable!()
+        };
+        let params = allowlisted(Some(&obj));
+        assert_eq!(params["bug_id"], json!(7));
+        assert_eq!(params["is_private"], json!(true));
+        let comment_len = serde_json::to_vec(&json!("definitely secret text"))
+            .unwrap()
+            .len();
+        assert_eq!(params["comment"], json!({ "_len": comment_len }));
+        let flat = serde_json::to_string(&params).unwrap();
+        assert!(!flat.contains("secret"), "free text leaked: {flat}");
+        assert!(!flat.contains("withheld"), "custom field leaked: {flat}");
+    }
+
+    #[test]
+    fn allowlist_truncates_long_strings_at_1024_chars() {
+        let obj: JsonObject = serde_json::from_value(json!({ "query": "q".repeat(5000) })).unwrap();
+        let params = allowlisted(Some(&obj));
+        assert_eq!(params["query"].as_str().unwrap().chars().count(), 1024);
+        // Strings inside allowlisted lists are capped the same way.
+        let obj: JsonObject =
+            serde_json::from_value(json!({ "keywords": ["k".repeat(2000)] })).unwrap();
+        let params = allowlisted(Some(&obj));
+        assert_eq!(params["keywords"][0].as_str().unwrap().len(), 1024);
+        // A short value is passed through untouched.
+        let obj: JsonObject = serde_json::from_value(json!({ "query": "kernel" })).unwrap();
+        assert_eq!(allowlisted(Some(&obj))["query"], json!("kernel"));
+    }
+
+    // The fail-mode scope tests below drive a REAL sink into failure via
+    // its cfg(test) injection hook, which integration tests cannot reach;
+    // everything else is the production path: a real MCP session over an
+    // in-memory duplex transport against a wiremock Bugzilla.
+
+    use crate::audit::{AuditConfig, AuditEvent, AuditEventKind, AuditSink};
+    use rmcp::service::{RoleClient, RunningService};
+    use rmcp::ServiceExt as _;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn audit_state(
+        dir: &std::path::Path,
+        fail_mode: FailMode,
+    ) -> (Arc<AuditState>, std::path::PathBuf) {
+        let path = dir.join("audit.jsonl");
+        let sink = AuditSink::open(AuditConfig {
+            path: path.clone(),
+            fsync: false,
+            fail_mode: None,
+            rotate_max_bytes: 0,
+            rotate_keep: 8,
+            suppressed_ids: true,
+        })
+        .expect("audit sink must open");
+        (Arc::new(AuditState::new(sink, fail_mode, None)), path)
+    }
+
+    fn read_audit_events(path: &std::path::Path) -> Vec<AuditEvent> {
+        let s = std::fs::read_to_string(path).expect("audit file must be readable");
+        s.lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| serde_json::from_str(l).expect("every audit line must parse"))
+            .collect()
+    }
+
+    /// Serve a [`BugWarden`] against `mock` over an in-memory duplex
+    /// transport, optionally audited, and connect an MCP client.
+    async fn mcp_client(
+        policy: &str,
+        mock_uri: &str,
+        audit: Option<Arc<AuditState>>,
+    ) -> RunningService<RoleClient, ()> {
+        use clap::Parser as _;
+        let cfg = Arc::new(Cli::parse_from([
+            "bugwarden",
+            "--bugzilla-server",
+            mock_uri,
+            "--transport",
+            "stdio",
+            "--api-key",
+            "test-key",
+        ]));
+        let guard = Arc::new(Guard {
+            policy: Policy::from_toml_str(policy).expect("test policy must parse"),
+        });
+        let bz = Arc::new(BugzillaClient::new(mock_uri, false).expect("client must build"));
+        let mut server = BugWarden::new(cfg, guard, bz).expect("server must build");
+        if let Some(audit) = audit {
+            server = server.with_audit(audit);
+        }
+        let (client_io, server_io) = tokio::io::duplex(1 << 16);
+        tokio::spawn(async move {
+            if let Ok(running) = server.serve(server_io).await {
+                let _ = running.waiting().await;
+            }
+        });
+        ().serve(client_io)
+            .await
+            .expect("MCP handshake must succeed")
+    }
+
+    async fn call(
+        client: &RunningService<RoleClient, ()>,
+        tool: &str,
+        args: Value,
+    ) -> CallToolResult {
+        let Value::Object(args) = args else {
+            panic!("tool arguments must be a JSON object");
+        };
+        client
+            .call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(args))
+            .await
+            .expect("tool call must not be a protocol error")
+    }
+
+    fn text_of(result: &CallToolResult) -> String {
+        result
+            .content
+            .iter()
+            .filter_map(|c| c.as_text())
+            .map(|t| t.text.as_str())
+            .collect()
+    }
+
+    fn is_error(result: &CallToolResult) -> bool {
+        result.is_error == Some(true)
+    }
+
+    fn world_bug(id: u64) -> Value {
+        json!({
+            "id": id,
+            "summary": "a plain bug",
+            "product": "openSUSE",
+            "component": "Kernel",
+            "status": "NEW",
+            "severity": "normal",
+            "priority": "P3",
+            "keywords": [],
+            "groups": [],
+            "whiteboard": "",
+            "creation_time": "2020-01-01T00:00:00Z",
+        })
+    }
+
+    /// Classify/full fetches for bug 7, the empty id=0 padding fetch, an
+    /// empty history, and a comment thread with one private comment.
+    async fn mount_bug7(mock: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/rest/bug"))
+            .and(query_param("id", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+            .mount(mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/bug"))
+            .and(query_param("id", "7"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "bugs": [world_bug(7)] })),
+            )
+            .mount(mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/bug/7/history"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "bugs": [{ "history": [] }] })),
+            )
+            .mount(mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/bug/7/comment"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "bugs": { "7": { "comments": [
+                    { "id": 1, "bug_id": 7, "is_private": false, "text": "public" },
+                    { "id": 2, "bug_id": 7, "is_private": true, "text": "private" },
+                ] } }
+            })))
+            .mount(mock)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn closed_all_gates_pre_dispatch_once_the_sink_is_failing() {
+        let mock = MockServer::start().await;
+        mount_bug7(&mock).await;
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::ClosedAll);
+        let client = mcp_client("", &mock.uri(), Some(Arc::clone(&audit))).await;
+
+        // Healthy sink: a granted read serves and is recorded.
+        let served = call(&client, "bug_history", json!({ "id": 7 })).await;
+        assert!(!is_error(&served), "healthy sink must serve");
+
+        audit.sink.set_fail_writes(true);
+        // The outage is discovered ON the response path: the tool ran
+        // (upstream was contacted), the record failed, and the response
+        // became the mapped refusal — the write sits on the response path.
+        let discovered = call(&client, "bug_history", json!({ "id": 7 })).await;
+        assert!(is_error(&discovered));
+        assert_eq!(text_of(&discovered), "Failed to fetch bug history");
+        let after_discovery = mock.received_requests().await.unwrap().len();
+
+        // From now on the gate closes BEFORE dispatch: no new upstream
+        // request, same refusal text.
+        let gated = call(&client, "bug_history", json!({ "id": 7 })).await;
+        assert!(is_error(&gated));
+        assert_eq!(text_of(&gated), "Failed to fetch bug history");
+        assert_eq!(
+            mock.received_requests().await.unwrap().len(),
+            after_discovery,
+            "the pre-dispatch gate must not contact upstream"
+        );
+
+        // On disk: only the healthy-phase records made it.
+        let events = read_audit_events(&audit_path);
+        assert_eq!(events.len(), 2, "initialize + the served call");
+    }
+
+    #[tokio::test]
+    async fn closed_writes_denials_scopes_refusal_to_writes_and_non_clean_reads() {
+        let mock = MockServer::start().await;
+        mount_bug7(&mock).await;
+        Mock::given(method("POST"))
+            .and(path("/rest/bug/7/comment"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 11 })))
+            .expect(0)
+            .mount(&mock)
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::ClosedWritesDenials);
+        // Failing from the very start; the initialize record is lost but
+        // the handshake proceeds (only closed_all refuses it).
+        audit.sink.set_fail_writes(true);
+        let client = mcp_client("", &mock.uri(), Some(Arc::clone(&audit))).await;
+
+        // A read the guard fully allows serves unaudited.
+        let served = call(&client, "bug_history", json!({ "id": 7 })).await;
+        assert!(!is_error(&served), "a clean read must serve unaudited");
+
+        // A write refuses BEFORE any upstream request (the sink is
+        // already failing, so the gate closes pre-dispatch: no classify,
+        // no POST).
+        let before_write = mock.received_requests().await.unwrap().len();
+        let write = call(
+            &client,
+            "add_comment",
+            json!({ "bug_id": 7, "comment": "hi" }),
+        )
+        .await;
+        assert!(is_error(&write));
+        assert_eq!(text_of(&write), "Failed to create a comment");
+        assert_eq!(
+            mock.received_requests().await.unwrap().len(),
+            before_write,
+            "a gated write must not contact upstream at all"
+        );
+
+        // A read whose guard suppressed something (a private comment
+        // filtered out) refuses.
+        let filtered = call(&client, "bug_comments", json!({ "id": 7 })).await;
+        assert!(is_error(&filtered));
+        assert_eq!(text_of(&filtered), "Failed to fetch bug comments");
+
+        // Recovery: the unaudited work shows up as the gap marker's drop
+        // count — initialize, the served read, the gated write's refusal
+        // record, and the filtered read.
+        audit.sink.set_fail_writes(false);
+        let again = call(&client, "bug_history", json!({ "id": 7 })).await;
+        assert!(!is_error(&again));
+        let events = read_audit_events(&audit_path);
+        assert_eq!(events.len(), 2, "gap marker + the recovered call");
+        match &events[0].kind {
+            AuditEventKind::AuditGap(gap) => assert_eq!(gap.dropped, 4),
+            other => panic!("expected audit_gap first after recovery, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn responses_byte_identical_with_audit_off_on_and_failing_open() {
+        // The same call sequence — a denial, a filtered read, a write —
+        // against one upstream, through three servers: audit off, audit
+        // on, audit failing under fail_mode = open. The client-visible
+        // results must serialize byte-identically (I15).
+        let policy = concat!(
+            "[[rule]]\nname = \"hide-secret\"\naction = \"deny\"\n",
+            "[rule.match]\nproducts = [\"Secret*\"]\n",
+        );
+        let mock = MockServer::start().await;
+        mount_bug7(&mock).await;
+        let mut secret = world_bug(99);
+        secret["product"] = json!("SecretSauce");
+        Mock::given(method("GET"))
+            .and(path("/rest/bug"))
+            .and(query_param("id", "99"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [secret] })))
+            .mount(&mock)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/rest/bug/7/comment"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 11 })))
+            .mount(&mock)
+            .await;
+
+        let client_off = mcp_client(policy, &mock.uri(), None).await;
+        let dir_on = tempfile::tempdir().unwrap();
+        let (audit_on, _) = audit_state(dir_on.path(), FailMode::Open);
+        let client_on = mcp_client(policy, &mock.uri(), Some(audit_on)).await;
+        let dir_fail = tempfile::tempdir().unwrap();
+        let (audit_fail, fail_path) = audit_state(dir_fail.path(), FailMode::Open);
+        audit_fail.sink.set_fail_writes(true);
+        let client_fail = mcp_client(policy, &mock.uri(), Some(Arc::clone(&audit_fail))).await;
+
+        let sequence = [
+            ("bug_info", json!({ "bug_ids": [7, 99] })),
+            ("bug_comments", json!({ "id": 7 })),
+            ("add_comment", json!({ "bug_id": 7, "comment": "hello" })),
+        ];
+        for (tool, args) in sequence {
+            let off = call(&client_off, tool, args.clone()).await;
+            let on = call(&client_on, tool, args.clone()).await;
+            let failing = call(&client_fail, tool, args).await;
+            let off = serde_json::to_string(&off).unwrap();
+            assert_eq!(
+                off,
+                serde_json::to_string(&on).unwrap(),
+                "auditing on must not change {tool}"
+            );
+            assert_eq!(
+                off,
+                serde_json::to_string(&failing).unwrap(),
+                "a failing-open sink must not change {tool}"
+            );
+        }
+
+        // fail-open accounts for the outage in the stream itself.
+        audit_fail.sink.set_fail_writes(false);
+        let _ = call(&client_fail, "bug_comments", json!({ "id": 7 })).await;
+        let events = read_audit_events(&fail_path);
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e.kind, AuditEventKind::AuditGap(_))),
+            "a gap marker must follow recovery"
+        );
     }
 }

--- a/crates/bugwarden/tests/audit_wiremock.rs
+++ b/crates/bugwarden/tests/audit_wiremock.rs
@@ -1,0 +1,703 @@
+//! End-to-end tests of the audit stream against a mock Bugzilla.
+//!
+//! Each test builds a real [`BugWarden`] with auditing enabled, serves it
+//! over an in-memory duplex transport, and calls the tools through an rmcp
+//! MCP client — the same dispatch path a production client takes, so the
+//! record-per-call guarantee is proven where it is enforced (the handler
+//! wrapper), not in a helper. The sink writes a real JSONL file in a
+//! tempdir; every assertion about "the record exists" reads that file
+//! immediately after the call future resolves, which is the
+//! persisted-before-response guarantee exercised end to end.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use bugwarden::audit::{
+    AuditConfig, AuditEvent, AuditEventKind, AuditSink, AuditState, FailMode, OutcomeClass,
+    TransportKind, Verdict,
+};
+use bugwarden::config::Cli;
+use bugwarden::server::BugWarden;
+use bugwarden_core::client::BugzillaClient;
+use bugwarden_core::guard::Guard;
+use bugwarden_core::policy::Policy;
+use clap::Parser as _;
+use rmcp::model::{CallToolRequestParams, CallToolResult};
+use rmcp::service::{RoleClient, RunningService};
+use rmcp::ServiceExt as _;
+use serde_json::{json, Value};
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A served, audited server plus the handles the assertions need.
+struct Audited {
+    client: RunningService<RoleClient, ()>,
+    audit_path: PathBuf,
+    /// Owns the audit directory for the test's lifetime.
+    _dir: tempfile::TempDir,
+}
+
+/// Serve a [`BugWarden`] built from `policy` with auditing on
+/// (fail_mode = open, so nothing in here depends on refusal behavior),
+/// and connect an MCP client over an in-memory duplex transport.
+async fn audited_client_for(policy: &str, mock: &MockServer, api_key: &str) -> Audited {
+    audited_client_with(policy, mock, api_key, true).await
+}
+
+/// As [`audited_client_for`], with the `suppressed_ids` record knob under
+/// the test's control.
+async fn audited_client_with(
+    policy: &str,
+    mock: &MockServer,
+    api_key: &str,
+    suppressed_ids: bool,
+) -> Audited {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let audit_path = dir.path().join("audit.jsonl");
+    let sink = AuditSink::open(AuditConfig {
+        path: audit_path.clone(),
+        fsync: false,
+        fail_mode: None,
+        rotate_max_bytes: 0,
+        rotate_keep: 8,
+        suppressed_ids,
+    })
+    .expect("audit sink must open");
+    let audit = Arc::new(AuditState::new(
+        sink,
+        FailMode::Open,
+        Some("sha256:policy-under-test".to_string()),
+    ));
+
+    let cfg = Arc::new(Cli::parse_from([
+        "bugwarden",
+        "--bugzilla-server",
+        &mock.uri(),
+        "--transport",
+        "stdio",
+        "--api-key",
+        api_key,
+    ]));
+    let guard = Arc::new(Guard {
+        policy: Policy::from_toml_str(policy).expect("test policy must parse"),
+    });
+    let bz = Arc::new(BugzillaClient::new(&mock.uri(), false).expect("client must build"));
+    let server = BugWarden::new(cfg, guard, bz)
+        .expect("server must build")
+        .with_audit(audit);
+
+    let (client_io, server_io) = tokio::io::duplex(1 << 16);
+    tokio::spawn(async move {
+        if let Ok(running) = server.serve(server_io).await {
+            let _ = running.waiting().await;
+        }
+    });
+    let client = ().serve(client_io).await.expect("MCP handshake must succeed");
+    Audited {
+        client,
+        audit_path,
+        _dir: dir,
+    }
+}
+
+/// An un-audited server over the same transport, for comparisons.
+async fn plain_client_for(policy: &str, mock: &MockServer) -> RunningService<RoleClient, ()> {
+    let cfg = Arc::new(Cli::parse_from([
+        "bugwarden",
+        "--bugzilla-server",
+        &mock.uri(),
+        "--transport",
+        "stdio",
+        "--api-key",
+        "test-key",
+    ]));
+    let guard = Arc::new(Guard {
+        policy: Policy::from_toml_str(policy).expect("test policy must parse"),
+    });
+    let bz = Arc::new(BugzillaClient::new(&mock.uri(), false).expect("client must build"));
+    let server = BugWarden::new(cfg, guard, bz).expect("server must build");
+    let (client_io, server_io) = tokio::io::duplex(1 << 16);
+    tokio::spawn(async move {
+        if let Ok(running) = server.serve(server_io).await {
+            let _ = running.waiting().await;
+        }
+    });
+    ().serve(client_io)
+        .await
+        .expect("MCP handshake must succeed")
+}
+
+async fn call(client: &RunningService<RoleClient, ()>, tool: &str, args: Value) -> CallToolResult {
+    let Value::Object(args) = args else {
+        panic!("tool arguments must be a JSON object");
+    };
+    client
+        .call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(args))
+        .await
+        .expect("tool call must not be a protocol error")
+}
+
+/// Parse every line of the audit file (empty lines skipped, as the sink's
+/// self-healing documents).
+fn read_events(path: &Path) -> Vec<AuditEvent> {
+    let s = std::fs::read_to_string(path).expect("audit file must be readable");
+    s.lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str(l).expect("every audit line must parse as AuditEvent"))
+        .collect()
+}
+
+fn last_tool_call(events: &[AuditEvent]) -> &bugwarden::audit::ToolCallEvent {
+    match &events.last().expect("at least one event").kind {
+        AuditEventKind::ToolCall(tc) => tc,
+        other => panic!("expected a tool_call record, got {other:?}"),
+    }
+}
+
+fn world_bug(id: u64) -> Value {
+    json!({
+        "id": id,
+        "summary": "a plain bug",
+        "product": "openSUSE",
+        "component": "Kernel",
+        "status": "NEW",
+        "severity": "normal",
+        "priority": "P3",
+        "keywords": [],
+        "groups": [],
+        "whiteboard": "",
+        "creation_time": "2020-01-01T00:00:00Z",
+    })
+}
+
+/// Mount a full fixture upstream: bug 7 (classify + bodies), the id=0
+/// padding fetch, history/comments/attachments for 7, attachment 55,
+/// write endpoints, server-info endpoints, and the quicksearch doc page.
+/// Mounted so that every routed tool has a workable happy path.
+async fn mount_fixture(mock: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .mount(mock)
+        .await;
+    // Catch-all for /rest/bug: classification and body fetches for id=7
+    // and the quicksearch scan all serve bug 7.
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [world_bug(7)] })))
+        .mount(mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/7/history"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "bugs": [{ "history": [] }] })),
+        )
+        .mount(mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/7/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "bugs": { "7": { "comments": [
+                { "id": 1, "bug_id": 7, "is_private": false, "text": "public comment" },
+            ] } }
+        })))
+        .mount(mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/7/attachment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": { "7": [] } })))
+        .mount(mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/attachment/55"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "attachments": { "55": {
+                "id": 55,
+                "bug_id": 7,
+                "is_private": false,
+                "size": 3,
+                "file_name": "log.txt",
+                "content_type": "text/plain",
+                "data": "QUFB",
+            } }
+        })))
+        .mount(mock)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/7"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .mount(mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/7/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 11 })))
+        .mount(mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/7/attachment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "ids": [31] })))
+        .mount(mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 4242 })))
+        .mount(mock)
+        .await;
+    for (endpoint, body) in [
+        ("/rest/version", json!({ "version": "5.0" })),
+        ("/rest/extensions", json!({ "extensions": {} })),
+        (
+            "/rest/time",
+            json!({ "web_time": "2026-01-01T00:00:00Z", "tz_name": "UTC" }),
+        ),
+        ("/rest/parameters", json!({ "parameters": {} })),
+    ] {
+        Mock::given(method("GET"))
+            .and(path(endpoint))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(mock)
+            .await;
+    }
+    Mock::given(method("GET"))
+        .and(path("/page.cgi"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("<html>quicksearch</html>"))
+        .mount(mock)
+        .await;
+}
+
+/// Minimal valid arguments for each routed tool against [`mount_fixture`].
+/// A new tool must be added here before the one-record-per-call test can
+/// pass.
+fn minimal_args(tool: &str) -> Value {
+    match tool {
+        "bug_info" => json!({ "bug_ids": [7] }),
+        "bug_history" => json!({ "id": 7 }),
+        "bug_comments" => json!({ "id": 7 }),
+        "bugs_quicksearch" => json!({ "query": "kernel" }),
+        "create_bug" => json!({
+            "product": "openSUSE",
+            "component": "core",
+            "summary": "crash on start",
+            "version": "1.0",
+        }),
+        "add_attachment" => json!({
+            "bug_id": 7,
+            "data": "QUFB",
+            "file_name": "log.txt",
+            "summary": "boot log",
+            "content_type": "text/plain",
+        }),
+        "add_comment" => json!({ "bug_id": 7, "comment": "hello" }),
+        "update_bug_status" => json!({ "bug_id": 7, "status": "NEW" }),
+        "assign_bug" => json!({ "bug_id": 7, "assignee": "dev@example.org" }),
+        "update_bug_fields" => json!({ "bug_id": 7, "priority": "P1" }),
+        "update_bug_dependencies" => json!({ "bug_id": 7, "blocks_add": [7] }),
+        "add_cc_to_bug" => json!({ "bug_id": 7, "cc_email": "cc@example.org" }),
+        "mark_as_duplicate" => json!({ "bug_id": 7, "duplicate_of": 7 }),
+        "list_attachments" => json!({ "bug_id": 7 }),
+        "download_attachment" => json!({ "attachment_id": 55 }),
+        "bug_url" => json!({ "bug_id": 7 }),
+        "bugzilla_server_info" => json!({}),
+        "quicksearch_syntax" => json!({}),
+        "mcp_server_info" => json!({}),
+        "summarize_bug" => json!({ "id": 7 }),
+        other => panic!("no minimal args for tool {other} — extend the map"),
+    }
+}
+
+#[tokio::test]
+async fn every_routed_tool_writes_exactly_one_record_per_call() {
+    let mock = MockServer::start().await;
+    mount_fixture(&mock).await;
+    let audited = audited_client_for("", &mock, "test-key").await;
+
+    let tools = audited
+        .client
+        .list_all_tools()
+        .await
+        .expect("list_tools must succeed");
+    assert!(!tools.is_empty(), "the router lists the tool surface");
+
+    // The handshake wrote the initialize record.
+    let mut expected = 1;
+    assert_eq!(read_events(&audited.audit_path).len(), expected);
+    for tool in &tools {
+        let _ = call(&audited.client, &tool.name, minimal_args(&tool.name)).await;
+        expected += 1;
+        // Read IMMEDIATELY after the response future resolves: the
+        // record must already be on disk (persisted before response).
+        let events = read_events(&audited.audit_path);
+        assert_eq!(
+            events.len(),
+            expected,
+            "calling {} must grow the file by exactly one record",
+            tool.name
+        );
+        assert_eq!(last_tool_call(&events).request.tool, tool.name);
+    }
+}
+
+#[tokio::test]
+async fn refusal_paths_write_exactly_one_record_each() {
+    // hide-secret first (it decides bug 99); the group_restricted rule
+    // makes may_create refuse ALL creation — the documented behaviour of
+    // such a policy.
+    let policy = concat!(
+        "[[rule]]\nname = \"hide-secret\"\naction = \"deny\"\n",
+        "[rule.match]\nproducts = [\"Secret*\"]\n",
+        "[[rule]]\nname = \"group-restricted\"\naction = \"deny\"\n",
+        "[rule.match]\ngroup_restricted = true\n",
+    );
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .mount(&mock)
+        .await;
+    let mut secret = world_bug(99);
+    secret["product"] = json!("SecretSauce");
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "99"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [secret] })))
+        .mount(&mock)
+        .await;
+    let audited = audited_client_for(policy, &mock, "test-key").await;
+
+    let mut expected = 1; // initialize
+    let mut check = |events: Vec<AuditEvent>, verdict: Verdict, rule: Option<&str>| {
+        expected += 1;
+        assert_eq!(events.len(), expected, "exactly one new record");
+        let tc = last_tool_call(&events);
+        let guard = tc.guard.as_ref().expect("the guard was consulted");
+        assert_eq!(guard.verdict, verdict);
+        assert_eq!(guard.rule.as_deref(), rule);
+    };
+
+    // too_many_ids: 26 distinct ids.
+    let ids: Vec<u64> = (1..=26).collect();
+    let refused = call(&audited.client, "bug_info", json!({ "bug_ids": ids })).await;
+    assert_eq!(refused.is_error, Some(true));
+    check(read_events(&audited.audit_path), Verdict::Refused, None);
+
+    // Empty id list.
+    let refused = call(&audited.client, "bug_info", json!({ "bug_ids": [] })).await;
+    assert_eq!(refused.is_error, Some(true));
+    check(read_events(&audited.audit_path), Verdict::Refused, None);
+
+    // A guard denial names its rule in the record — and nowhere else.
+    let denied = call(&audited.client, "bug_history", json!({ "id": 99 })).await;
+    assert_eq!(denied.is_error, Some(true));
+    check(
+        read_events(&audited.audit_path),
+        Verdict::Denied,
+        Some("hide-secret"),
+    );
+    // The denial is a well-formed response: outcome class stays ok.
+    let events = read_events(&audited.audit_path);
+    assert_eq!(last_tool_call(&events).outcome.class, OutcomeClass::Ok);
+
+    // create_bug under a group_restricted policy: refused as requested.
+    let refused = call(
+        &audited.client,
+        "create_bug",
+        json!({
+            "product": "openSUSE",
+            "component": "core",
+            "summary": "crash on start",
+            "version": "1.0",
+        }),
+    )
+    .await;
+    assert_eq!(refused.is_error, Some(true));
+    check(read_events(&audited.audit_path), Verdict::Refused, None);
+}
+
+#[tokio::test]
+async fn unknown_and_stripped_tools_error_identically_and_still_record() {
+    let mock = MockServer::start().await;
+    let read_only = "[global]\nread_only = true\n";
+    let audited = audited_client_for(read_only, &mock, "test-key").await;
+    let plain = plain_client_for(read_only, &mock).await;
+
+    // Unknown tool: the same protocol error with auditing on or off,
+    // plus exactly one record with outcome error.
+    let with_audit = audited
+        .client
+        .call_tool(CallToolRequestParams::new("no_such_tool".to_string()))
+        .await
+        .expect_err("unknown tool is a protocol error");
+    let without = plain
+        .call_tool(CallToolRequestParams::new("no_such_tool".to_string()))
+        .await
+        .expect_err("unknown tool is a protocol error");
+    assert_eq!(
+        format!("{with_audit:?}"),
+        format!("{without:?}"),
+        "auditing must not change the protocol error"
+    );
+    let events = read_events(&audited.audit_path);
+    assert_eq!(events.len(), 2, "initialize + the failed call");
+    let tc = last_tool_call(&events);
+    assert_eq!(tc.request.tool, "no_such_tool");
+    assert_eq!(tc.outcome.class, OutcomeClass::Error);
+    assert!(tc.guard.is_none(), "no guard ran for an unknown tool");
+
+    // A write tool stripped by read-only mode (I13) is an unknown tool.
+    let with_audit = audited
+        .client
+        .call_tool(
+            CallToolRequestParams::new("add_comment".to_string()).with_arguments(
+                serde_json::Map::from_iter([
+                    ("bug_id".to_string(), json!(7)),
+                    ("comment".to_string(), json!("hi")),
+                ]),
+            ),
+        )
+        .await
+        .expect_err("a stripped tool is a protocol error");
+    let without = plain
+        .call_tool(
+            CallToolRequestParams::new("add_comment".to_string()).with_arguments(
+                serde_json::Map::from_iter([
+                    ("bug_id".to_string(), json!(7)),
+                    ("comment".to_string(), json!("hi")),
+                ]),
+            ),
+        )
+        .await
+        .expect_err("a stripped tool is a protocol error");
+    assert_eq!(format!("{with_audit:?}"), format!("{without:?}"));
+    let events = read_events(&audited.audit_path);
+    assert_eq!(events.len(), 3, "one more record for the stripped call");
+    let tc = last_tool_call(&events);
+    assert_eq!(tc.request.tool, "add_comment");
+    assert_eq!(tc.outcome.class, OutcomeClass::Error);
+    // The comment body is not allowlisted even on this path.
+    assert_eq!(tc.request.params["comment"], json!({ "_len": 4 }));
+}
+
+/// Policy hiding every bug in a `Secret*` product.
+const HIDE_SECRET_POLICY: &str = concat!(
+    "[[rule]]\nname = \"hide-secret\"\naction = \"deny\"\n",
+    "[rule.match]\nproducts = [\"Secret*\"]\n",
+);
+
+/// Bug 7 names the [`HIDE_SECRET_POLICY`]-hidden bug 666 twice: its
+/// `depends_on` links it, and its history records the link being added.
+/// Both are I14 scrub sites, so both must enrich the record.
+async fn mount_hidden_link(mock: &MockServer) {
+    let mut linked = world_bug(7);
+    linked["depends_on"] = json!([666]);
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "7"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [linked] })))
+        .mount(mock)
+        .await;
+    let mut secret = world_bug(666);
+    secret["product"] = json!("SecretSauce");
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "666"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [secret] })))
+        .mount(mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/7/history"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "bugs": [{ "history": [{
+                "when": "2020-01-02T00:00:00Z",
+                "who": "dev@example.org",
+                "changes": [
+                    { "field_name": "depends_on", "added": "666", "removed": "" },
+                ],
+            }] }]
+        })))
+        .mount(mock)
+        .await;
+}
+
+#[tokio::test]
+async fn suppressed_ids_reach_the_log_never_the_envelope() {
+    // Bug 7 depends on the policy-hidden bug 666: I14 scrubs the link
+    // from the served envelope; the audit record carries the id.
+    let mock = MockServer::start().await;
+    mount_hidden_link(&mock).await;
+    let audited = audited_client_for(HIDE_SECRET_POLICY, &mock, "test-key").await;
+
+    let result = call(&audited.client, "bug_info", json!({ "bug_ids": [7] })).await;
+    assert_ne!(result.is_error, Some(true), "bug 7 itself is served");
+    let envelope = serde_json::to_string(&result).unwrap();
+    assert!(
+        !envelope.contains("666"),
+        "the hidden id must be scrubbed from the client envelope (I14): {envelope}"
+    );
+
+    let events = read_events(&audited.audit_path);
+    let tc = last_tool_call(&events);
+    let guard = tc.guard.as_ref().expect("guard info recorded");
+    assert_eq!(guard.verdict, Verdict::ServedFiltered);
+    assert!(
+        guard.suppressed_ids.contains(&666),
+        "the audit record must carry the suppressed id: {:?}",
+        guard.suppressed_ids
+    );
+    assert!(guard.suppressed_count >= 1);
+    assert_eq!(
+        guard.policy_hash.as_deref(),
+        Some("sha256:policy-under-test"),
+        "records tie to the policy in force"
+    );
+
+    // The history of bug 7 names 666 too: the scrub site is a different
+    // one, and its record must carry the id all the same.
+    let result = call(&audited.client, "bug_history", json!({ "id": 7 })).await;
+    assert_ne!(result.is_error, Some(true), "the history itself is served");
+    let envelope = serde_json::to_string(&result).unwrap();
+    assert!(
+        !envelope.contains("666"),
+        "the hidden id must be scrubbed from the served history (I14): {envelope}"
+    );
+    let events = read_events(&audited.audit_path);
+    let tc = last_tool_call(&events);
+    assert_eq!(tc.request.tool, "bug_history");
+    let guard = tc.guard.as_ref().expect("guard info recorded");
+    assert!(
+        guard.suppressed_ids.contains(&666),
+        "the bug_history record must carry the scrubbed id: {:?}",
+        guard.suppressed_ids
+    );
+}
+
+#[tokio::test]
+async fn suppressed_ids_off_records_the_count_never_the_ids() {
+    // The same scenario with `suppressed_ids = false` in the audit config:
+    // the record still counts the suppression but names no id — and the
+    // served envelope is exactly as clean as with the knob on.
+    let mock = MockServer::start().await;
+    mount_hidden_link(&mock).await;
+    let audited = audited_client_with(HIDE_SECRET_POLICY, &mock, "test-key", false).await;
+
+    let result = call(&audited.client, "bug_info", json!({ "bug_ids": [7] })).await;
+    assert_ne!(result.is_error, Some(true), "bug 7 itself is served");
+    let envelope = serde_json::to_string(&result).unwrap();
+    assert!(
+        !envelope.contains("666"),
+        "the hidden id must be scrubbed from the client envelope (I14): {envelope}"
+    );
+
+    let events = read_events(&audited.audit_path);
+    let tc = last_tool_call(&events);
+    let guard = tc.guard.as_ref().expect("guard info recorded");
+    assert_eq!(guard.verdict, Verdict::ServedFiltered);
+    assert!(
+        guard.suppressed_count >= 1,
+        "the count survives the elision: {guard:?}"
+    );
+    assert!(
+        guard.suppressed_ids.is_empty(),
+        "ids are elided when the knob is off: {:?}",
+        guard.suppressed_ids
+    );
+}
+
+#[tokio::test]
+async fn canary_content_never_reaches_the_audit_file() {
+    const KEY_CANARY: &str = "canary-api-key-5c9e02";
+    const SUMMARY_CANARY: &str = "canary-summary-77aa01";
+    const COMMENT_CANARY: &str = "canary-comment-b3f604";
+    const OUTGOING_CANARY: &str = "canary-outgoing-19dd08";
+
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .mount(&mock)
+        .await;
+    let mut bug = world_bug(7);
+    bug["summary"] = json!(SUMMARY_CANARY);
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "7"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [bug] })))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/7/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "bugs": { "7": { "comments": [
+                { "id": 1, "bug_id": 7, "is_private": false, "text": COMMENT_CANARY },
+            ] } }
+        })))
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/7/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 11 })))
+        .mount(&mock)
+        .await;
+    let audited = audited_client_for("", &mock, KEY_CANARY).await;
+
+    let _ = call(&audited.client, "bug_info", json!({ "bug_ids": [7] })).await;
+    let _ = call(&audited.client, "bug_comments", json!({ "id": 7 })).await;
+    let _ = call(
+        &audited.client,
+        "add_comment",
+        json!({ "bug_id": 7, "comment": OUTGOING_CANARY }),
+    )
+    .await;
+
+    let raw = std::fs::read_to_string(&audited.audit_path).expect("audit file readable");
+    for canary in [KEY_CANARY, SUMMARY_CANARY, COMMENT_CANARY, OUTGOING_CANARY] {
+        assert!(
+            !raw.contains(canary),
+            "canary {canary} leaked into the audit file"
+        );
+    }
+    // The outgoing comment appears as presence + size only.
+    let events = read_events(&audited.audit_path);
+    let tc = last_tool_call(&events);
+    assert_eq!(tc.request.tool, "add_comment");
+    let expected_len = serde_json::to_vec(&json!(OUTGOING_CANARY)).unwrap().len();
+    assert_eq!(
+        tc.request.params["comment"],
+        json!({ "_len": expected_len })
+    );
+}
+
+#[tokio::test]
+async fn initialize_writes_exactly_one_record_with_the_client_identity() {
+    // Recorded unconditionally: auditing on means session starts are in
+    // the stream — there is no configuration knob that turns this off.
+    let mock = MockServer::start().await;
+    let audited = audited_client_for("", &mock, "test-key").await;
+
+    let events = read_events(&audited.audit_path);
+    assert_eq!(events.len(), 1, "the handshake writes exactly one record");
+    let init = match &events[0].kind {
+        AuditEventKind::Initialize(init) => init,
+        other => panic!("expected an initialize record, got {other:?}"),
+    };
+    assert!(
+        init.client.name.as_deref().is_some_and(|n| !n.is_empty()),
+        "client name recorded: {init:?}"
+    );
+    assert!(
+        init.client.version.is_some(),
+        "client version recorded: {init:?}"
+    );
+    assert!(
+        init.protocol_version.is_some(),
+        "protocol version recorded: {init:?}"
+    );
+    // Session info anchors the stdio session to the process.
+    assert_eq!(events[0].session.transport, TransportKind::Stdio);
+    let id = events[0].session.id.as_deref().expect("stdio session id");
+    let (pid, _) = id.split_once('-').expect("session id is <pid>-<epoch>");
+    assert_eq!(pid, std::process::id().to_string());
+    assert_eq!(events[0].session.remote, None);
+}

--- a/crates/bugwarden/tests/tools_wiremock.rs
+++ b/crates/bugwarden/tests/tools_wiremock.rs
@@ -20,7 +20,7 @@
 use std::sync::Arc;
 
 use bugwarden::config::Cli;
-use bugwarden::server::BugWarden;
+use bugwarden::server::{BugWarden, WRITE_TOOLS};
 use bugwarden_core::client::BugzillaClient;
 use bugwarden_core::guard::Guard;
 use bugwarden_core::policy::Policy;
@@ -671,4 +671,49 @@ async fn add_attachment_comment_travels_as_a_plain_string() {
     let result = call(&client, "add_attachment", args).await;
     assert!(!is_error(&result), "result: {}", text_of(&result));
     assert!(text_of(&result).contains("55"));
+}
+
+/// Tool names a client sees when it lists the server's tools — a real
+/// `tools/list` request over the wire, so the handler's own listing path
+/// is what answers.
+async fn listed_tools(client: &RunningService<RoleClient, ()>) -> Vec<String> {
+    client
+        .list_all_tools()
+        .await
+        .expect("list_tools must succeed")
+        .into_iter()
+        .map(|t| t.name.to_string())
+        .collect()
+}
+
+#[tokio::test]
+async fn list_tools_serves_the_pruned_instance_router_i13() {
+    // The listing must come from the instance router `BugWarden::new`
+    // pruned, not a freshly built default one: a listing that resurrects
+    // stripped tools would advertise operations the policy removed (I13).
+    let mock = MockServer::start().await;
+
+    let client = client_for("[global]\nread_only = true\n", &mock).await;
+    let names = listed_tools(&client).await;
+    for tool in WRITE_TOOLS {
+        assert!(
+            !names.iter().any(|n| n == tool),
+            "read-only mode must delist write tool {tool} (I13): {names:?}"
+        );
+    }
+    assert!(
+        names.iter().any(|n| n == "bug_info"),
+        "a read tool stays listed: {names:?}"
+    );
+
+    let client = client_for("[global]\ndisabled_tools = [\"bug_history\"]\n", &mock).await;
+    let names = listed_tools(&client).await;
+    assert!(
+        !names.iter().any(|n| n == "bug_history"),
+        "a policy-disabled tool must be delisted (I13): {names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n == "bug_info"),
+        "a read tool stays listed: {names:?}"
+    );
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -85,6 +85,13 @@ Dependency direction: `bugwarden -> bugwarden-core`, never the reverse.
 - **I13** In read-only mode (policy or CLI) write tools are removed from the
   tool listing via `ToolRouter::remove_route`, not merely erroring. Same for
   `global.disabled_tools`.
+- **I15** The audit stream is never reachable through any MCP surface.
+  When auditing is enabled, every tool call produces exactly one audit
+  record, persisted before the response is returned. The API key and
+  free-text bug content are unrepresentable in the audit event type.
+  Client-visible responses are byte-identical with auditing on, off, or
+  failing — except the scoped fail-closed refusals, which reuse the tools'
+  existing uniform failure texts and never vary with the guard's verdict.
 
 ## bugwarden-core API (exact signatures)
 
@@ -474,9 +481,52 @@ clap derive `Cli`, with env fallbacks:
 | --use-auth-header | — | false | Bearer to Bugzilla instead of api_key query param |
 | --read-only | MCP_READ_ONLY | false | tighten-only (I9) |
 | --policy | BUGWARDEN_POLICY | — | path to guard policy TOML |
+| --audit-config | BUGWARDEN_AUDIT_CONFIG | — | path to audit configuration TOML; without it no audit stream is written |
 
 Startup validation: stdio without api_key => exit with error; http with
-api_key => tracing::warn (ignored).
+api_key => tracing::warn (ignored); http without audit_config =>
+tracing::warn (remote tool calls leave no audit record).
+
+## Audit stream (crates/bugwarden/src/audit.rs + the server.rs wrapper)
+
+The operator-side record of what was asked and what the guard decided —
+the counterpart of the client-side invisibility the invariants mandate.
+Decisions, all deliberate:
+
+- **One record per call (I15).** The hand-written `call_tool` owns the
+  record; tools only enrich it through a per-request cell in the request
+  extensions (verdict worst-wins merged, suppressed ids unioned). An
+  unknown tool, a protocol error, or a missed enrichment still yields
+  exactly one record — a poorer record is possible, an audit gap is not.
+  The record is persisted (sink is synchronous) before the response is
+  returned. `initialize` is always recorded, with no configuration knob
+  to turn it off; `list_tools` is not recorded in schema v1 — no event
+  kind exists for a listing, deliberately.
+- **Boundary.** Records go only to the operator's JSONL file (0600,
+  parent 0700) — never stderr, never any MCP surface. The schema has no
+  field that could carry the API key or free-text bug content; client
+  parameters pass a key allowlist (identifiers and routing/vocabulary
+  fields by value, strings capped at 1024 chars) and every other key is
+  recorded as `{"_len": N}` — presence and size, never content.
+- **Fail modes** (`fail_mode` in audit.toml): `open` keeps serving and
+  accounts for the outage with an `audit_gap` record; `closed_writes_denials`
+  refuses writes and any call where the guard suppressed, denied, or
+  refused something; `closed_all` refuses every call. Unset, the mode derives
+  from the transport: stdio → `open` (availability for a single local
+  user), http → `closed_all` (accountability for a fleet). A sink
+  already in failure also gates matching calls BEFORE dispatch, so an
+  outage cannot be farmed for unaudited upstream work.
+- **Refusals are not a fingerprint.** A fail-closed refusal reuses the
+  tool's existing uniform failure text, chosen by tool name alone; a
+  protocol error from the router stands unchanged (swapping it would
+  create an outage-only distinguisher). Every routed tool must have a
+  refusal mapping (tested against the full router).
+- **Record provenance.** `guard.policy_hash` is `sha256:<hex>` over the
+  policy file bytes, so a record ties to the exact policy that produced
+  it (`None` under the built-in default policy). stdio sessions are
+  anchored by `<pid>-<startup epoch>`; http sessions by the
+  `mcp-session-id` header, with the remote address when the listener
+  provides connect-info.
 
 ## rmcp 2.2 usage notes
 
@@ -549,5 +599,15 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   on `attach`; the upload size cap refuses before anything is POSTed; and
   the attachment `comment` travels as a plain string (Bug.add_attachment
   API shape), pinned by a wiremock body matcher.
+- Audit tests (crates/bugwarden/tests/audit_wiremock.rs + #[cfg(test)] in
+  server.rs and audit.rs): one record per call for EVERY routed tool,
+  refusal paths and protocol errors included; the refusal map is total
+  over the full router; responses byte-identical with auditing off, on,
+  and failing-open; suppressed ids in the record and never in the
+  envelope; content and API-key canaries never reach the file; the
+  fail-closed scopes (pre-dispatch gate proven by upstream request
+  counts) via the sink's cfg(test) fault injection; the transport-derived
+  fail-mode defaults bound to their documented wording; the params
+  allowlist (free text to `_len`, 1024-char truncation).
 - CI: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
   `cargo test --workspace --locked`, `cargo deny check`.

--- a/examples/audit.toml
+++ b/examples/audit.toml
@@ -20,8 +20,12 @@
 # The schema is closed: fixed structs, fixed vocabularies, and no
 # dedicated field for the Bugzilla API key, request headers, or free-text
 # bug content. The one open field, `request.params`, is fed exclusively
-# through a per-tool allowlist of client-authored values at the recording
+# through an allowlist of client-authored parameter keys at the recording
 # call site; nothing fetched FROM Bugzilla is ever written here.
+#
+# bugwarden loads this file via --audit-config or the
+# BUGWARDEN_AUDIT_CONFIG environment variable; without that flag no audit
+# stream is written.
 #
 # Parsing is strict: unknown keys anywhere in this file are a startup
 # error, so a typo cannot silently disable a setting.


### PR DESCRIPTION
Wires the audit module into the MCP request path. With `--audit-config` / `BUGWARDEN_AUDIT_CONFIG` set, every tool call produces exactly one audit record — unknown tools, read-only-stripped tools, refusals and protocol errors included — persisted before the response is returned; `initialize` records a session-start event unconditionally.

## What changed

- `#[tool_handler]` is replaced by hand-written `call_tool`, `list_tools` and `get_tool` (verified textually equivalent to the rmcp 2.2 macro expansion, dispatching through the pruned instance router — I13). `initialize` replicates the default handler's peer bookkeeping and version negotiation, then records the session event.
- An `AuditCell` in the request extensions lets the existing guard call sites enrich records with verdict (worst-wins merge), deciding rule, suppressed bug ids and redacted fields. Enrichment observes; it never changes what is served.
- Fail-mode enforcement at the wrapper: a failing sink gates further work pre-dispatch (`closed_all`: every tool; `closed_writes_denials`: write tools) so an audit outage cannot accumulate unaudited mutations; post-failure refusals reuse each tool's existing uniform failure text and never vary with the guard's verdict. Defaults derive from the transport: stdio → `open`, http → `closed_all`; explicit config wins.
- Params are recorded through a closed key allowlist (identifier/vocabulary fields only, strings capped at 1024 chars); non-allowlisted keys appear as byte lengths. The API key and free-text bug content remain unrepresentable in the event type (I12).
- `main.rs`: audit config loading, transport-derived fail-mode resolution, `policy_hash` (sha256 of the policy file bytes) stamped into every record, a prominent warning when http runs without auditing, and connect-info wiring so records carry the remote address.
- New invariant **I15** plus an audit section in `docs/DESIGN.md`; `examples/audit.toml` wording updated.

## Adversarial review

An independent adversarial review ran before this PR: line-by-line pass plus 23 gutting mutations, each expected to be killed by the suite. 20 were killed on the spot; the 3 survivors were all missing tests, not production defects, and are fixed here:

- `list_tools`/`get_tool` were not test-pinned to the pruned instance router (the unpruned `Self::tool_router()` trap survived) → new listing/lookup tests over the duplex transport against read-only and `disabled_tools` servers.
- `policy_hash` was computed inline in `main.rs` and unexecuted by tests → extracted to `policy_hash_of`, unit-bound to the FIPS 180-2 sha256("abc") vector.
- The `suppressed_ids = false` counts-only knob was unpinned through the wrapper → new wiremock test asserting empty id array with a positive count.

Also from review: bug_history now notes scrubbed link ids like the other read tools, and the `closed_writes_denials` docs were tightened to match the code (suppressed, denied, **or refused**). All formerly surviving mutations were re-applied and confirmed killed in two independent passes. Accepted review notes: guard denials record outcome class `ok` (the denial lives in `guard.verdict`, per the schema docs), and quicksearch window drops are not recorded (the accounting lives inside `bugwarden-core`, which this change does not touch — documented at the site).

## Tests

223 → 249, covering: one record per call for every routed tool; persisted-before-response; byte-identical client responses with auditing off / on / failing-open; denied ids in the log and never in the envelope (I14 tie-in); fail-closed scopes with an injected failing sink (pre-dispatch gate proven by absent upstream requests); transport-default binding; refusal-map totality over the full router; four-canary content test (API key, summary, comment body, attachment data never reach the file); initialize event identity; allowlist reduction and truncation.

All gates green: fmt, clippy `-D warnings`, full test suite, cargo-deny, typos.