### PR TITLE
fix(policy): scope rules by operation so create cannot shadow reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ is `bug_url`, which computes a URL string locally and contacts nothing.
   filtering happened at all. (Server-side debug logs do record it for the
   operator.)
 - **Fail closed.** If the classification fetch fails, if a bug is absent from
-  the response, or if a rule cannot be decided because the bug object did not
-  carry a field that rule asks about, the bug is treated as denied — never as
-  allowed.
+  the response, or if a rule consulted for the operation being decided cannot
+  be decided because the bug object did not carry a field that rule asks
+  about, the bug is treated as denied — never as allowed. (A rule scoped away
+  from the operation via `operations` is not consulted at all — scoping
+  changes which rules run, never how a consulted rule resolves.)
 - **Private-comment gate.** Private comments are returned only when the policy
   sets `allow_private_comments = true` **and** the individual call opts in
   with `include_private = true`. Either alone is not enough.
@@ -239,6 +241,13 @@ applies. Put your most specific (usually most restrictive) rules first.
 | `match` | table | `{}` (matches every bug) | Match criteria, see below |
 | `action` | `"allow"` \| `"deny"` \| `"restrict"` | *required* | `allow` grants all capabilities, `deny` grants none, `restrict` grants exactly `capabilities` |
 | `capabilities` | array of capability strings | `[]` | Only for `action = "restrict"`, where at least one is required. Must be empty/absent for `allow` and `deny` |
+| `operations` | array of `"create"` \| `"access"` | absent (rule applies to every operation) | Scopes the rule to the named operations: `create` is the create gate judging a prospective `create_bug` request, `access` is every classification of an existing bug (retrieval, search filtering, comments, history, attachments, updates). The scope is checked **before** the matcher, so a scoped rule is completely invisible to the operations it does not cover — a create-scoped rule can never hide an existing bug. An explicitly empty list is a startup error, as is a `restrict` rule whose scope and `capabilities` disagree about `create`: a rule scoped to only `create` must grant exactly the `create` capability (the create gate consults nothing else), and a rule scoped away from `create` must not grant it (nothing else consults it). Older bugwarden versions reject a policy using this key at startup (strict parsing — the file fails closed rather than being misread) |
+
+Note that a `restrict` rule's `capabilities` list is the **complete grant**
+for every operation the rule covers, not an addition to what other rules or
+`default_action` would have granted — that is why a rule granting only
+`create` should carry `operations = ["create"]`, so it decides filing without
+becoming the first-match rule for reads of the bugs it matches.
 
 #### `match` criteria
 
@@ -279,6 +288,9 @@ Two things this deliberately does *not* do. A criterion that already failed
 definitively wins over an unknown one, so a rule ruled out by another criterion
 stays ruled out. And only the fields a rule actually consults matter — a
 missing whiteboard is irrelevant to a rule that never mentions the whiteboard.
+Likewise, only the rules actually consulted matter: a rule scoped away from
+the operation being decided (`operations`) is skipped before its matcher runs,
+so its criteria cannot make anything undecidable for that operation.
 A field that is present but empty (`""`, `[]`) is knowledge, not ignorance, and
 is matched normally.
 
@@ -317,7 +329,7 @@ implied.
 | `assign` | write | changing the assignee |
 | `cc` | write | modifying the CC list |
 | `deps` | write | changing blocks/depends_on |
-| `create` | write | filing a new bug — judged against the bug *as requested*, so a rule that hides a product by name also refuses filing into it. The request's `groups` claim is never trusted (Bugzilla adds mandatory groups server-side), so **a policy whose rules consult `groups` or `group_restricted` refuses all bug filing** |
+| `create` | write | filing a new bug — judged against the bug *as requested*, so a rule that hides a product by name also refuses filing into it. The request's `groups` claim is never trusted (Bugzilla adds mandatory groups server-side), so **a rule consulting `groups` or `group_restricted` refuses every create request that reaches it** — to accept new bugs under such a policy, grant `create` in a rule scoped with `operations = ["create"]` placed before the group-consulting rules; being create-scoped, the grant leaves reads of existing bugs untouched, and without such a grant the policy refuses all bug filing |
 | `attach` | write | uploading an attachment to a bug |
 
 When the server is read-only (policy or CLI), the eight write capabilities

--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -21,7 +21,7 @@ use chrono::Utc;
 use serde_json::{Map, Value};
 
 use crate::client::{BugzillaClient, CLASSIFY_FIELDS};
-use crate::policy::{Access, BugMeta, Capability, Policy};
+use crate::policy::{Access, BugMeta, Capability, Operation, Policy};
 
 /// Fields kept by the redacted summary-only projection of a bug
 /// ([`Guard::summary_view`]). Everything else — assignee, CC, groups,
