### PR TITLE
docs(readme): replace packaging roadmap with install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,40 @@ is `bug_url`, which computes a URL string locally and contacts nothing.
 - **`update_bug_fields` custom fields are restricted** to `cf_*` keys as
   described above.
 
-## Installation / build
+## Installation
+
+### openSUSE (zypper)
+
+bugwarden is packaged in openSUSE Tumbleweed:
+
+```bash
+sudo zypper install bugwarden
+```
+
+For other openSUSE distributions (Leap 16.x, Slowroll), packages are built in
+the [`devel:tools`](https://build.opensuse.org/package/show/devel:tools/bugwarden)
+project on the openSUSE Build Service.
+
+The package installs worked-example configuration files —
+`/etc/bugwarden/policy.toml` (guard policy) and `/etc/bugwarden/audit.toml`
+(audit stream) — marked `%config(noreplace)`, so local edits survive package
+upgrades. Neither is loaded implicitly: the server reads a policy only when
+one is named via `--policy` / `BUGWARDEN_POLICY`, and an audit configuration
+only via `--audit-config` / `BUGWARDEN_AUDIT_CONFIG`, so installing the
+package does not by itself activate anything.
+
+### crates.io (cargo)
+
+```bash
+cargo install bugwarden
+```
+
+This installs the `bugwarden` binary into `~/.cargo/bin`. Unlike the openSUSE
+package it ships no configuration files — copy
+[`examples/policy.toml`](examples/policy.toml) somewhere and name it via
+`--policy`.
+
+### From source
 
 ```bash
 git clone https://github.com/plusky/bugwarden
@@ -201,6 +234,7 @@ Command-line arguments take precedence over environment variables.
 | `--use-auth-header` | — | `false` | Authenticate to Bugzilla with `Authorization: Bearer <key>` instead of the `api_key` query parameter |
 | `--read-only` | `MCP_READ_ONLY` | `false` | Disable all write tools. Tighten-only: ORed with the policy's `global.read_only`; cannot re-enable writes a policy forbids |
 | `--policy <PATH>` | `BUGWARDEN_POLICY` | — | Path to the guard policy TOML. Without it, an allow-all policy applies (with private comments off) |
+| `--audit-config <PATH>` | `BUGWARDEN_AUDIT_CONFIG` | — | Path to the audit stream configuration TOML (worked example in [`examples/audit.toml`](examples/audit.toml)). Without it, no audit stream is written |
 
 ## Policy file reference
 
@@ -360,10 +394,6 @@ action.
 | `bugzilla_server_info` | Bugzilla version, extensions, timezone, time, parameters | none |
 | `quicksearch_syntax` | Bugzilla's quicksearch syntax documentation (HTML) | none |
 | `mcp_server_info` | bugwarden version, Bugzilla URL, transport, coarse policy summary | none |
-
-## Roadmap
-
-- **OBS / openSUSE packaging** for installation via zypper.
 
 ## License
 


### PR DESCRIPTION
Fixes #30.

## What changed

The README's **Roadmap** section listed openSUSE packaging as future work. Both gates named in the issue have cleared: the Factory submission was accepted on 2026-07-28 (SR 1368198), and it went in at 0.2.0 directly, so distribution users get the current guard behaviour from the start. The Roadmap entry is replaced by real installation instructions, and the Roadmap section is deleted (it was the only entry).

The former "Installation / build" section becomes **Installation** with three routes:

- **openSUSE (zypper)** — `sudo zypper install bugwarden` on Tumbleweed; Leap 16.x and Slowroll builds via the `devel:tools` OBS project. Documents what the package installs: `/etc/bugwarden/policy.toml` and `/etc/bugwarden/audit.toml`, both worked examples marked `%config(noreplace)`, and states that neither is loaded implicitly — a policy only via `--policy` / `BUGWARDEN_POLICY`, an audit configuration only via `--audit-config` / `BUGWARDEN_AUDIT_CONFIG`.
- **crates.io (cargo)** — `cargo install bugwarden`, noting that unlike the package it ships no configuration files, so a packaged install and a cargo install are not documented as if they were the same thing (the issue's explicit ask).
- **From source** — the previous content, unchanged.

## Adversarial review (before this PR)

One hostile docs-vs-reality review over the diff, every factual claim checked against primary sources: the Factory spec (both config files installed from `examples/`, `%config(noreplace)`, the `/etc/bugwarden` directory owned), OBS build **and publish** state (the 0.2.0 RPM is live in the published Tumbleweed oss repo, so the zypper command works today; Leap 16.0/16.1 and Slowroll builds in devel:tools succeeded and are published), crates.io (`bugwarden` 0.2.0, not yanked, `bin_names: ["bugwarden"]`), and the flag definitions in `config.rs`/`main.rs` (nothing auto-loads `/etc/bugwarden` — the "neither is loaded implicitly" claim is code-verified).

**No majors.** One content finding, fixed in this PR: the Installation section cited `--audit-config` while the README's CLI reference table omitted the flag — a pre-existing gap (the table never gained a row when the audit feature shipped, and Installation is the README's first mention of audit at all). The missing row is added so the README agrees with itself; wording mirrors `docs/DESIGN.md` and the `config.rs` doc comment. The reviewer also confirmed the deleted Roadmap bullet is exactly what the new section delivers, and that nothing anywhere in the repo links to the removed section or the old "Installation / build" heading anchor.

## Verification

Docs-only diff (README.md). On the branch: `typos`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --all-targets --locked` (265 passed, 0 failed), `cargo deny check` (advisories/bans/licenses/sources ok). Claims verified against primary sources: the Factory spec (`osc cat openSUSE:Factory bugwarden bugwarden.spec` — both config files, `%config(noreplace)`), Factory and devel:tools build results, crates.io (`bugwarden` 0.2.0 published), and `crates/bugwarden/src/config.rs` for the exact flag spellings.