@@ -177,7 +177,10 @@ impl Guard {
             let entry = match fetched.get(&id) {
                 Some(bug) => {
                     let meta = BugMeta::from_json(bug);
-                    (self.policy.classify(&meta, now), bug.clone())
+                    (
+                        self.policy.classify(&meta, now, Operation::Access),
+                        bug.clone(),
+                    )
                 }
                 // Absent from the response: nonexistent, server-side denied,
                 // or fetch failure — all fail closed identically (I4).
@@ -397,7 +400,11 @@ impl Guard {
                     continue;
                 }
                 let meta = BugMeta::from_json(bug);
-                if self.policy.classify(&meta, now).allows(Capability::Summary) {
+                if self
+                    .policy
+                    .classify(&meta, now, Operation::Access)
+                    .allows(Capability::Summary)
+                {
                     out.insert(id);
                 }
             }
@@ -708,9 +715,19 @@ impl Guard {
     /// claiming `groups: []` would otherwise defeat a group deny rule that
     /// omitting `groups` correctly trips. The group list of a prospective
     /// bug is forced to UNKNOWN, whatever the payload said, and unknown
-    /// fails closed (I4). Consequence, deliberate: a policy whose applicable
-    /// rules consult `groups` or `group_restricted` refuses ALL creation,
-    /// because the answer cannot be known before the bug exists.
+    /// fails closed (I4). Consequence, deliberate: a rule consulting
+    /// `groups` or `group_restricted` refuses every create request that
+    /// REACHES it, because the answer cannot be known before the bug
+    /// exists — so creation is possible only where an earlier rule covering
+    /// the create operation grants `create` first, and a policy with no
+    /// such earlier grant refuses all creation.
+    ///
+    /// The request is classified for [`Operation::Create`]: a rule scoped to
+    /// `operations = ["access"]` is not consulted here, and a rule scoped to
+    /// `operations = ["create"]` exists ONLY here — which is what lets an
+    /// operator grant filing into a product ahead of the group-consulting
+    /// rules without that grant shadowing reads of the product's existing
+    /// bugs (issue #26).
     ///
     /// The prospective bug is dated NOW, so an age rule (`younger_than_days`,
     /// `min_bug_age_days`) refuses creation wherever it would immediately
@@ -724,7 +741,7 @@ impl Guard {
         // Every other field the request does not mention is unknown, not
         // empty, and classification fails closed on it (I4).
         self.policy
-            .classify(&meta, Utc::now())
+            .classify(&meta, Utc::now(), Operation::Create)
             .allows(Capability::Create)
     }
 
@@ -774,7 +791,7 @@ impl Guard {
         let mut dropped = 0usize;
         for bug in bugs {
             let meta = BugMeta::from_json(&bug);
-            let access = self.policy.classify(&meta, now);
+            let access = self.policy.classify(&meta, now, Operation::Access);
             if access.allows(Capability::Read) {
                 kept.push(bug);
             } else if access.allows(Capability::Summary) {
@@ -1620,24 +1637,93 @@ products = ["NoView*"]
     }
 
     #[test]
-    fn shipped_example_policy_parses_and_refuses_all_creation() {
-        // examples/policy.toml documents, in its header, that filing bugs is
-        // impossible under it: its first rule consults the group list, which
-        // is unknowable for a not-yet-created bug. Pin that the shipped file
-        // parses and behaves as its own comments claim. Read at runtime (not
-        // include_str!) so the core crate stays packageable without the file.
+    fn shipped_example_policy_files_into_desktop_products_only_and_keeps_reads() {
+        // examples/policy.toml promises, in its header: new bug reports are
+        // accepted into the desktop products ONLY (the create-scoped
+        // "reporters" rule), except that an embargo-marked title may not be
+        // filed anywhere; everywhere else filing is refused because the
+        // first deny rule the create gate reaches consults the unknowable
+        // group list. Pin the whole shipped contract — the accept half, the
+        // refuse half, and that the create grant stays invisible to reads
+        // of existing desktop bugs (the silent-vanishing regression of
+        // issue #26). Read at runtime (not include_str!) so the core crate
+        // stays packageable without the file.
         let path =
             std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/policy.toml");
         let toml = std::fs::read_to_string(path).expect("example policy must exist in-repo");
         let g = Guard {
             policy: policy(&toml),
         };
+
+        // Accept half: the desktop products take new bug reports.
+        assert!(
+            g.may_create(&create_request("GNOME Shell")),
+            "the example's headline: desktop products accept filings"
+        );
+        assert!(g.may_create(&create_request("KDE Frameworks")));
+
+        // ...but never with the embargo marker in the title: the
+        // create-scoped screen refuses what "undisclosed-marker" would
+        // instantly hide (no create-then-vanish).
+        let mut marked = create_request("GNOME Shell");
+        marked["summary"] = json!("EMBARGO: heap overflow in the shell");
+        assert!(
+            !g.may_create(&marked),
+            "an embargo-marked title must not be filed anywhere"
+        );
+
+        // Refuse half: everywhere else the group-consulting deny rule fails
+        // closed on the unknowable group list, whatever the request claims.
         let mut req = create_request("openSUSE");
         assert!(!g.may_create(&req), "omitted groups: refused");
         req["groups"] = json!([]);
         assert!(!g.may_create(&req), "claimed empty groups: refused");
         req["groups"] = json!(["security-team"]);
         assert!(!g.may_create(&req), "claimed groups: refused");
+
+        // Issue #26: the create grant is scoped away from access, so an
+        // existing world-readable desktop bug keeps its FULL read — under
+        // the pre-fix policy shape the same rule was first match for reads
+        // and silently revoked everything but `create`.
+        let public = BugMeta::from_json(&json!({
+            "id": 500,
+            "summary": "totem crashes when seeking in a webm file",
+            "product": "GNOME Multimedia",
+            "component": "totem",
+            "groups": [],
+            "keywords": [],
+            "whiteboard": "",
+            "status": "NEW",
+            "creation_time": "2020-01-01T00:00:00Z",
+        }));
+        assert!(
+            g.policy
+                .classify(&public, Utc::now(), Operation::Access)
+                .allows(Capability::Read),
+            "existing desktop bugs must stay fully readable"
+        );
+
+        // ...while a group-restricted desktop bug stays denied: the grant
+        // does not shadow the deny rules for reads either.
+        let restricted = BugMeta::from_json(&json!({
+            "id": 501,
+            "summary": "totem crashes when seeking in a webm file",
+            "product": "GNOME Multimedia",
+            "component": "totem",
+            "groups": ["secteam"],
+            "keywords": [],
+            "whiteboard": "",
+            "status": "NEW",
+            "creation_time": "2020-01-01T00:00:00Z",
+        }));
+        assert!(
+            matches!(
+                g.policy
+                    .classify(&restricted, Utc::now(), Operation::Access),
+                Access::Denied { .. }
+            ),
+            "group-restricted desktop bugs must stay denied"
+        );
     }
 
     #[test]
@@ -1670,7 +1756,10 @@ products = ["NoView*"]
         // The shipped file as-is: denied (the broad rule reaches it first).
         let full = policy(&toml);
         assert!(
-            matches!(full.classify(&bug, Utc::now()), Access::Denied { .. }),
+            matches!(
+                full.classify(&bug, Utc::now(), Operation::Access),
+                Access::Denied { .. }
+            ),
             "shipped policy must deny a security-group bug"
         );
 
@@ -1686,7 +1775,7 @@ products = ["NoView*"]
                 .find("[[rule]]")
                 .expect("a rule must follow the broad rule");
         let narrowed = policy(&format!("{}{}", &toml[..start], &toml[end..]));
-        match narrowed.classify(&bug, Utc::now()) {
+        match narrowed.classify(&bug, Utc::now(), Operation::Access) {
             Access::Denied { rule } => assert_eq!(
                 rule, "security-groups",
                 "the named-group rule itself must be the one denying"
@@ -1713,12 +1802,15 @@ products = ["NoView*"]
             "creation_time": "2020-01-01T00:00:00Z",
         }));
         assert!(
-            matches!(full.classify(&partner, Utc::now()), Access::Denied { .. }),
+            matches!(
+                full.classify(&partner, Utc::now(), Operation::Access),
+                Access::Denied { .. }
+            ),
             "shipped policy hides every restricted bug"
         );
         assert!(
             matches!(
-                narrowed.classify(&partner, Utc::now()),
+                narrowed.classify(&partner, Utc::now(), Operation::Access),
                 Access::Granted { .. }
             ),
             "narrowing is meant to expose non-security restricted bugs"
@@ -1783,6 +1875,125 @@ products = ["NoView*"]
     fn may_create_refuses_everything_in_read_only() {
         let g = Guard {
             policy: policy("[global]\nread_only = true\n"),
+        };
+        assert!(!g.may_create(&create_request("openSUSE")));
+    }
+
+    // ---------- operation-scoped rules (issue #26) ----------
+
+    /// The policy shape from the issue #26 reproduction, fixed: a
+    /// create-scoped grant placed ahead of the group-consulting deny rule.
+    const ISSUE_26_POLICY: &str = r#"
+default_action = "allow"
+
+[[rule]]
+name = "file-new-bugs"
+action = "restrict"
+capabilities = ["create"]
+operations = ["create"]
+[rule.match]
+products = ["SUSE Linux Enterprise*"]
+
+[[rule]]
+name = "group-restricted"
+action = "deny"
+[rule.match]
+group_restricted = true
+"#;
+
+    #[test]
+    fn create_scoped_rule_no_longer_shadows_reads_issue_26() {
+        let g = Guard {
+            policy: policy(ISSUE_26_POLICY),
+        };
+
+        // An existing, world-readable bug in a matched product: the
+        // create-scoped rule is invisible to access classification, so the
+        // bug falls through the deny rule to the allowing default — this is
+        // the read the pre-fix policy shape silently revoked.
+        let public = BugMeta::from_json(&json!({
+            "id": 100,
+            "summary": "boot hangs after update",
+            "product": "SUSE Linux Enterprise Server 15",
+            "component": "Kernel",
+            "groups": [],
+            "creation_time": "2020-01-01T00:00:00Z",
+        }));
+        match g.policy.classify(&public, Utc::now(), Operation::Access) {
+            Access::Granted { rule, .. } => assert_eq!(rule, "default"),
+            other => panic!("non-restricted bug must stay readable, got {other:?}"),
+        }
+
+        // A group-restricted bug in the same product stays denied: the
+        // create grant does not shadow the deny rule for reads.
+        let restricted = BugMeta::from_json(&json!({
+            "id": 101,
+            "summary": "boot hangs after update",
+            "product": "SUSE Linux Enterprise Server 15",
+            "component": "Kernel",
+            "groups": ["secteam"],
+            "creation_time": "2020-01-01T00:00:00Z",
+        }));
+        match g
+            .policy
+            .classify(&restricted, Utc::now(), Operation::Access)
+        {
+            Access::Denied { rule } => assert_eq!(rule, "group-restricted"),
+            other => panic!("group-restricted bug must stay denied, got {other:?}"),
+        }
+
+        // Filing into the matched product works: for the create operation
+        // the scoped rule is first match and grants `create` before the
+        // group-consulting rule can fail closed on the unknowable groups.
+        assert!(g.may_create(&create_request("SUSE Linux Enterprise Server 15")));
+        // Elsewhere creation still fails closed on the group rule.
+        assert!(!g.may_create(&create_request("openSUSE")));
+    }
+
+    #[test]
+    fn create_scoped_grant_does_not_defeat_a_preceding_name_deny() {
+        // A deny rule placed ABOVE the create-scoped grant still wins for
+        // creation: scoping changes which rules are consulted, never the
+        // first-match order among those that are.
+        let g = Guard {
+            policy: policy(concat!(
+                "[[rule]]\nname = \"hide-sle\"\naction = \"deny\"\n",
+                "[rule.match]\nproducts = [\"SUSE Linux Enterprise*\"]\n",
+                "[[rule]]\nname = \"file-new-bugs\"\naction = \"restrict\"\n",
+                "capabilities = [\"create\"]\noperations = [\"create\"]\n",
+                "[rule.match]\nproducts = [\"SUSE Linux Enterprise*\"]\n",
+            )),
+        };
+        assert!(!g.may_create(&create_request("SUSE Linux Enterprise Server 15")));
+    }
+
+    #[test]
+    fn access_scoped_rule_is_invisible_to_may_create() {
+        // A rule scoped to `operations = ["access"]` decides nothing for the
+        // create gate: creation falls through to the denying default.
+        let g = Guard {
+            policy: policy(concat!(
+                "default_action = \"deny\"\n",
+                "[[rule]]\nname = \"readers\"\naction = \"restrict\"\n",
+                "capabilities = [\"read\"]\noperations = [\"access\"]\n",
+                "[rule.match]\nproducts = [\"openSUSE*\"]\n",
+            )),
+        };
+        assert!(!g.may_create(&create_request("openSUSE")));
+    }
+
+    #[test]
+    fn may_create_read_only_strips_a_create_scoped_grant() {
+        // I9: read_only strips write capabilities from EVERY grant, a
+        // create-scoped one included — the scoping must not open a side door
+        // around read-only mode.
+        let g = Guard {
+            policy: policy(concat!(
+                "[global]\nread_only = true\n",
+                "[[rule]]\nname = \"file-new-bugs\"\naction = \"restrict\"\n",
+                "capabilities = [\"create\"]\noperations = [\"create\"]\n",
+                "[rule.match]\nproducts = [\"openSUSE*\"]\n",
+            )),
         };
         assert!(!g.may_create(&create_request("openSUSE")));
     }

--- a/crates/bugwarden-core/src/policy.rs
+++ b/crates/bugwarden-core/src/policy.rs
@@ -37,6 +37,13 @@
 //!
 //! Rules are evaluated in file order, first match wins; unmatched bugs fall
 //! through to `default_action`.
+//!
+//! A rule may additionally carry `operations = [...]` to scope itself to a
+//! subset of evaluation kinds: `"create"` (the create gate judging a
+//! prospective bug) and/or `"access"` (every classification of an existing
+//! bug). The scope is checked BEFORE the rule's matcher, so a scoped rule is
+//! fully invisible — including its fail-closed path — to the operations it
+//! does not cover. A rule without the key applies to every operation.
 
 use std::collections::BTreeSet;
 use std::path::Path;
@@ -406,6 +413,28 @@ pub enum Action {
     Restrict,
 }
 
+/// The kind of evaluation a classification is performed for.
+///
+/// Every call to [`Policy::classify`] names the operation it is deciding,
+/// and a rule carrying an `operations` list is consulted only for the
+/// operations it names. The scope check runs BEFORE the rule's matcher, so
+/// a rule scoped away from the operation at hand is fully invisible to it —
+/// it can neither match nor fail closed on unreadable metadata. This is
+/// what lets a rule grant `create` for a product without becoming the
+/// first-match rule for that product's EXISTING bugs (issue #26).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Operation {
+    /// Classification of a PROSPECTIVE bug: the create gate
+    /// (`Guard::may_create`) judging a `create_bug` request before anything
+    /// is filed.
+    Create,
+    /// Every classification of an EXISTING bug: retrieval, search-result
+    /// filtering, comments, history, attachments, link disclosure, and all
+    /// updates to the bug.
+    Access,
+}
+
 /// One policy rule: matching criteria plus the action to take.
 ///
 /// Rule names exist for operator-side logging only; they are never exposed
@@ -427,6 +456,42 @@ pub struct Rule {
     /// `allow`/`deny` and non-empty for `restrict` (validated).
     #[serde(default)]
     pub capabilities: Vec<Capability>,
+    /// Operations this rule is consulted for; leaving the key out means the
+    /// rule applies to every operation (the behaviour of every rule before
+    /// this field existed).
+    ///
+    /// A rule scoped away from an operation is invisible to it: the scope is
+    /// checked BEFORE the matcher (see [`Rule::applies_to`]), so a
+    /// create-scoped rule can never deny a read — not even through the
+    /// fail-closed path for unreadable metadata (I4), because for reads it
+    /// is not consulted at all. An explicitly empty list is rejected at
+    /// validation: a rule applying to no operation is dead configuration
+    /// masking operator intent.
+    #[serde(default)]
+    pub operations: Option<Vec<Operation>>,
+}
+
+impl Rule {
+    /// Whether this rule is consulted when classifying for `op`.
+    ///
+    /// An absent `operations` field applies to every operation; a written
+    /// list applies to exactly the operations it names. An explicitly empty
+    /// list is rejected by [`Policy::from_toml_str`] validation; should one
+    /// appear in a hand-constructed [`Policy`], it is treated as unscoped —
+    /// exactly as if the field were absent. No fallback for that invalid
+    /// state is uniformly fail-closed: honouring "applies to no operation"
+    /// would silently skip a deny rule everywhere (fail open), and would
+    /// just as silently skip a restrict rule under an allowing default
+    /// (also fail open — matched bugs would fall through to the full
+    /// default grant). The unscoped reading is canonical because it never
+    /// SKIPS a rule the author wrote; rejecting the state outright is
+    /// validation's job, not this method's.
+    pub fn applies_to(&self, op: Operation) -> bool {
+        match &self.operations {
+            None => true,
+            Some(ops) => ops.is_empty() || ops.contains(&op),
+        }
+    }
 }
 
 /// Policy-wide guards applied on top of (and before) the rule list.
@@ -521,7 +586,21 @@ impl Policy {
     /// - `restrict` rules carry at least one capability;
     /// - `allow`/`deny` rules carry no capabilities (a capability list on
     ///   them would be dead configuration masking operator intent);
-    /// - `default_action` is not `restrict`.
+    /// - `default_action` is not `restrict`;
+    /// - `operations`, when written, is non-empty (`operations = []` would
+    ///   apply the rule to no operation at all);
+    /// - a `restrict` rule scoped to ONLY the `create` operation grants
+    ///   exactly the `create` capability — without it the rule could never
+    ///   grant anything, and any other capability it named would be
+    ///   unreachable (the create gate consults only `create`);
+    /// - a `restrict` rule scoped away from `create` does not grant the
+    ///   `create` capability (nothing outside the create gate consults it,
+    ///   so the grant would be dead — and an operator who typoed the scope
+    ///   would silently lose both the filing they meant to permit and the
+    ///   reads the capability list withholds).
+    ///
+    /// Unknown operation names, like every other unknown name or key, are
+    /// rejected by strict deserialization.
     pub fn from_toml_str(s: &str) -> anyhow::Result<Policy> {
         let policy: Policy = toml::from_str(s).context("failed to parse guard policy TOML")?;
         policy.validate()?;
@@ -578,23 +657,80 @@ impl Policy {
                 }
                 _ => {}
             }
+            if let Some(ops) = &rule.operations {
+                if ops.is_empty() {
+                    anyhow::bail!(
+                        "rule \"{}\": operations = [] would apply the rule to no operation; \
+                         omit the key to apply the rule to every operation",
+                        rule.name
+                    );
+                }
+                // The create gate consults exactly one capability
+                // (`create`), and nothing outside the create gate consults
+                // it. A restrict rule whose scope and capability list
+                // disagree about that is dead configuration masking
+                // operator intent — the same startup-error class as a
+                // capability list on an allow/deny rule.
+                if rule.action == Action::Restrict {
+                    let covers_create = ops.contains(&Operation::Create);
+                    let covers_access = ops.contains(&Operation::Access);
+                    let grants_create = rule.capabilities.contains(&Capability::Create);
+                    if covers_create && !covers_access {
+                        if !grants_create {
+                            anyhow::bail!(
+                                "rule \"{}\": scoped to operations = [\"create\"] but its \
+                                 capabilities do not include \"create\", so it could never \
+                                 grant anything reachable",
+                                rule.name
+                            );
+                        }
+                        if rule.capabilities.iter().any(|&c| c != Capability::Create) {
+                            anyhow::bail!(
+                                "rule \"{}\": scoped to operations = [\"create\"] but grants \
+                                 capabilities besides \"create\"; the create gate consults \
+                                 only \"create\", so the others could never be granted \
+                                 anywhere — drop them or widen the scope",
+                                rule.name
+                            );
+                        }
+                    }
+                    if covers_access && !covers_create && grants_create {
+                        anyhow::bail!(
+                            "rule \"{}\": scoped to operations = [\"access\"] but grants \
+                             \"create\", which only the create gate consults; the grant \
+                             is dead — drop the capability or add \"create\" to operations",
+                            rule.name
+                        );
+                    }
+                }
+            }
         }
         Ok(())
     }
 
-    /// Classify one bug into an [`Access`] decision.
+    /// Classify one bug into an [`Access`] decision, for operation `op`.
+    ///
+    /// `op` names what the classification is FOR: [`Operation::Access`] for
+    /// every evaluation of an existing bug, [`Operation::Create`] for the
+    /// create gate judging a prospective one.
     ///
     /// Evaluation order (normative):
     ///
     /// 1. `global.min_bug_age_days` — a bug younger than the minimum age is
     ///    Denied before any rule runs. A missing/unparsable `creation_time`
-    ///    while this gate is active is also Denied (fail closed, I4).
-    /// 2. Rules in file order, first match wins.
+    ///    while this gate is active is also Denied (fail closed, I4). This
+    ///    gate is global, never operation-scoped: the create gate dates a
+    ///    prospective bug NOW, so an active age gate deliberately refuses
+    ///    all creation.
+    /// 2. Rules in file order, first match wins — consulting only the rules
+    ///    whose `operations` cover `op`. The scope check precedes matcher
+    ///    evaluation, so a rule scoped away from `op` can neither match nor
+    ///    fail closed on unreadable metadata for this classification.
     /// 3. `default_action`.
     ///
     /// Every grant — from a rule or from the default — has write capabilities
     /// stripped when `global.read_only` is set.
-    pub fn classify(&self, bug: &BugMeta, now: DateTime<Utc>) -> Access {
+    pub fn classify(&self, bug: &BugMeta, now: DateTime<Utc>, op: Operation) -> Access {
         if self.global.min_bug_age_days > 0 {
             let too_young = match (
                 bug.creation_time,
@@ -613,6 +749,14 @@ impl Policy {
             }
         }
         for rule in &self.rules {
+            // Operation scoping is decided BEFORE the matcher runs: a rule
+            // scoped away from `op` is fully invisible to this
+            // classification, including the Unknown fail-closed arm below —
+            // a create-only rule must never deny a read over unreadable
+            // metadata, because for reads it is not consulted at all.
+            if !rule.applies_to(op) {
+                continue;
+            }
             match rule.matcher.evaluate(bug, now) {
                 // The rule definitively does not apply; try the next one.
                 MatchOutcome::No => continue,
@@ -1516,6 +1660,169 @@ products = ["SUSE*"]
         assert!(msg.contains("default_action"), "unexpected error: {msg}");
     }
 
+    // ---------- operations (rule scoping) ----------
+
+    #[test]
+    fn operations_toml_spellings_pinned() {
+        // Pins the operator-facing TOML spellings "create" and "access", and
+        // that an absent key parses as None (unscoped).
+        let s = concat!(
+            "[[rule]]\nname = \"scoped\"\naction = \"deny\"\n",
+            "operations = [\"create\", \"access\"]\n",
+            "[[rule]]\nname = \"unscoped\"\naction = \"deny\"\n",
+        );
+        let p = Policy::from_toml_str(s).unwrap();
+        assert_eq!(
+            p.rules[0].operations,
+            Some(vec![Operation::Create, Operation::Access])
+        );
+        assert_eq!(p.rules[1].operations, None);
+    }
+
+    #[test]
+    fn reject_unknown_operation_name() {
+        let s = "[[rule]]\nname = \"r\"\naction = \"deny\"\noperations = [\"delete\"]\n";
+        assert!(Policy::from_toml_str(s).is_err());
+    }
+
+    #[test]
+    fn reject_explicitly_empty_operations() {
+        // A rule applying to no operation is dead weight / operator error.
+        let s = "[[rule]]\nname = \"r\"\naction = \"deny\"\noperations = []\n";
+        let err = Policy::from_toml_str(s).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("no operation"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn reject_create_only_restrict_that_cannot_grant_create() {
+        // Scoped to the create operation, the capability list is consulted
+        // only by the create gate; without "create" in it the rule could
+        // never grant anything reachable.
+        let s = concat!(
+            "[[rule]]\nname = \"r\"\naction = \"restrict\"\n",
+            "capabilities = [\"read\"]\noperations = [\"create\"]\n",
+        );
+        let err = Policy::from_toml_str(s).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("create"), "unexpected error: {msg}");
+
+        // With "create" granted the same shape is valid...
+        let ok = concat!(
+            "[[rule]]\nname = \"r\"\naction = \"restrict\"\n",
+            "capabilities = [\"create\"]\noperations = [\"create\"]\n",
+        );
+        assert!(Policy::from_toml_str(ok).is_ok());
+        // ...and so is a read-granting rule that also covers access.
+        let ok = concat!(
+            "[[rule]]\nname = \"r\"\naction = \"restrict\"\n",
+            "capabilities = [\"read\"]\noperations = [\"create\", \"access\"]\n",
+        );
+        assert!(Policy::from_toml_str(ok).is_ok());
+        // A rule covering BOTH operations may mix create and access
+        // capabilities freely: each is reachable under one of its scopes.
+        let ok = concat!(
+            "[[rule]]\nname = \"r\"\naction = \"restrict\"\n",
+            "capabilities = [\"read\", \"create\"]\noperations = [\"access\", \"create\"]\n",
+        );
+        assert!(Policy::from_toml_str(ok).is_ok());
+    }
+
+    #[test]
+    fn reject_create_only_restrict_with_unreachable_extra_capabilities() {
+        // The create gate consults only the `create` capability, so a
+        // create-only rule granting anything else is dead configuration:
+        // the operator named a capability the rule can never hand out.
+        let s = concat!(
+            "[[rule]]\nname = \"r\"\naction = \"restrict\"\n",
+            "capabilities = [\"create\", \"read\"]\noperations = [\"create\"]\n",
+        );
+        let err = Policy::from_toml_str(s).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("besides \"create\""),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_access_scoped_restrict_granting_create() {
+        // Mirror image: `create` in an access-only rule is never consulted
+        // (may_create classifies with Operation::Create, which skips the
+        // rule). Accepting it would let a typoed scope silently drop both
+        // the intended filing grant AND every read the capability list
+        // withholds — a fail-closed outage with no startup diagnostic.
+        let s = concat!(
+            "[[rule]]\nname = \"r\"\naction = \"restrict\"\n",
+            "capabilities = [\"create\"]\noperations = [\"access\"]\n",
+        );
+        let err = Policy::from_toml_str(s).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("dead"), "unexpected error: {msg}");
+
+        // Also rejected when `create` rides along other, reachable caps.
+        let s = concat!(
+            "[[rule]]\nname = \"r\"\naction = \"restrict\"\n",
+            "capabilities = [\"read\", \"create\"]\noperations = [\"access\"]\n",
+        );
+        assert!(Policy::from_toml_str(s).is_err());
+    }
+
+    #[test]
+    fn hand_constructed_empty_operations_list_is_unscoped() {
+        // `operations = []` never survives from_toml_str, but every Rule
+        // field is pub, so a hand-built Policy can carry Some(vec![]). Pin
+        // the documented fallback: the empty list behaves exactly like the
+        // absent field — the rule stays consulted for EVERY operation.
+        // Honouring "applies nowhere" would silently skip a deny rule
+        // everywhere (fail open), and would skip a restrict rule under an
+        // allowing default just the same; the unscoped reading is the one
+        // that never skips a rule the author wrote.
+        let rule = Rule {
+            name: "hand-built".to_string(),
+            description: String::new(),
+            matcher: Matcher::default(),
+            action: Action::Deny,
+            capabilities: Vec::new(),
+            operations: Some(Vec::new()),
+        };
+        assert!(rule.applies_to(Operation::Access));
+        assert!(rule.applies_to(Operation::Create));
+
+        // End to end: a deny rule carrying the empty list still denies for
+        // both operations instead of being skipped into the allowing
+        // default.
+        let p = Policy {
+            default_action: Action::Allow,
+            global: GlobalGuards::default(),
+            rules: vec![rule],
+        };
+        for op in [Operation::Access, Operation::Create] {
+            match p.classify(&meta(), now(), op) {
+                Access::Denied { rule } => assert_eq!(rule, "hand-built"),
+                other => {
+                    panic!("empty-list deny rule must stay consulted for {op:?}, got {other:?}")
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn rule_applies_to_semantics() {
+        let p = Policy::from_toml_str(concat!(
+            "[[rule]]\nname = \"unscoped\"\naction = \"deny\"\n",
+            "[[rule]]\nname = \"create-only\"\naction = \"deny\"\noperations = [\"create\"]\n",
+            "[[rule]]\nname = \"access-only\"\naction = \"deny\"\noperations = [\"access\"]\n",
+        ))
+        .unwrap();
+        assert!(p.rules[0].applies_to(Operation::Create));
+        assert!(p.rules[0].applies_to(Operation::Access));
+        assert!(p.rules[1].applies_to(Operation::Create));
+        assert!(!p.rules[1].applies_to(Operation::Access));
+        assert!(!p.rules[2].applies_to(Operation::Create));
+        assert!(p.rules[2].applies_to(Operation::Access));
+    }
+
     // ---------- Policy::load ----------
 
     #[test]
@@ -1553,7 +1860,7 @@ products = ["SUSE*"]
     #[test]
     fn classify_default_allow_grants_everything() {
         let p = Policy::default();
-        let access = p.classify(&meta(), now());
+        let access = p.classify(&meta(), now(), Operation::Access);
         match &access {
             Access::Granted { caps, rule } => {
                 assert_eq!(rule, "default");
@@ -1569,7 +1876,7 @@ products = ["SUSE*"]
     #[test]
     fn classify_default_deny_denies_everything() {
         let p = Policy::from_toml_str("default_action = \"deny\"").unwrap();
-        let access = p.classify(&meta(), now());
+        let access = p.classify(&meta(), now(), Operation::Access);
         match &access {
             Access::Denied { rule } => assert_eq!(rule, "default"),
             other => panic!("expected denial, got {other:?}"),
@@ -1595,14 +1902,14 @@ action = "allow"
 products = ["*"]
 "#;
         let p = Policy::from_toml_str(s).unwrap();
-        match p.classify(&meta(), now()) {
+        match p.classify(&meta(), now(), Operation::Access) {
             Access::Denied { rule } => assert_eq!(rule, "first"),
             other => panic!("first matching rule must win, got {other:?}"),
         }
         // A bug the first rule does not match falls through to the second.
         let mut other_bug = meta();
         other_bug.product = Some("GNOME".into());
-        match p.classify(&other_bug, now()) {
+        match p.classify(&other_bug, now(), Operation::Access) {
             Access::Granted { rule, .. } => assert_eq!(rule, "second"),
             other => panic!("expected grant from catch-all, got {other:?}"),
         }
@@ -1622,12 +1929,14 @@ groups = ["*security*", "*embargo*"]
         let p = Policy::from_toml_str(s).unwrap();
         let mut bug = meta();
         bug.groups = Some(vec!["suse-security-internal".into()]);
-        match p.classify(&bug, now()) {
+        match p.classify(&bug, now(), Operation::Access) {
             Access::Denied { rule } => assert_eq!(rule, "embargo"),
             other => panic!("embargoed bug must be denied, got {other:?}"),
         }
         // Without the group the default allows.
-        assert!(p.classify(&meta(), now()).allows(Capability::Read));
+        assert!(p
+            .classify(&meta(), now(), Operation::Access)
+            .allows(Capability::Read));
     }
 
     #[test]
@@ -1635,12 +1944,14 @@ groups = ["*security*", "*embargo*"]
         let p = Policy::from_toml_str("[global]\nmin_bug_age_days = 30\n").unwrap();
         let mut bug = meta();
         bug.creation_time = Some(t("2026-01-14T00:00:00Z")); // 1 day old
-        match p.classify(&bug, now()) {
+        match p.classify(&bug, now(), Operation::Access) {
             Access::Denied { rule } => assert_eq!(rule, "min_bug_age_days"),
             other => panic!("young bug must be denied, got {other:?}"),
         }
         bug.creation_time = Some(t("2025-01-01T00:00:00Z")); // over a year old
-        assert!(p.classify(&bug, now()).allows(Capability::Read));
+        assert!(p
+            .classify(&bug, now(), Operation::Access)
+            .allows(Capability::Read));
     }
 
     #[test]
@@ -1648,13 +1959,13 @@ groups = ["*security*", "*embargo*"]
         let p = Policy::from_toml_str("[global]\nmin_bug_age_days = 30\n").unwrap();
         let mut bug = meta();
         bug.creation_time = None;
-        match p.classify(&bug, now()) {
+        match p.classify(&bug, now(), Operation::Access) {
             Access::Denied { rule } => assert_eq!(rule, "min_bug_age_days"),
             other => panic!("unknown age must be denied under an age gate (I4), got {other:?}"),
         }
         // With the gate disabled a missing creation_time is fine.
         assert!(Policy::default()
-            .classify(&bug, now())
+            .classify(&bug, now(), Operation::Access)
             .allows(Capability::Read));
     }
 
@@ -1664,10 +1975,15 @@ groups = ["*security*", "*embargo*"]
         let mut bug = meta();
         // Exactly 7 days old => age requirement met => allowed.
         bug.creation_time = Some(t("2026-01-08T12:00:00Z"));
-        assert!(p.classify(&bug, now()).allows(Capability::Read));
+        assert!(p
+            .classify(&bug, now(), Operation::Access)
+            .allows(Capability::Read));
         // One second younger => denied.
         bug.creation_time = Some(t("2026-01-08T12:00:01Z"));
-        assert!(matches!(p.classify(&bug, now()), Access::Denied { .. }));
+        assert!(matches!(
+            p.classify(&bug, now(), Operation::Access),
+            Access::Denied { .. }
+        ));
     }
 
     #[test]
@@ -1683,7 +1999,7 @@ action = "allow"
         let p = Policy::from_toml_str(s).unwrap();
         let mut bug = meta();
         bug.creation_time = Some(t("2026-01-14T00:00:00Z"));
-        match p.classify(&bug, now()) {
+        match p.classify(&bug, now(), Operation::Access) {
             Access::Denied { rule } => assert_eq!(rule, "min_bug_age_days"),
             other => panic!("global age gate must precede rules, got {other:?}"),
         }
@@ -1698,7 +2014,7 @@ action = "restrict"
 capabilities = ["summary", "comments"]
 "#;
         let p = Policy::from_toml_str(s).unwrap();
-        let access = p.classify(&meta(), now());
+        let access = p.classify(&meta(), now(), Operation::Access);
         assert!(access.allows(Capability::Summary));
         assert!(access.allows(Capability::Comments));
         assert!(!access.allows(Capability::Read));
@@ -1721,15 +2037,19 @@ younger_than_days = 14
         let p = Policy::from_toml_str(s).unwrap();
         let mut bug = meta();
         bug.creation_time = Some(t("2026-01-10T00:00:00Z")); // 5 days old
-        let access = p.classify(&bug, now());
+        let access = p.classify(&bug, now(), Operation::Access);
         assert!(access.allows(Capability::Summary));
         assert!(!access.allows(Capability::Read));
         // Old bug falls through to default allow.
         bug.creation_time = Some(t("2025-06-01T00:00:00Z"));
-        assert!(p.classify(&bug, now()).allows(Capability::Read));
+        assert!(p
+            .classify(&bug, now(), Operation::Access)
+            .allows(Capability::Read));
         // Unknown age is treated as young (fail closed).
         bug.creation_time = None;
-        assert!(!p.classify(&bug, now()).allows(Capability::Read));
+        assert!(!p
+            .classify(&bug, now(), Operation::Access)
+            .allows(Capability::Read));
     }
 
     #[test]
@@ -1771,7 +2091,7 @@ younger_than_days = 14
     #[test]
     fn read_only_strips_write_caps_from_default_grant() {
         let p = Policy::from_toml_str("[global]\nread_only = true\n").unwrap();
-        let access = p.classify(&meta(), now());
+        let access = p.classify(&meta(), now(), Operation::Access);
         for c in Capability::ALL {
             if c.is_write() {
                 assert!(!access.allows(c), "{c:?} must be stripped in read-only");
@@ -1792,7 +2112,7 @@ name = "allow-all"
 action = "allow"
 "#;
         let p = Policy::from_toml_str(s).unwrap();
-        let access = p.classify(&meta(), now());
+        let access = p.classify(&meta(), now(), Operation::Access);
         assert!(access.allows(Capability::Read));
         assert!(!access.allows(Capability::Comment));
         assert!(!access.allows(Capability::Status));
@@ -1817,7 +2137,7 @@ action = "restrict"
 capabilities = ["summary", "comment", "status"]
 "#;
         let p = Policy::from_toml_str(s).unwrap();
-        let access = p.classify(&meta(), now());
+        let access = p.classify(&meta(), now(), Operation::Access);
         assert!(access.allows(Capability::Summary));
         assert!(!access.allows(Capability::Comment));
         assert!(!access.allows(Capability::Status));
@@ -1833,7 +2153,7 @@ capabilities = ["summary", "comment", "status"]
         // cannot make this vacuously true: filing bugs and uploading
         // attachments are writes, and read-only must strip them.
         let p = Policy::from_toml_str("[global]\nread_only = true\n").unwrap();
-        let access = p.classify(&meta(), now());
+        let access = p.classify(&meta(), now(), Operation::Access);
         assert!(!access.allows(Capability::Create));
         assert!(!access.allows(Capability::Attach));
         // Their read-side counterpart survives.
@@ -1851,7 +2171,7 @@ action = "restrict"
 capabilities = ["comment"]
 "#;
         let p = Policy::from_toml_str(s).unwrap();
-        let access = p.classify(&meta(), now());
+        let access = p.classify(&meta(), now(), Operation::Access);
         assert!(access.allows(Capability::Comment));
         assert!(!access.allows(Capability::Create));
         assert!(!access.allows(Capability::Attach));
@@ -1868,7 +2188,7 @@ action = "restrict"
 capabilities = ["summary", "create", "attach"]
 "#;
         let p = Policy::from_toml_str(s).unwrap();
-        let access = p.classify(&meta(), now());
+        let access = p.classify(&meta(), now(), Operation::Access);
         assert!(access.allows(Capability::Create));
         assert!(access.allows(Capability::Attach));
         assert!(!access.allows(Capability::Read));
@@ -1897,11 +2217,11 @@ capabilities = ["summary", "create", "attach"]
         ))
         .unwrap();
         assert!(matches!(
-            allow_rule.classify(&unreadable, now()),
+            allow_rule.classify(&unreadable, now(), Operation::Access),
             Access::Denied { .. }
         ));
         assert!(allow_rule
-            .classify(&known_fresh, now())
+            .classify(&known_fresh, now(), Operation::Access)
             .allows(Capability::Read));
 
         // The case a permissive default would hide: under `deny`, a restrict
@@ -1914,11 +2234,11 @@ capabilities = ["summary", "create", "attach"]
         ))
         .unwrap();
         assert!(matches!(
-            restrict_rule.classify(&unreadable, now()),
+            restrict_rule.classify(&unreadable, now(), Operation::Access),
             Access::Denied { .. }
         ));
         assert!(restrict_rule
-            .classify(&known_fresh, now())
+            .classify(&known_fresh, now(), Operation::Access)
             .allows(Capability::Summary));
     }
 
@@ -1943,7 +2263,7 @@ capabilities = ["summary", "create", "attach"]
             ..meta()
         };
         assert!(matches!(
-            p.classify(&readable, now()),
+            p.classify(&readable, now(), Operation::Access),
             Access::Denied { .. }
         ));
         // The same bug with neither field readable must not do better.
@@ -1953,7 +2273,7 @@ capabilities = ["summary", "create", "attach"]
             ..meta()
         };
         assert!(matches!(
-            p.classify(&unreadable, now()),
+            p.classify(&unreadable, now(), Operation::Access),
             Access::Denied { .. }
         ));
     }
@@ -1973,7 +2293,9 @@ capabilities = ["summary", "create", "attach"]
             whiteboard: None,
             ..meta()
         };
-        assert!(p.classify(&no_whiteboard, now()).allows(Capability::Read));
+        assert!(p
+            .classify(&no_whiteboard, now(), Operation::Access)
+            .allows(Capability::Read));
     }
 
     #[test]
@@ -1985,7 +2307,90 @@ capabilities = ["summary", "create", "attach"]
             global: GlobalGuards::default(),
             rules: Vec::new(),
         };
-        assert!(matches!(p.classify(&meta(), now()), Access::Denied { .. }));
+        assert!(matches!(
+            p.classify(&meta(), now(), Operation::Access),
+            Access::Denied { .. }
+        ));
+    }
+
+    #[test]
+    fn classify_create_scoped_rule_is_skipped_before_its_matcher_runs() {
+        // The crux of operation scoping (issue #26): a create-scoped rule is
+        // fully invisible to access classification, INCLUDING the fail-closed
+        // path for unreadable metadata. This bug's group list is unreadable,
+        // so the rule's matcher would return Unknown — but the rule must not
+        // be consulted at all, and the bug falls through to the default.
+        let unreadable_groups = BugMeta {
+            groups: None,
+            ..meta()
+        };
+        let scoped = Policy::from_toml_str(concat!(
+            "default_action = \"allow\"\n",
+            "[[rule]]\nname = \"filers\"\naction = \"restrict\"\n",
+            "capabilities = [\"create\"]\noperations = [\"create\"]\n",
+            "[rule.match]\ngroup_restricted = false\n",
+        ))
+        .unwrap();
+        match scoped.classify(&unreadable_groups, now(), Operation::Access) {
+            Access::Granted { rule, .. } => assert_eq!(rule, "default"),
+            other => panic!("create-scoped rule must be invisible to access, got {other:?}"),
+        }
+
+        // The SAME rule without `operations` keeps the pre-scoping
+        // behaviour: consulted, undecidable, and fail closed (I4) unchanged.
+        let unscoped = Policy::from_toml_str(concat!(
+            "default_action = \"allow\"\n",
+            "[[rule]]\nname = \"filers\"\naction = \"restrict\"\n",
+            "capabilities = [\"create\"]\n",
+            "[rule.match]\ngroup_restricted = false\n",
+        ))
+        .unwrap();
+        assert!(matches!(
+            unscoped.classify(&unreadable_groups, now(), Operation::Access),
+            Access::Denied { .. }
+        ));
+    }
+
+    #[test]
+    fn classify_access_scoped_rule_is_invisible_to_create() {
+        // The mirror image: a rule scoped to access decides nothing for the
+        // create operation, even when its matcher would match.
+        let p = Policy::from_toml_str(concat!(
+            "default_action = \"deny\"\n",
+            "[[rule]]\nname = \"readers\"\naction = \"restrict\"\n",
+            "capabilities = [\"read\"]\noperations = [\"access\"]\n",
+            "[rule.match]\nproducts = [\"openSUSE*\"]\n",
+        ))
+        .unwrap();
+        // For access the rule matches and grants read.
+        assert!(p
+            .classify(&meta(), now(), Operation::Access)
+            .allows(Capability::Read));
+        // For create it is skipped and the denying default decides.
+        match p.classify(&meta(), now(), Operation::Create) {
+            Access::Denied { rule } => assert_eq!(rule, "default"),
+            other => panic!("access-scoped rule must be invisible to create, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_min_bug_age_gate_is_not_operation_scoped() {
+        // The global age gate stays global: it runs for every operation,
+        // whatever any rule's `operations` says.
+        let p = Policy::from_toml_str(concat!(
+            "[global]\nmin_bug_age_days = 30\n",
+            "[[rule]]\nname = \"filers\"\naction = \"restrict\"\n",
+            "capabilities = [\"create\"]\noperations = [\"create\"]\n",
+        ))
+        .unwrap();
+        let mut young = meta();
+        young.creation_time = Some(t("2026-01-14T00:00:00Z"));
+        for op in [Operation::Access, Operation::Create] {
+            match p.classify(&young, now(), op) {
+                Access::Denied { rule } => assert_eq!(rule, "min_bug_age_days"),
+                other => panic!("age gate must precede scoped rules for {op:?}, got {other:?}"),
+            }
+        }
     }
 
     // ---------- BugMeta::from_json ----------

--- a/crates/bugwarden/tests/tools_wiremock.rs
+++ b/crates/bugwarden/tests/tools_wiremock.rs
@@ -302,6 +302,77 @@ async fn create_bug_group_restricted_policy_refuses_all_creation() {
     assert_eq!(text_of(&result), CREATE_DENIAL);
 }
 
+#[tokio::test]
+async fn create_scoped_rule_files_bugs_without_hiding_reads_issue_26() {
+    // Issue #26, fixed: a create-scoped grant placed ahead of the
+    // group-consulting deny rule lets filing work while existing bugs in the
+    // matched products stay searchable — the pre-fix shape made them vanish
+    // from quicksearch entirely.
+    let mock = MockServer::start().await;
+    let mut bug = world_readable_bug(7);
+    bug["product"] = json!("SUSE Linux Enterprise Server 15");
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("quicksearch", "ALL product:Enterprise"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [bug] })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 4242 })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let client = client_for(
+        concat!(
+            "[[rule]]\nname = \"file-new-bugs\"\naction = \"restrict\"\n",
+            "capabilities = [\"create\"]\noperations = [\"create\"]\n",
+            "[rule.match]\nproducts = [\"SUSE Linux Enterprise*\"]\n",
+            "[[rule]]\nname = \"group-restricted\"\naction = \"deny\"\n",
+            "[rule.match]\ngroup_restricted = true\n",
+        ),
+        &mock,
+    )
+    .await;
+
+    // The read the pre-fix shape silently revoked: the existing
+    // world-readable bug stays in search results, because the create-scoped
+    // rule is invisible to access classification.
+    let search = call(
+        &client,
+        "bugs_quicksearch",
+        json!({ "query": "product:Enterprise" }),
+    )
+    .await;
+    assert!(
+        !is_error(&search),
+        "search must succeed: {}",
+        text_of(&search)
+    );
+    assert!(
+        text_of(&search).contains("\"id\": 7"),
+        "the existing bug must not vanish from search: {}",
+        text_of(&search)
+    );
+
+    // Filing into the matched product reaches Bugzilla: the scoped rule is
+    // first match for the create operation and grants `create` before the
+    // group rule can fail closed on the unknowable group list.
+    let created = call(
+        &client,
+        "create_bug",
+        create_args("SUSE Linux Enterprise Server 15"),
+    )
+    .await;
+    assert!(
+        !is_error(&created),
+        "create must be permitted: {}",
+        text_of(&created)
+    );
+    assert!(text_of(&created).contains("4242"));
+}
+
 // ---------- add_attachment (HIGH-3 mutations a and c, LOW-2) ----------
 
 #[tokio::test]

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -35,12 +35,16 @@ Dependency direction: `bugwarden -> bugwarden-core`, never the reverse.
 - **I3** Search filtering is silent: counts of dropped/filtered results are
   never returned to the client (server-side debug logging is fine).
 - **I4** Fail closed: classification-fetch failure, bug absent from the
-  response, or a rule that cannot be decided because the bug object did not
-  carry a field that rule asks about (absent, null, wrongly typed, or only
-  partially recoverable — including an unparsable `creation_time`) => Denied.
-  Unreadable metadata never yields more access than readable metadata would:
-  it satisfies no granting rule, and it does not let a bug slip past a rule
-  that would otherwise have caught it.
+  response, or a CONSULTED rule that cannot be decided because the bug object
+  did not carry a field that rule asks about (absent, null, wrongly typed, or
+  only partially recoverable — including an unparsable `creation_time`) =>
+  Denied. The consulted rules are those whose `operations` cover the
+  operation being classified (see classify): a rule scoped away from the
+  operation is skipped before its matcher runs and can neither grant nor
+  deny there — scoping changes which rules are consulted, never how a
+  consulted rule resolves. Unreadable metadata never yields more access than
+  readable metadata would: it satisfies no granting rule, and it does not let
+  a bug slip past a consulted rule that would otherwise have caught it.
 - **I14** A bug id the policy would deny must not appear inside something the
   client IS shown: dependency/duplicate/see_also fields of a served bug,
   history changes naming other bugs, or Bugzilla's auto-generated duplicate
@@ -186,6 +190,14 @@ impl Matcher {
 #[serde(rename_all = "snake_case")]
 pub enum Action { Allow, Deny, Restrict }
 
+// TOML spellings "create" / "access". `create` is the classification of a
+// PROSPECTIVE bug performed by Guard::may_create; `access` is every
+// classification of an EXISTING bug (retrieval, list filtering, comments,
+// history, attachments, link disclosure, updates).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Operation { Create, Access }
+
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Rule {
@@ -194,6 +206,21 @@ pub struct Rule {
     #[serde(rename = "match", default)] pub matcher: Matcher,
     pub action: Action,
     #[serde(default)] pub capabilities: Vec<Capability>, // only for action = "restrict"
+    // Operations this rule is consulted for; an ABSENT key means every
+    // operation (the behaviour of every pre-existing policy, unchanged).
+    // An explicitly written empty list is a validation error.
+    #[serde(default)] pub operations: Option<Vec<Operation>>,
+}
+impl Rule {
+    // Absent list, or a list containing `op`. (A hand-constructed empty
+    // list — unreachable via from_toml_str, which rejects it — counts as
+    // unscoped, exactly like the absent field. No fallback for that invalid
+    // state is uniformly fail-closed: honouring "applies nowhere" silently
+    // skips a deny rule everywhere AND skips a restrict rule under an
+    // allowing default — both fail open. The unscoped reading is canonical
+    // because it never skips a rule the author wrote; rejection is
+    // validation's job.)
+    pub fn applies_to(&self, op: Operation) -> bool;
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -222,10 +249,28 @@ impl Policy {
     pub fn from_toml_str(s: &str) -> anyhow::Result<Policy>; // strict parse + validate
     pub fn load(path: &std::path::Path) -> anyhow::Result<Policy>; // read + from_toml_str; on unix warn (tracing::warn) if file is group/other-writable
     // validate: Restrict rules need >=1 capability; Allow/Deny rules must have
-    // empty capabilities; default_action must not be Restrict.
-    pub fn classify(&self, bug: &BugMeta, now: chrono::DateTime<chrono::Utc>) -> Access;
-    // order: global min_bug_age_days first (missing creation_time => Denied, I4),
-    // then rules first-match-wins, then default_action.
+    // empty capabilities; default_action must not be Restrict; a written
+    // `operations = []` is an error (a rule applying to no operation is dead
+    // configuration); a Restrict rule scoped to ONLY `create` must grant
+    // exactly the `create` capability (without it the rule could grant
+    // nothing reachable, and any other capability it named would be dead —
+    // the create gate consults only `create`); a Restrict rule scoped away
+    // from `create` must not grant `create` (nothing outside the create
+    // gate consults it, so a typoed scope would otherwise silently lose
+    // both the intended filing grant and the reads the capability list
+    // withholds). Unknown operation names are rejected by serde.
+    pub fn classify(&self, bug: &BugMeta, now: chrono::DateTime<chrono::Utc>, op: Operation) -> Access;
+    // order: global min_bug_age_days first (missing creation_time => Denied, I4;
+    // the gate is global, never operation-scoped — it deliberately refuses
+    // creation too, since may_create dates the prospective bug NOW), then
+    // rules first-match-wins CONSULTING ONLY the rules whose `operations`
+    // cover `op`, then default_action. The operation scope is checked BEFORE
+    // the rule's matcher is evaluated: a rule scoped away from `op` is fully
+    // invisible to that classification — it can neither match nor fail
+    // closed through the MatchOutcome::Unknown path (a create-only rule must
+    // never deny a read over unreadable metadata; it is not consulted at
+    // all). For the rules that ARE consulted, the Unknown => Denied
+    // resolution (I4) is unchanged.
     // Every grant (rule or default) strips write caps when global.read_only.
 }
 
@@ -363,9 +408,17 @@ impl Guard {
     /// payload said. Taking `groups: []` as fact would make claiming a
     /// field strictly MORE permissive than omitting it and file straight
     /// past a group deny rule into a security-* embargo product.
-    /// Consequence, deliberate and documented: a policy whose applicable
-    /// rules consult `groups` or `group_restricted` refuses ALL creation —
-    /// the answer cannot be known before the bug exists. creation_time is
+    /// Consequence, deliberate and documented: a rule consulting `groups`
+    /// or `group_restricted` refuses every create request that REACHES it —
+    /// the answer cannot be known before the bug exists — so creation is
+    /// possible only where an earlier rule covering the create operation
+    /// grants `create` first, and a policy with no such earlier grant
+    /// refuses all creation. The request is classified with Operation::Create: rules
+    /// scoped to `operations = ["access"]` are not consulted here, and a
+    /// rule scoped to `operations = ["create"]` exists only here, which is
+    /// how an operator grants filing into a product ahead of the
+    /// group-consulting rules WITHOUT that grant becoming the first-match
+    /// rule for the product's existing bugs (issue #26). creation_time is
     /// forced to NOW, whatever the payload claims, so an age rule refuses
     /// creation wherever it would immediately hide the result.
     pub fn may_create(&self, requested: &Value) -> bool;
@@ -449,7 +502,7 @@ constraints the model must know.
 | bug_history | id, new_since?: DateTime<Utc> | history | |
 | bug_comments | id, include_private: bool = false, new_since? | comments | filter_comments applied (I5) |
 | bugs_quicksearch | query, status: String = "ALL", include_fields: String = "id,product,component,assigned_to,status,resolution,summary,last_change_time", limit: u32 = 50, offset: u32 = 0 | post-filter | fetch include_fields = requested ∪ CLASSIFY_FIELDS; after filter, project kept bugs to requested fields (keep `_redacted` marker); envelope `{"bugs":[..]}` only (I3), except an advisory `note` when the query is nothing but bug ids (comma/whitespace-separated, optional `#` per id) steering exact id sets to bug_info — the note is a pure function of the CLIENT'S REQUEST (the query and status strings), never of results, verdicts, or anything upstream said (no new oracle), and the `bugs` array is byte-identical with or without it (the query is still searched, never rerouted); its wording tracks the request: a non-empty status is prefixed to the query so upstream content-matches the whole expression, while an empty status sends the query bare and Bugzilla routes a bare all-number query to an exact id lookup (bug_id + anyexact) — on that path the note drops the content-matching claim — and a query naming more distinct ids than MAX_ASSESS_IDS steers to batched bug_info calls (the cap is already public in the too_many_ids refusal text) instead of straight into that refusal | **limit/offset address the bugs the client may SEE, not upstream rows** (Guard::quicksearch_window): filtering an already-paginated page left a hole exactly where a hidden bug sat — a short page the next offset contradicted — and since quicksearch matches summary text that hole was a probe for the hidden title, one word at a time. The guard now scans upstream from row 0 in 200-row chunks, classifies each, and fills the window from the survivors; rows are deduped on the server-reported id (relevance order is not stable between calls) and an id-less row is dropped (I4). Bounds: MAX_SEARCH_WINDOW=1000 addressable, 2000 rows scanned (<=10 sequential requests); hitting either truncates, which looks exactly like the end of results. The objects returned are the ones classified. The scan target is quantised to whole chunks so the stopping point does not track the client's `limit`; without that, `limit` could be binary-searched against the clock to recover each block's exact hidden count. Residual, accepted: filling a window of VISIBLE bugs needs more rows when bugs are hidden, so a stopwatch still learns one bit per scanned block ("not entirely visible"). Removing that would mean scanning the worst case on every search, or letting pages go short again. Search failure returns a bare "Search failed"; the upstream text is logged server-side only (it can name a bug and say whether it exists) |
-| create_bug | product, component, summary, version, description = "", severity?, priority?, op_sys?, platform?, keywords?: Vec<String>, groups?: Vec<String> | create (write), judged on the bug AS REQUESTED (Guard::may_create) | there is no bug id to assess, so the request itself is classified BEFORE any upstream call (I8): the rules that hide a product by name refuse filing into it, a field the request omits fails closed (I4), and a client-claimed `groups` list is never trusted — Bugzilla unions the product's mandatory groups in server-side, so may_create forces groups to unknown, which means a policy whose applicable rules consult groups/group_restricted refuses ALL creation. **Both refusals are one refusal**: a policy refusal and an upstream failure return the same fixed create_denial text after the same single upstream request — the refused path burns one classify call against bug id 0 (never a valid id, creates nothing; download_attachment's padding precedent) instead of the POST. Two texts, or 0 vs 1 requests, would be a free policy-enumeration oracle: send a guaranteed-invalid `version` plus a probe product and read the policy off which refusal (or which latency) comes back, with nothing created. Residual, accepted: a SUCCESSFUL create still confirms the product is allowed — that is the tool doing its job, and it costs a real, attributable bug; and the padding equalizes request count, not the upstream handler's exact latency (GET classify vs rejected POST). Bugzilla's failure message is logged server-side only (it can say whether a product/component exists) |
+| create_bug | product, component, summary, version, description = "", severity?, priority?, op_sys?, platform?, keywords?: Vec<String>, groups?: Vec<String> | create (write), judged on the bug AS REQUESTED (Guard::may_create) | there is no bug id to assess, so the request itself is classified BEFORE any upstream call (I8): the rules that hide a product by name refuse filing into it, a field the request omits fails closed (I4), and a client-claimed `groups` list is never trusted — Bugzilla unions the product's mandatory groups in server-side, so may_create forces groups to unknown, which means a group-consulting rule refuses every create request that REACHES it — creation is possible only where an earlier rule covering the create operation grants it (a rule carrying `operations = ["create"]`, placed ahead of the group-consulting rules, is how an operator permits filing without that grant shadowing reads of existing bugs — issue #26), and a policy with no such grant refuses all creation. **Both refusals are one refusal**: a policy refusal and an upstream failure return the same fixed create_denial text after the same single upstream request — the refused path burns one classify call against bug id 0 (never a valid id, creates nothing; download_attachment's padding precedent) instead of the POST. Two texts, or 0 vs 1 requests, would be a free policy-enumeration oracle: send a guaranteed-invalid `version` plus a probe product and read the policy off which refusal (or which latency) comes back, with nothing created. Residual, accepted: a SUCCESSFUL create still confirms the product is allowed — that is the tool doing its job, and it costs a real, attributable bug; and the padding equalizes request count, not the upstream handler's exact latency (GET classify vs rejected POST). Bugzilla's failure message is logged server-side only (it can say whether a product/component exists) |
 | add_attachment | bug_id, data (base64), file_name, summary, content_type, comment = "", is_private = false, is_patch = false | attach (write) on bug_id | guard assessment before the upload (I8), uniform denial (I2); then global.max_attachment_bytes caps the DECODED size of `data` (0 = no cap) — the ceiling the operator set on downloads binds uploads through the same server too, measured after base64 expansion is stripped so encoding overhead cannot shrink it. The refusal names neither the payload's size nor the cap value (max_attachment_bytes is not I1-disclosable, exactly as on the download path). `comment` travels as a PLAIN string — Bug.add_attachment documents it so; the `{"comment": {"body": ..}}` shape belongs to Bug.update only |
 | add_comment | bug_id, comment, is_private: bool = false | comment (write) | |
 | update_bug_status | bug_id, status, resolution?, comment: String = "" | status (write) | CLOSED requires resolution (error otherwise); when reopening (status not CLOSED/VERIFIED and no resolution given) set `"resolution": ""` |
@@ -562,7 +615,31 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   a group_restricted policy refuses all creation; a group rule ruled out by
   another criterion does not block), a creation_time claimed by the payload
   is ignored in favour of NOW, restrict must name "create", and the
-  create_denial text is fixed.
+  create_denial text is fixed; operation scoping — the issue-#26
+  reproduction fixed (a create-scoped restrict rule ahead of a
+  group-restricted deny rule under an allowing default: existing
+  non-restricted bugs in matched products fall through to a full grant,
+  group-restricted bugs stay denied, may_create succeeds for the matched
+  product and still fails closed elsewhere, and a preceding name-deny rule
+  still refuses creation), a create-scoped rule is skipped BEFORE its
+  matcher runs so it never denies access classification through the
+  Unknown fail-closed path while the same rule without `operations` still
+  does (I4 unchanged), an access-scoped rule is invisible to may_create,
+  the global age gate is not operation-scoped, read_only strips a
+  create-scoped grant so may_create refuses (I9), the TOML spellings
+  "create"/"access" are pinned, a hand-constructed `operations` list that
+  is EMPTY (unreachable via from_toml_str) is pinned unscoped for both
+  operations — a deny rule carrying it still denies instead of being
+  skipped into an allowing default — and validation rejects
+  `operations = []`, unknown operation names, a restrict rule scoped to
+  only `create` whose capabilities are not exactly `create`, and a
+  restrict rule scoped away from `create` that grants `create`; the
+  shipped examples/policy.toml is pinned end to end against its own
+  header: it parses, accepts filing into the desktop products, refuses an
+  embargo-marked title everywhere, refuses filing elsewhere (omitted and
+  claimed group lists alike), keeps existing world-readable desktop bugs
+  fully readable (the issue-#26 regression surface), and keeps
+  group-restricted desktop bugs denied.
 - Unit tests (#[cfg(test)] in crates/bugwarden/src/server.rs): assemble_bug_info
   re-classification — a body embargoed after the verdict is refused, a body
   that now earns only summary is downgraded, a body granting neither read nor
@@ -594,7 +671,10 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   upstream request (nothing POSTed on the refused path, which instead burns
   a classify call against bug id 0); a claimed `groups` list never defeats
   a group deny rule and a group_restricted policy refuses all creation;
-  an allowed create reaches POST /rest/bug; add_attachment refuses on a
+  an allowed create reaches POST /rest/bug; a create-scoped rule placed
+  ahead of a group-restricted deny rule both files into its products (the
+  POST is reached) and leaves existing bugs in them searchable
+  (issue #26); add_attachment refuses on a
   grant carrying `attachments` (read) without `attach` (write) and uploads
   on `attach`; the upload size cap refuses before anything is POSTed; and
   the attachment `comment` travels as a plain string (Bug.add_attachment

--- a/examples/policy.toml
+++ b/examples/policy.toml
@@ -12,23 +12,38 @@
 #   * bugs labelled "security" are invisible while they are fresher than
 #     5 days (the window in which details are typically still unreviewed);
 #   * every other bug is shown to the user in full;
-#   * filing new bugs is refused entirely: rule 1 depends on the group
-#     list, and a not-yet-created bug's groups cannot be known — see the
-#     note before the commented-out "reporters" rule below.
+#   * new bug reports are accepted into the desktop products ONLY — see the
+#     "reporters" rule in section 0, whose `operations = ["create"]` scope
+#     grants filing without touching what may be read — except that a title
+#     carrying the embargo marker may not be filed anywhere
+#     ("no-embargo-filings"). Everywhere else filing is refused: the first
+#     deny rule the create gate reaches ("group-restricted") consults the
+#     group list, a not-yet-created bug's groups cannot be known, and
+#     unknown fails closed.
 #
 # The policy is read once at server startup (--policy / BUGWARDEN_POLICY) and
 # is never visible to the MCP client. Parsing is strict: unknown keys anywhere
 # are a startup error, so typos cannot silently disable a guard.
 #
 # Rule evaluation order:
-#   1. global.min_bug_age_days (a too-young bug is invisible, no rule runs)
-#   2. [[rule]] entries top to bottom — FIRST MATCH WINS
+#   1. global.min_bug_age_days (a too-young bug is invisible, no rule runs;
+#      this gate is global — it is never operation-scoped, and it refuses
+#      creation too, since a just-created bug would be immediately hidden)
+#   2. [[rule]] entries top to bottom — FIRST MATCH WINS. A rule carrying
+#      `operations = [...]` is consulted only for the operations it names
+#      ("create" = the create gate judging a prospective bug, "access" =
+#      every classification of an existing bug); the scope is checked
+#      BEFORE the rule's match criteria, so a scoped rule is completely
+#      invisible to the operations it does not cover.
 #   3. default_action for bugs no rule matched
 #
 # Unreadable metadata: if a bug object does not carry a field some rule asks
 # about — absent, null, wrongly typed, or a list with an unreadable element —
 # that rule cannot be decided and the bug is DENIED, whatever the rule's
-# action. This holds for every criterion below, so none of them repeats it.
+# action. This holds for every criterion of every rule CONSULTED for the
+# operation at hand — an operation-scoped rule (section 0) is skipped before
+# its criteria are read, so it can make nothing undecidable for the
+# operations it does not cover — and none of the rules below repeats it.
 # A field that is present but empty ("" or []) is knowledge, not ignorance,
 # and matches normally.
 #
@@ -68,6 +83,66 @@ read_only = false
 # The same ceiling caps what add_attachment may UPLOAD, also measured on the
 # decoded bytes. 0 removes the cap. Default: 2 MiB.
 #max_attachment_bytes = 2097152
+
+# ---------------------------------------------------------------------------
+# 0. New bug reports: accepted into the desktop products, and only there.
+#
+# Filing must be decided before the bug exists, so the policy judges the bug
+# AS DESCRIBED by the create request. The first deny rule below
+# ("group-restricted") consults the group list, the group list of a
+# not-yet-created bug is unknowable (Bugzilla unions the product's mandatory
+# groups into whatever the request claims), and unknown fails closed — so
+# every create request that reaches it is refused, and no rule after it is
+# ever consulted for creation. A rule granting "create" must therefore come
+# BEFORE it.
+#
+# What makes that placement safe is `operations = ["create"]`: the rule is
+# consulted ONLY by the create gate and is invisible to every classification
+# of an EXISTING bug, including the fail-closed handling of unreadable
+# metadata. Without the scoping, this rule would also be the first match for
+# every existing bug in these products — and a restrict rule's
+# `capabilities` list is the COMPLETE grant for all operations the rule
+# covers, not an addition to what other rules or the default would allow, so
+# `capabilities = ["create"]` alone would silently make those bugs
+# unreadable (gone from searches, "not accessible" from bug_info). With the
+# scoping, filing works and reads are untouched: existing GNOME*/KDE* bugs
+# fall through to the rules below and default_action exactly as if this
+# rule did not exist.
+#
+# Granting creation ahead of the deny rules also takes their OTHER screens
+# out of the create path, so the title screen is restated create-side:
+# "no-embargo-filings" refuses a filing whose title carries the embargo
+# marker, which "reporters" would otherwise accept and "undisclosed-marker"
+# would then instantly hide (a bug created and never readable serves
+# nobody). The keyword screen ("embargo-keyword") deliberately has no
+# create-side twin: a create request may omit `keywords`, an omitted field
+# is unknown, and unknown fails closed — a keyword rule ahead of the grant
+# would refuse every keywordless filing. Residual, accepted: a desktop
+# filing that CLAIMS an embargo keyword is created and then immediately
+# hidden by "embargo-keyword".
+#
+# NOTE: bugwarden versions without operation support REJECT a policy using
+# `operations` at startup — parsing is strict, so the whole file fails
+# closed instead of the rule being silently misread as unscoped.
+
+[[rule]]
+name = "no-embargo-filings"
+description = "Embargo-marked titles may not be filed anywhere"
+action = "deny"
+operations = ["create"]
+[rule.match]
+# Same criterion as "undisclosed-marker" below; scoped to the create gate so
+# it screens filings without duplicating that rule's job for reads.
+summary_contains = ["embargo"]
+
+[[rule]]
+name = "reporters"
+description = "Desktop products accept new bug reports"
+action = "restrict"
+capabilities = ["create"]
+operations = ["create"]
+[rule.match]
+products = ["GNOME*", "KDE*"]
 
 # ---------------------------------------------------------------------------
 # 1. Undisclosed security bugs: fully invisible, at any age.
@@ -202,41 +277,23 @@ younger_than_days = 5
 
 # Filing new bugs ("create") and uploading attachments ("attach") are
 # capabilities like any other. A create request has no bug id yet, so the
-# policy judges the bug AS DESCRIBED by the request — the deny rules above
-# therefore also refuse filing into anything they hide by name, with no
-# extra configuration. A request that omits a field a rule asks about is
-# refused (unknown, not empty), and the request's OWN claim about `groups`
-# is never trusted: Bugzilla unions the product's mandatory groups into
-# whatever was claimed, so what groups the created bug would end up in
-# cannot be known before it exists.
-#
-# BE AWARE: under THIS policy, filing bugs is impossible — deliberately.
-# Rule 1 ("group-restricted") consults the group list, the group list of a
-# not-yet-created bug is unknowable (see above), and unknown fails closed.
-# Every create request is therefore refused before Bugzilla is contacted,
-# and a rule granting "create" placed BELOW rule 1 — like the example
-# below — can never be reached by a create request. The same holds for any
-# policy whose applicable rules use `groups` or `group_restricted`.
-#
-# To actually accept new bugs, a create-granting rule must come BEFORE
-# every group-consulting rule and match on fields the request does carry
-# (products, components, summary, keywords, ...). First match wins, so
-# such a rule then also decides access to EXISTING bugs it matches —
-# grant it "create" alone (as below) and matched existing bugs stay
-# unreadable; add read capabilities to it and you have re-opened the
-# group-restricted bugs of those products, which is exactly what rule 1
-# exists to prevent. Weigh that trade before moving it up.
+# policy judges the bug AS DESCRIBED by the request — a deny rule above
+# therefore also refuses filing into anything it hides by name, with no
+# extra configuration, for every create request that REACHES it (a grant
+# matched earlier, like "reporters", decides first). A request that omits a
+# field a rule asks about is refused (unknown, not empty), and the request's
+# OWN claim about `groups` is never trusted: Bugzilla unions the product's
+# mandatory groups into whatever was claimed, so what groups the created bug
+# would end up in cannot be known before it exists. That is why accepting
+# new bugs takes a rule scoped with `operations = ["create"]`, placed before
+# every group-consulting rule and matching on fields the request does carry
+# (products, components, summary, keywords, ...) — see the "reporters" rule
+# in section 0 at the top of this file and its comment for the full
+# reasoning.
 #
 # "attach" is judged against the target bug like every other write (the
 # bug exists, so its real group list is fetched and rule 1 applies
 # normally), and the upload is capped by max_attachment_bytes above.
-#[[rule]]
-#name = "reporters"
-#description = "Desktop products accept new bug reports"
-#action = "restrict"
-#capabilities = ["create"]
-#[rule.match]
-#products = ["GNOME*", "KDE*"]
 
 # Every remaining match criterion, in one rule.
 #[[rule]]


### PR DESCRIPTION
Fixes #26.

## What changed

Rules can now declare which operations they cover:

```toml
[[rule]]
name = "reporters"
action = "restrict"
capabilities = ["create"]
operations = ["create"]
```

`"create"` is the classification of a prospective bug by `Guard::may_create`; `"access"` is every classification of an existing bug. `Policy::classify` takes the operation being decided and skips a rule scoped away from it **before the matcher is evaluated**, so a create-scoped rule is invisible to access classification including the `MatchOutcome::Unknown` fail-closed arm — placed ahead of the group-consulting rules it makes filing reachable without becoming the first-match grant for existing bugs, which was the defect: "may file, may read non-restricted, may not read restricted" was unsatisfiable (issue #26's option 1).

An absent `operations` key means every operation: existing policies parse and behave identically, and the pre-existing test suite passes with only the mechanical `classify`-parameter addition, which is the back-compat proof. Validation rejects `operations = []` and every restrict rule whose scope and capability list disagree about `create` (missing, extra, or scope-typoed — all dead configuration that would surface as a silent outage). Older bugwarden versions reject a policy using the key at startup (strict parsing): the file fails closed rather than being misread.

`examples/policy.toml` activates the formerly commented `reporters` rule create-scoped, adds a create-side `no-embargo-filings` screen (so a filing the rule accepts is not created-then-hidden by the embargo marker rule), and replaces the trade-off text that documented the conflict as unavoidable. The shipped file's whole header contract is pinned by a unit test.

## Invariants touched (DESIGN.md updated in this commit)

- **I4** — unchanged in behavior for every consulted rule; the invariant text now says a **consulted** rule that cannot be decided denies, and that scoping changes which rules are consulted, never how a consulted rule resolves.
- **I9** — `read_only` still strips a create-scoped grant (test-pinned: `may_create` is false in read-only mode).
- The global `min_bug_age_days` gate remains unscoped and keeps refusing creation.
- I1/I2/I3 untouched: no policy introspection surface added, denial texts and drop accounting unchanged; `create_denial` stays single-text/single-request.

## Adversarial review (before this PR, per AGENTS.md)

Three independent hostile reviews (security-bypass, correctness/fail-closed, docs-vs-code) plus mutation verification against the DESIGN.md invariants.

**Mutation verification — all killed:** un-scoping the rules (restores the #26 bug) → caught by the reproduction tests (unit + wiremock); moving the skip after matcher evaluation → caught by the skip-ordering test; consulting access-scoped rules during create → caught; dropping the `operations = []` validation → caught; treating an absent key as create-only → caught by the back-compat suite; deleting `operations = ["create"]` from the shipped example → caught by the shipped-example pin; both fallback variants for a hand-constructed empty list → caught.

**Findings addressed:** the two majors — DESIGN.md's I4 wording (and its echoes in README and the example header) had become false without the "consulted" qualifier, now reworded at all four sites; the shipped example's create-scoped rule had zero test coverage, now pinned end to end (desktop filing accepted, embargo-marked titles refused, filing elsewhere refused whatever `groups` the request claims, existing desktop bugs stay readable, group-restricted ones stay denied). Minors: validation asymmetries closed (dead extra capabilities on a create-only rule, dead `create` grant on an access-scoped rule), stale test name/comment rewritten, one-sided rustdoc rationale completed.

**Finding rebutted:** a reviewer proposed resolving a hand-constructed `Some(vec![])` operations list per-action (deny = unscoped, allow/restrict = applies nowhere). Not adopted: skipping a restrict rule under an allowing default hands matched bugs the full default grant, so that resolution is itself fail-open in the mirror quadrant. No fallback for the invalid state is uniformly fail-closed; the unscoped reading — never skip a rule the author wrote — stays, now documented from both halves and pinned by a test. The state is unreachable from TOML (validation rejects `[]`).

## Verification

From the repo root on the final tree: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --all-targets --locked` (265 passed, 0 failed), `cargo deny check` (advisories/bans/licenses/sources ok). No new dependencies, `Cargo.lock` untouched, MSRV unaffected.
