### PR TITLE
feat(policy): add created_by_me identity-relative matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ touched or data is returned.
   prompt tool.
 - **Guard policy engine**: per-bug `allow` / `deny` / `restrict` decisions
   matched on product, component, group, keyword, status, severity, priority,
-  whiteboard, and bug age — with a fine-grained 13-capability vocabulary for
-  `restrict`.
+  whiteboard, summary, group-restrictedness, bug age, and authorship (whether
+  the requesting account filed the bug) — with a fine-grained 13-capability
+  vocabulary for `restrict`.
 - **No existence oracle**: a policy-denied bug is indistinguishable from a
   nonexistent one.
 - **Silent search filtering**: denied bugs simply never appear in search
@@ -71,9 +72,11 @@ is `bug_url`, which computes a URL string locally and contacts nothing.
 - **Fail closed.** If the classification fetch fails, if a bug is absent from
   the response, or if a rule consulted for the operation being decided cannot
   be decided because the bug object did not carry a field that rule asks
-  about, the bug is treated as denied — never as allowed. (A rule scoped away
-  from the operation via `operations` is not consulted at all — scoping
-  changes which rules run, never how a consulted rule resolves.)
+  about — or, for the identity criterion `created_by_me`, because the
+  bug–caller relationship could not be established — the bug is treated as
+  denied — never as allowed. (A rule scoped away from the operation via
+  `operations` is not consulted at all — scoping changes which rules run,
+  never how a consulted rule resolves.)
 - **Private-comment gate.** Private comments are returned only when the policy
   sets `allow_private_comments = true` **and** the individual call opts in
   with `include_private = true`. Either alone is not enough.
@@ -303,13 +306,23 @@ write two consecutive rules.
 | `summary_contains` | array of strings | case-insensitive substring search in the bug's one-line summary |
 | `group_restricted` | boolean | `true` matches bugs readable only through at least one Bugzilla group, `false` matches world-readable bugs |
 | `younger_than_days` | integer | matches bugs created within the last N days |
+| `created_by_me` | boolean | whether the API key's account authored the bug: the caller's login is resolved per request via Bugzilla's `whoami` endpoint (at most one lookup per tool call, and none at all under a policy without an access-covering `created_by_me` rule — a rule scoped to `operations = ["create"]` alone never triggers a lookup) and compared case-insensitively to the bug's creator. `true` matches the caller's own reports, `false` everyone else's. An unresolvable identity (`whoami` failure) makes the criterion **unknown**, which denies (see Unreadable metadata). In the create gate the prospective bug always counts as created by the caller — no lookup happens there. Older bugwarden versions reject a policy using this key at startup (strict parsing fails closed) |
 
 #### Unreadable metadata
 
 Every criterion needs a field the bug object may not carry — absent, `null`,
 of an unexpected type, or a list with an element the parser cannot read. Such
 a field is **unknown**, and a rule that consults one is undecidable: it neither
-holds nor fails.
+holds nor fails. One criterion needs more than the bug object:
+`created_by_me` also needs the caller's identity, and if either half is
+missing — an unreadable creator, or a `whoami` lookup that failed — it is
+just as undecidable and resolves the same way. A policy consulting identity
+therefore denies everything its identity rules are consulted for while
+`whoami` is failing; that is deliberate (treating unknown identity as "does
+not match" would let a `created_by_me` deny rule be defeated by breaking
+`whoami`). The criterion cannot widen exposure beyond the credential:
+Bugzilla enforces its own permissions on every fetch, so an authorship rule
+only surfaces bugs the API key could already read.
 
 bugwarden resolves an undecidable rule by **denying the bug**, whatever the
 rule's action. A `deny` rule denies because the bug may well be what it was

--- a/crates/bugwarden-core/src/client.rs
+++ b/crates/bugwarden-core/src/client.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 
 /// Fields fetched for guard classification of a bug.
 pub const CLASSIFY_FIELDS: &str =
-    "id,summary,product,component,status,resolution,severity,priority,keywords,groups,whiteboard,creation_time,last_change_time";
+    "id,summary,product,component,status,resolution,severity,priority,keywords,groups,whiteboard,creation_time,last_change_time,creator";
 
 /// Bugzilla `new_since` timestamp format (UTC, second precision, `Z`
 /// suffix).
@@ -68,6 +68,24 @@ impl BugzillaClient {
             .and_then(Value::as_str)
             .map(str::to_owned)
             .ok_or_else(|| anyhow!("bugzilla /version response is missing the \"version\" field"))
+    }
+
+    /// GET `/rest/whoami` — the login name of the account the API key
+    /// authenticates (the response's `name` field).
+    ///
+    /// A missing, non-string, or blank (empty or all-whitespace) `name` is
+    /// a failure, not a login: a blank identity never resolves, so a
+    /// degenerate empty caller can never compare equal to a blank `creator`
+    /// field and grant on no evidence — resolution fails closed instead
+    /// (I4). Authentication and error sanitization are identical to every
+    /// other call: the key never appears in any error this returns (I12).
+    pub async fn whoami(&self, key: &str) -> Result<String> {
+        let v = self.get_json(key, "/whoami", &[]).await?;
+        v.get("name")
+            .and_then(Value::as_str)
+            .filter(|name| !name.trim().is_empty())
+            .map(str::to_owned)
+            .ok_or_else(|| anyhow!("bugzilla /whoami response carries no usable \"name\" field"))
     }
 
     /// Sequential GET of `/rest/version`, `/rest/extensions`, `/rest/time`

--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -112,12 +112,18 @@ impl Guard {
     /// being fetched. Sequential rather than concurrent because some Bugzilla
     /// deployments drop parallel connections (see `client::server_info`).
     ///
+    /// `caller` is the requesting account's login as resolved ONCE per tool
+    /// call by [`Guard::resolve_caller`] — this method performs no identity
+    /// lookup of its own. `None` leaves the `created_by_me` criterion
+    /// undecidable, which fails closed for every rule consulting it (I4).
+    ///
     /// The API key is only forwarded to the client and never logged (I12).
     pub async fn assess(
         &self,
         bz: &BugzillaClient,
         key: &str,
         ids: &[u64],
+        caller: Option<&str>,
     ) -> BTreeMap<u64, (Access, Value)> {
         let mut out = BTreeMap::new();
         if ids.is_empty() {
@@ -176,7 +182,7 @@ impl Guard {
         for &id in ids {
             let entry = match fetched.get(&id) {
                 Some(bug) => {
-                    let meta = BugMeta::from_json(bug);
+                    let meta = BugMeta::from_json(bug, caller);
                     (
                         self.policy.classify(&meta, now, Operation::Access),
                         bug.clone(),
@@ -255,6 +261,7 @@ impl Guard {
         bz: &BugzillaClient,
         key: &str,
         req: &SearchRequest<'_>,
+        caller: Option<&str>,
     ) -> anyhow::Result<Vec<Value>> {
         let SearchRequest {
             query,
@@ -309,7 +316,7 @@ impl Guard {
                         .is_some_and(|id| seen.insert(id))
                 })
                 .collect();
-            let (kept, dropped) = self.filter_bug_list(fresh);
+            let (kept, dropped) = self.filter_bug_list(fresh, caller);
             dropped_total += dropped;
             visible.extend(kept);
             scanned += returned;
@@ -371,6 +378,7 @@ impl Guard {
         bz: &BugzillaClient,
         key: &str,
         ids: &BTreeSet<u64>,
+        caller: Option<&str>,
     ) -> BTreeSet<u64> {
         let now = Utc::now();
         // Bug id 0 never exists, so an empty candidate set still costs one
@@ -399,7 +407,7 @@ impl Guard {
                 if !ids.contains(&id) {
                     continue;
                 }
-                let meta = BugMeta::from_json(bug);
+                let meta = BugMeta::from_json(bug, caller);
                 if self
                     .policy
                     .classify(&meta, now, Operation::Access)
@@ -732,17 +740,61 @@ impl Guard {
     /// The prospective bug is dated NOW, so an age rule (`younger_than_days`,
     /// `min_bug_age_days`) refuses creation wherever it would immediately
     /// hide the result. Filing a bug nobody may then read is not a service.
+    ///
+    /// `created_by_me` is forced to `Some(true)` unconditionally: the
+    /// creator of a bug being filed is definitionally the caller — Bugzilla
+    /// assigns `creator` server-side from the authenticating account, and
+    /// the typed `create_bug` parameters cannot claim it. No `whoami`
+    /// lookup is ever performed for the create gate (which is also why a
+    /// create-scoped identity rule never triggers one — see
+    /// `Policy::needs_identity`). Consequence: a create-covering rule with
+    /// `created_by_me = true` matches every create request that reaches it,
+    /// and one with `created_by_me = false` can never match a create.
     pub fn may_create(&self, requested: &Value) -> bool {
-        let mut meta = BugMeta::from_json(requested);
+        let mut meta = BugMeta::from_json(requested, None);
         meta.creation_time = Some(Utc::now());
         // Bugzilla augments the group list server-side on creation; the
         // request's claim about it is not knowledge (see above).
         meta.groups = None;
+        // The filer IS the creator — a fact, not a claim (see above).
+        meta.created_by_me = Some(true);
         // Every other field the request does not mention is unknown, not
         // empty, and classification fails closed on it (I4).
         self.policy
             .classify(&meta, Utc::now(), Operation::Create)
             .allows(Capability::Create)
+    }
+
+    /// Resolve the caller's login for this tool call, lazily.
+    ///
+    /// Contract (see DESIGN.md, "Identity resolution"):
+    /// - when the policy consults no identity for access classification
+    ///   ([`Policy::needs_identity`] is false), returns `None` WITHOUT any
+    ///   HTTP request — a policy without `created_by_me` never costs a
+    ///   `whoami` lookup;
+    /// - otherwise performs exactly one `GET /rest/whoami` and returns the
+    ///   account's login, mapping every failure to `None` (the sanitized
+    ///   error is debug-logged only — never the key, I12). `None` makes
+    ///   every `created_by_me` criterion undecidable, which denies every
+    ///   classification consulting it (I4): a whoami outage blacks out
+    ///   what the identity rules cover, it never fails open.
+    ///
+    /// Callers (the MCP tools) invoke this at most once per tool call and
+    /// thread the result to every classification within that call. The
+    /// result is never cached across tool calls.
+    pub async fn resolve_caller(&self, bz: &BugzillaClient, key: &str) -> Option<String> {
+        if !self.policy.needs_identity() {
+            return None;
+        }
+        match bz.whoami(key).await {
+            Ok(login) => Some(login),
+            Err(err) => {
+                // Sanitized by the client (I12); identity stays unknown and
+                // every consulted identity rule fails closed (I4).
+                tracing::debug!(error = %err, "whoami failed; caller identity unresolved");
+                None
+            }
+        }
     }
 
     /// The refusal for a bug that was not filed.
@@ -785,12 +837,17 @@ impl Guard {
     /// The input objects must include the classification fields (callers
     /// fetch `requested ∪ CLASSIFY_FIELDS`), otherwise bugs may be
     /// misclassified against empty metadata.
-    pub fn filter_bug_list(&self, bugs: Vec<Value>) -> (Vec<Value>, usize) {
+    ///
+    /// `caller` is the login resolved once for the surrounding tool call
+    /// ([`Guard::resolve_caller`]); under an identity-consulting policy a
+    /// caller of `None` denies every bug the identity rules are consulted
+    /// for (I4).
+    pub fn filter_bug_list(&self, bugs: Vec<Value>, caller: Option<&str>) -> (Vec<Value>, usize) {
         let now = Utc::now();
         let mut kept = Vec::new();
         let mut dropped = 0usize;
         for bug in bugs {
-            let meta = BugMeta::from_json(&bug);
+            let meta = BugMeta::from_json(&bug, caller);
             let access = self.policy.classify(&meta, now, Operation::Access);
             if access.allows(Capability::Read) {
                 kept.push(bug);
@@ -1361,7 +1418,7 @@ products = ["NoView*"]
             // comments-only grants neither read nor summary => dropped.
             json!({"id": 4, "product": "NoViewer", "summary": "also hidden"}),
         ];
-        let (kept, dropped) = g.filter_bug_list(bugs);
+        let (kept, dropped) = g.filter_bug_list(bugs, None);
         assert_eq!(dropped, 2, "denied and view-less bugs are dropped");
         assert_eq!(kept.len(), 2);
         // Full-read bug passes through unmodified — extra fields intact, no
@@ -1402,7 +1459,7 @@ products = ["NoView*"]
             // evaluated, so this one goes too.
             json!({"id": 6, "groups": []}),
         ];
-        let (kept, dropped) = g.filter_bug_list(bugs);
+        let (kept, dropped) = g.filter_bug_list(bugs, None);
         assert_eq!(dropped, 5, "only the plain, world-readable bug survives");
         assert_eq!(kept.len(), 1);
         assert_eq!(kept[0]["id"], json!(1));
@@ -1416,7 +1473,7 @@ products = ["NoView*"]
             ),
         };
         let (kept, dropped) =
-            g.filter_bug_list(vec![json!({"id": 9, "product": "x", "cc": ["a@b"]})]);
+            g.filter_bug_list(vec![json!({"id": 9, "product": "x", "cc": ["a@b"]})], None);
         assert_eq!(dropped, 0);
         assert_eq!(kept.len(), 1);
         assert_eq!(kept[0]["cc"], json!(["a@b"]));
@@ -1428,7 +1485,7 @@ products = ["NoView*"]
         let g = Guard {
             policy: Policy::default(),
         };
-        let (kept, dropped) = g.filter_bug_list(vec![json!({"id": 1}), json!({"id": 2})]);
+        let (kept, dropped) = g.filter_bug_list(vec![json!({"id": 1}), json!({"id": 2})], None);
         assert_eq!(kept.len(), 2);
         assert_eq!(dropped, 0);
     }
@@ -1438,7 +1495,7 @@ products = ["NoView*"]
         let g = Guard {
             policy: policy("default_action = \"deny\""),
         };
-        let (kept, dropped) = g.filter_bug_list(vec![json!({"id": 1}), json!({"id": 2})]);
+        let (kept, dropped) = g.filter_bug_list(vec![json!({"id": 1}), json!({"id": 2})], None);
         assert!(kept.is_empty());
         assert_eq!(dropped, 2);
     }
@@ -1448,7 +1505,7 @@ products = ["NoView*"]
         let g = Guard {
             policy: Policy::default(),
         };
-        let (kept, dropped) = g.filter_bug_list(Vec::new());
+        let (kept, dropped) = g.filter_bug_list(Vec::new(), None);
         assert!(kept.is_empty());
         assert_eq!(dropped, 0);
     }
@@ -1464,7 +1521,7 @@ products = ["NoView*"]
             json!({"id": 1, "product": "P", "groups": ["suse-security"]}),
             json!({"id": 2, "product": "P", "groups": []}),
         ];
-        let (kept, dropped) = g.filter_bug_list(bugs);
+        let (kept, dropped) = g.filter_bug_list(bugs, None);
         assert_eq!(dropped, 1);
         assert_eq!(kept.len(), 1);
         assert_eq!(kept[0]["id"], json!(2));
@@ -1637,6 +1694,44 @@ products = ["NoView*"]
     }
 
     #[test]
+    fn may_create_forces_created_by_me_true_without_whoami() {
+        // The account filing a bug is definitionally its creator: Bugzilla
+        // assigns `creator` server-side, and the typed create params cannot
+        // claim it. may_create takes no client and performs no whoami — the
+        // forcing is a fact about the operation, not a lookup. A
+        // create-covering deny rule on created_by_me = true therefore
+        // refuses every create request that reaches it...
+        let deny_own = Guard {
+            policy: policy(concat!(
+                "[[rule]]\nname = \"no-self-filing\"\naction = \"deny\"\n",
+                "operations = [\"create\"]\n",
+                "[rule.match]\ncreated_by_me = true\n",
+            )),
+        };
+        assert!(!deny_own.may_create(&create_request("openSUSE")));
+
+        // ...and one on created_by_me = false can never match a create: the
+        // rule is a definitive No and the allowing default decides.
+        let deny_foreign = Guard {
+            policy: policy(concat!(
+                "[[rule]]\nname = \"no-foreign\"\naction = \"deny\"\n",
+                "[rule.match]\ncreated_by_me = false\n",
+            )),
+        };
+        assert!(deny_foreign.may_create(&create_request("openSUSE")));
+
+        // The unscoped deny-own variant refuses creation too: forcing does
+        // not depend on the rule's scoping, only on the operation.
+        let deny_own_unscoped = Guard {
+            policy: policy(concat!(
+                "[[rule]]\nname = \"no-self-filing\"\naction = \"deny\"\n",
+                "[rule.match]\ncreated_by_me = true\n",
+            )),
+        };
+        assert!(!deny_own_unscoped.may_create(&create_request("openSUSE")));
+    }
+
+    #[test]
     fn shipped_example_policy_files_into_desktop_products_only_and_keeps_reads() {
         // examples/policy.toml promises, in its header: new bug reports are
         // accepted into the desktop products ONLY (the create-scoped
@@ -1681,21 +1776,32 @@ products = ["NoView*"]
         req["groups"] = json!(["security-team"]);
         assert!(!g.may_create(&req), "claimed groups: refused");
 
+        // Every read below runs with the caller's identity KNOWN, as
+        // resolve_caller provides it in production: the "my-own-reports"
+        // rule consults created_by_me, so identity-unknown classification
+        // is a different (pinned further down) regime.
+        let caller = Some("reporter@example.com");
+
         // Issue #26: the create grant is scoped away from access, so an
-        // existing world-readable desktop bug keeps its FULL read — under
-        // the pre-fix policy shape the same rule was first match for reads
-        // and silently revoked everything but `create`.
-        let public = BugMeta::from_json(&json!({
-            "id": 500,
-            "summary": "totem crashes when seeking in a webm file",
-            "product": "GNOME Multimedia",
-            "component": "totem",
-            "groups": [],
-            "keywords": [],
-            "whiteboard": "",
-            "status": "NEW",
-            "creation_time": "2020-01-01T00:00:00Z",
-        }));
+        // existing world-readable desktop bug someone ELSE filed keeps its
+        // FULL read — under the pre-fix policy shape the same rule was
+        // first match for reads and silently revoked everything but
+        // `create`.
+        let public = BugMeta::from_json(
+            &json!({
+                "id": 500,
+                "summary": "totem crashes when seeking in a webm file",
+                "product": "GNOME Multimedia",
+                "component": "totem",
+                "groups": [],
+                "keywords": [],
+                "whiteboard": "",
+                "status": "NEW",
+                "creator": "other.person@example.com",
+                "creation_time": "2020-01-01T00:00:00Z",
+            }),
+            caller,
+        );
         assert!(
             g.policy
                 .classify(&public, Utc::now(), Operation::Access)
@@ -1703,9 +1809,9 @@ products = ["NoView*"]
             "existing desktop bugs must stay fully readable"
         );
 
-        // ...while a group-restricted desktop bug stays denied: the grant
-        // does not shadow the deny rules for reads either.
-        let restricted = BugMeta::from_json(&json!({
+        // ...while a group-restricted desktop bug someone else filed stays
+        // denied: the grant does not shadow the deny rules for reads either.
+        let restricted_foreign = json!({
             "id": 501,
             "summary": "totem crashes when seeking in a webm file",
             "product": "GNOME Multimedia",
@@ -1714,8 +1820,10 @@ products = ["NoView*"]
             "keywords": [],
             "whiteboard": "",
             "status": "NEW",
+            "creator": "other.person@example.com",
             "creation_time": "2020-01-01T00:00:00Z",
-        }));
+        });
+        let restricted = BugMeta::from_json(&restricted_foreign, caller);
         assert!(
             matches!(
                 g.policy
@@ -1723,6 +1831,74 @@ products = ["NoView*"]
                 Access::Denied { .. }
             ),
             "group-restricted desktop bugs must stay denied"
+        );
+
+        // The identity carve-out ("my-own-reports"): the SAME
+        // group-restricted bug, authored by the caller, is readable —
+        // reads, comments, history and attachment listing, and nothing
+        // that writes.
+        let mut own_restricted_json = restricted_foreign.clone();
+        own_restricted_json["creator"] = json!("reporter@example.com");
+        let own_restricted = BugMeta::from_json(&own_restricted_json, caller);
+        let own_access = g
+            .policy
+            .classify(&own_restricted, Utc::now(), Operation::Access);
+        for cap in [
+            Capability::Read,
+            Capability::Comments,
+            Capability::History,
+            Capability::Attachments,
+        ] {
+            assert!(
+                own_access.allows(cap),
+                "the caller's own group-restricted bug must grant {cap:?}"
+            );
+        }
+        for cap in Capability::ALL.iter().filter(|c| c.is_write()) {
+            assert!(
+                !own_access.allows(*cap),
+                "the my-own-reports carve-out must not grant the write {cap:?}"
+            );
+        }
+
+        // Identity unknown (whoami failed): the my-own-reports rule cannot
+        // be decided for ANY bug it is consulted for, and an undecidable
+        // consulted rule denies (I4) — the caller's own restricted bug AND
+        // the world-readable public bug alike. This blackout is the
+        // deliberate fail-closed reading; do not "fix" it into fail-open.
+        for bug_json in [&own_restricted_json, &restricted_foreign] {
+            let unknown = BugMeta::from_json(bug_json, None);
+            assert!(
+                matches!(
+                    g.policy.classify(&unknown, Utc::now(), Operation::Access),
+                    Access::Denied { .. }
+                ),
+                "identity-unknown must deny (blackout), bug {}",
+                bug_json["id"]
+            );
+        }
+        let public_unknown = BugMeta::from_json(
+            &json!({
+                "id": 500,
+                "summary": "totem crashes when seeking in a webm file",
+                "product": "GNOME Multimedia",
+                "component": "totem",
+                "groups": [],
+                "keywords": [],
+                "whiteboard": "",
+                "status": "NEW",
+                "creator": "other.person@example.com",
+                "creation_time": "2020-01-01T00:00:00Z",
+            }),
+            None,
+        );
+        assert!(
+            matches!(
+                g.policy
+                    .classify(&public_unknown, Utc::now(), Operation::Access),
+                Access::Denied { .. }
+            ),
+            "even a world-readable desktop bug is denied while identity is unknown"
         );
     }
 
@@ -1735,23 +1911,30 @@ products = ["NoView*"]
         // comment invites — must not thereby expose security-group bugs.
         // Pin both layers on a bug carrying NO other deniable signal: no
         // marker in the summary, no keywords, empty whiteboard, years past
-        // every freshness window.
+        // every freshness window — and somebody ELSE'S bug under a resolved
+        // caller identity, so the "my-own-reports" carve-out (a definitive
+        // No here) neither grants nor fails closed in the way.
+        let caller = Some("reporter@example.com");
         let path =
             std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/policy.toml");
         let toml = std::fs::read_to_string(path).expect("example policy must exist in-repo");
-        let bug = BugMeta::from_json(&json!({
-            "id": 42,
-            "summary": "kernel oops when unplugging a USB dock",
-            "groups": ["team-security"],
-            "keywords": [],
-            "whiteboard": "",
-            "product": "Base System",
-            "component": "Kernel",
-            "status": "NEW",
-            "severity": "major",
-            "priority": "P2",
-            "creation_time": "2020-01-01T00:00:00Z",
-        }));
+        let bug = BugMeta::from_json(
+            &json!({
+                "id": 42,
+                "summary": "kernel oops when unplugging a USB dock",
+                "groups": ["team-security"],
+                "keywords": [],
+                "whiteboard": "",
+                "product": "Base System",
+                "component": "Kernel",
+                "status": "NEW",
+                "severity": "major",
+                "priority": "P2",
+                "creator": "other.person@example.com",
+                "creation_time": "2020-01-01T00:00:00Z",
+            }),
+            caller,
+        );
 
         // The shipped file as-is: denied (the broad rule reaches it first).
         let full = policy(&toml);
@@ -1788,19 +1971,23 @@ products = ["NoView*"]
         // A restricted-but-not-security bug is exactly what an operator
         // removes the broad rule FOR: under the narrowed policy it falls
         // through to default_action and becomes visible.
-        let partner = BugMeta::from_json(&json!({
-            "id": 43,
-            "summary": "invoice import fails for partner deployments",
-            "groups": ["partnerconfidential"],
-            "keywords": [],
-            "whiteboard": "",
-            "product": "Base System",
-            "component": "Billing",
-            "status": "NEW",
-            "severity": "major",
-            "priority": "P2",
-            "creation_time": "2020-01-01T00:00:00Z",
-        }));
+        let partner = BugMeta::from_json(
+            &json!({
+                "id": 43,
+                "summary": "invoice import fails for partner deployments",
+                "groups": ["partnerconfidential"],
+                "keywords": [],
+                "whiteboard": "",
+                "product": "Base System",
+                "component": "Billing",
+                "status": "NEW",
+                "severity": "major",
+                "priority": "P2",
+                "creator": "other.person@example.com",
+                "creation_time": "2020-01-01T00:00:00Z",
+            }),
+            caller,
+        );
         assert!(
             matches!(
                 full.classify(&partner, Utc::now(), Operation::Access),
@@ -1911,14 +2098,17 @@ group_restricted = true
         // create-scoped rule is invisible to access classification, so the
         // bug falls through the deny rule to the allowing default — this is
         // the read the pre-fix policy shape silently revoked.
-        let public = BugMeta::from_json(&json!({
-            "id": 100,
-            "summary": "boot hangs after update",
-            "product": "SUSE Linux Enterprise Server 15",
-            "component": "Kernel",
-            "groups": [],
-            "creation_time": "2020-01-01T00:00:00Z",
-        }));
+        let public = BugMeta::from_json(
+            &json!({
+                "id": 100,
+                "summary": "boot hangs after update",
+                "product": "SUSE Linux Enterprise Server 15",
+                "component": "Kernel",
+                "groups": [],
+                "creation_time": "2020-01-01T00:00:00Z",
+            }),
+            None,
+        );
         match g.policy.classify(&public, Utc::now(), Operation::Access) {
             Access::Granted { rule, .. } => assert_eq!(rule, "default"),
             other => panic!("non-restricted bug must stay readable, got {other:?}"),
@@ -1926,14 +2116,17 @@ group_restricted = true
 
         // A group-restricted bug in the same product stays denied: the
         // create grant does not shadow the deny rule for reads.
-        let restricted = BugMeta::from_json(&json!({
-            "id": 101,
-            "summary": "boot hangs after update",
-            "product": "SUSE Linux Enterprise Server 15",
-            "component": "Kernel",
-            "groups": ["secteam"],
-            "creation_time": "2020-01-01T00:00:00Z",
-        }));
+        let restricted = BugMeta::from_json(
+            &json!({
+                "id": 101,
+                "summary": "boot hangs after update",
+                "product": "SUSE Linux Enterprise Server 15",
+                "component": "Kernel",
+                "groups": ["secteam"],
+                "creation_time": "2020-01-01T00:00:00Z",
+            }),
+            None,
+        );
         match g
             .policy
             .classify(&restricted, Utc::now(), Operation::Access)

--- a/crates/bugwarden-core/src/policy.rs
+++ b/crates/bugwarden-core/src/policy.rs
@@ -259,6 +259,23 @@ pub struct Matcher {
     /// (I4), whichever side the rule asked about.
     #[serde(default)]
     pub group_restricted: Option<bool>,
+    /// Matches on whether the REQUESTING account authored the bug: `true`
+    /// selects the caller's own bug reports, `false` everyone else's.
+    ///
+    /// This is the one identity-relative criterion — it describes the
+    /// bug–caller relationship, not the bug's content. The caller's login
+    /// is resolved once per tool call (`Guard::resolve_caller`, backed by
+    /// Bugzilla's `whoami` endpoint) and compared case-insensitively
+    /// against the bug's `creator`. When the relationship cannot be
+    /// established — the creator is unreadable, OR the caller's identity
+    /// did not resolve (no identity rule triggered a lookup, or `whoami`
+    /// failed) — the criterion is undecidable and resolves per
+    /// `unknown_matches` fail-closed (I4), whichever side the rule asked
+    /// about. In the create gate the prospective bug's author is
+    /// definitionally the caller, so there `created_by_me` is forced true
+    /// with no lookup at all (see `Guard::may_create`).
+    #[serde(default)]
+    pub created_by_me: Option<bool>,
     /// Matches when `creation_time` is newer than `now - N days`.
     ///
     /// A bug with a missing/unparsable `creation_time` MATCHES this
@@ -368,6 +385,20 @@ impl Matcher {
                 None => unknown = true,
                 Some(groups) => {
                     if !groups.is_empty() != want_restricted {
+                        return MatchOutcome::No;
+                    }
+                }
+            }
+        }
+
+        if let Some(want_mine) = self.created_by_me {
+            match bug.created_by_me {
+                // Creator unreadable or caller identity unresolved: the
+                // relationship answers neither way, whichever side the rule
+                // asked about (I4 — classify() resolves Unknown fail-closed).
+                None => unknown = true,
+                Some(mine) => {
+                    if mine != want_mine {
                         return MatchOutcome::No;
                     }
                 }
@@ -801,6 +832,23 @@ impl Policy {
         }
     }
 
+    /// Whether classifying for [`Operation::Access`] can consult the
+    /// caller's identity, i.e. whether any rule consulted for `access`
+    /// carries a `created_by_me` criterion.
+    ///
+    /// This is the laziness contract behind `Guard::resolve_caller`: a
+    /// policy for which this returns `false` never triggers a `whoami`
+    /// lookup — not once, on any tool call. Rules scoped to ONLY the
+    /// `create` operation do not count: the create gate forces
+    /// `created_by_me` to true without resolving anything (see
+    /// `Guard::may_create`), so a create-scoped identity rule needs no
+    /// identity either.
+    pub fn needs_identity(&self) -> bool {
+        self.rules
+            .iter()
+            .any(|r| r.applies_to(Operation::Access) && r.matcher.created_by_me.is_some())
+    }
+
     /// Build a grant, stripping write capabilities when `global.read_only`.
     fn grant(&self, caps: impl IntoIterator<Item = Capability>, rule: &str) -> Access {
         let mut set: BTreeSet<Capability> = caps.into_iter().collect();
@@ -847,6 +895,12 @@ pub struct BugMeta {
     pub whiteboard: Option<String>,
     /// Creation time; `None` when absent or unparsable.
     pub creation_time: Option<DateTime<Utc>>,
+    /// Whether the requesting account authored this bug. `Some(true/false)`
+    /// is an established relationship; `None` means it cannot be known —
+    /// the bug's `creator` was unreadable, OR the caller's identity was not
+    /// resolved (no identity criterion in the policy, or the `whoami`
+    /// lookup failed). Unknown fails closed like every other field (I4).
+    pub created_by_me: Option<bool>,
 }
 
 /// A string field, or `None` when absent or not a string.
@@ -902,13 +956,21 @@ fn whiteboard_field(v: &Value) -> Option<String> {
 impl BugMeta {
     /// Build classification metadata from a Bugzilla REST bug object.
     ///
+    /// `caller` is the requesting account's login (as resolved by
+    /// `Guard::resolve_caller`), or `None` when the caller's identity is
+    /// unknown. `created_by_me` is established only when BOTH sides are
+    /// known: the bug's `creator` field is a string AND `caller` is
+    /// `Some`, compared case-insensitively (the same normalization the
+    /// glob matcher applies). Either side missing leaves the relationship
+    /// unknown, never assumed.
+    ///
     /// Tolerant on shape — the `component` field may be a string or an array
     /// of strings, `groups` elements may be plain names or objects carrying a
     /// `name` key, the whiteboard may arrive under either key — but tolerance
     /// stops short of pretending a field was there. Anything absent, null,
     /// oddly typed, or only partially recoverable becomes `None`, i.e.
     /// unknown, which fails closed during classification (I4).
-    pub fn from_json(v: &Value) -> BugMeta {
+    pub fn from_json(v: &Value, caller: Option<&str>) -> BugMeta {
         BugMeta {
             id: v.get("id").and_then(Value::as_u64).unwrap_or(0),
             summary: str_field(v, "summary"),
@@ -925,6 +987,12 @@ impl BugMeta {
                 .and_then(Value::as_str)
                 .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
                 .map(|dt| dt.with_timezone(&Utc)),
+            created_by_me: match (caller, str_field(v, "creator")) {
+                (Some(login), Some(creator)) => {
+                    Some(login.to_lowercase() == creator.to_lowercase())
+                }
+                _ => None,
+            },
         }
     }
 }
@@ -994,6 +1062,7 @@ mod tests {
             groups: Some(vec![]),
             whiteboard: Some("needs-triage [qa:blocked]".into()),
             creation_time: Some(t("2025-06-01T00:00:00Z")),
+            created_by_me: Some(false),
         }
     }
 
@@ -1312,6 +1381,54 @@ mod tests {
     }
 
     #[test]
+    fn matcher_created_by_me_semantics() {
+        let mine = BugMeta {
+            created_by_me: Some(true),
+            ..meta()
+        };
+        let foreign = BugMeta {
+            created_by_me: Some(false),
+            ..meta()
+        };
+
+        let want_mine = Matcher {
+            created_by_me: Some(true),
+            ..Default::default()
+        };
+        assert!(want_mine.evaluate(&mine, now()).is_yes());
+        assert_eq!(want_mine.evaluate(&foreign, now()), MatchOutcome::No);
+
+        let want_foreign = Matcher {
+            created_by_me: Some(false),
+            ..Default::default()
+        };
+        assert!(want_foreign.evaluate(&foreign, now()).is_yes());
+        assert_eq!(want_foreign.evaluate(&mine, now()), MatchOutcome::No);
+    }
+
+    #[test]
+    fn matcher_created_by_me_unresolved_is_unknown_either_way() {
+        // Creator unreadable or caller identity unresolved: the relationship
+        // answers neither way, whichever side the rule asked about — it is
+        // classify() that resolves the Unknown on the restrictive side (I4).
+        let unresolved = BugMeta {
+            created_by_me: None,
+            ..meta()
+        };
+        for asked in [true, false] {
+            let m = Matcher {
+                created_by_me: Some(asked),
+                ..Default::default()
+            };
+            assert_eq!(
+                m.evaluate(&unresolved, now()),
+                MatchOutcome::Unknown,
+                "asked for created_by_me = {asked}"
+            );
+        }
+    }
+
+    #[test]
     fn matcher_every_criterion_reports_unknown_on_an_unreadable_field() {
         // No criterion may silently treat "could not read" as "empty".
         let cases: Vec<(Matcher, BugMeta)> = vec![
@@ -1412,6 +1529,16 @@ mod tests {
                 },
                 BugMeta {
                     creation_time: None,
+                    ..meta()
+                },
+            ),
+            (
+                Matcher {
+                    created_by_me: Some(true),
+                    ..Default::default()
+                },
+                BugMeta {
+                    created_by_me: None,
                     ..meta()
                 },
             ),
@@ -1821,6 +1948,119 @@ products = ["SUSE*"]
         assert!(!p.rules[1].applies_to(Operation::Access));
         assert!(!p.rules[2].applies_to(Operation::Create));
         assert!(p.rules[2].applies_to(Operation::Access));
+    }
+
+    // ---------- created_by_me (identity-relative matcher) ----------
+
+    #[test]
+    fn created_by_me_toml_spelling_pinned() {
+        // Pins the operator-facing TOML spelling `created_by_me = true|false`
+        // and that an absent key parses as None (criterion not present).
+        let s = concat!(
+            "[[rule]]\nname = \"mine\"\naction = \"deny\"\n",
+            "[rule.match]\ncreated_by_me = true\n",
+            "[[rule]]\nname = \"foreign\"\naction = \"deny\"\n",
+            "[rule.match]\ncreated_by_me = false\n",
+            "[[rule]]\nname = \"absent\"\naction = \"deny\"\n",
+        );
+        let p = Policy::from_toml_str(s).unwrap();
+        assert_eq!(p.rules[0].matcher.created_by_me, Some(true));
+        assert_eq!(p.rules[1].matcher.created_by_me, Some(false));
+        assert_eq!(p.rules[2].matcher.created_by_me, None);
+    }
+
+    #[test]
+    fn classify_identity_unknown_denies_for_deny_and_restrict_alike() {
+        // The I4 machinery, unchanged and uniform: a consulted rule whose
+        // created_by_me criterion cannot be decided denies the bug whatever
+        // the rule's action. Resolving identity-unknown as "criterion
+        // fails" instead would let a created_by_me deny rule be dodged by
+        // making whoami fail — fail open, exactly the asymmetry I4 forbids.
+        let unresolved = BugMeta {
+            created_by_me: None,
+            ..meta()
+        };
+        let known_foreign = meta(); // created_by_me: Some(false)
+
+        let deny_rule = Policy::from_toml_str(concat!(
+            "default_action = \"allow\"\n",
+            "[[rule]]\nname = \"no-self-service\"\naction = \"deny\"\n",
+            "[rule.match]\ncreated_by_me = true\n",
+        ))
+        .unwrap();
+        match deny_rule.classify(&unresolved, now(), Operation::Access) {
+            Access::Denied { rule } => assert_eq!(rule, "no-self-service"),
+            other => panic!("identity-unknown must deny under a deny rule, got {other:?}"),
+        }
+        // With the relationship known and negative, the rule is a definitive
+        // No and the default allows.
+        assert!(deny_rule
+            .classify(&known_foreign, now(), Operation::Access)
+            .allows(Capability::Read));
+
+        // The granting side of the same coin: a restrict rule under a
+        // denying default may neither grant on an unresolved identity nor
+        // be skipped into a later grant.
+        let restrict_rule = Policy::from_toml_str(concat!(
+            "default_action = \"deny\"\n",
+            "[[rule]]\nname = \"my-own\"\naction = \"restrict\"\n",
+            "capabilities = [\"read\"]\n",
+            "[rule.match]\ncreated_by_me = true\n",
+        ))
+        .unwrap();
+        match restrict_rule.classify(&unresolved, now(), Operation::Access) {
+            Access::Denied { rule } => assert_eq!(rule, "my-own:unreadable-metadata"),
+            other => panic!("identity-unknown must deny under a restrict rule, got {other:?}"),
+        }
+        let known_mine = BugMeta {
+            created_by_me: Some(true),
+            ..meta()
+        };
+        assert!(restrict_rule
+            .classify(&known_mine, now(), Operation::Access)
+            .allows(Capability::Read));
+    }
+
+    #[test]
+    fn needs_identity_only_for_access_covering_identity_rules() {
+        // No rules, or rules without the criterion: no identity needed —
+        // this is what keeps whoami at zero calls for every pre-identity
+        // policy.
+        assert!(!Policy::default().needs_identity());
+        assert!(!Policy::from_toml_str(concat!(
+            "[[rule]]\nname = \"embargo\"\naction = \"deny\"\n",
+            "[rule.match]\ngroups = [\"*security*\"]\n",
+        ))
+        .unwrap()
+        .needs_identity());
+
+        // An unscoped identity rule covers access: identity needed.
+        assert!(Policy::from_toml_str(concat!(
+            "[[rule]]\nname = \"mine\"\naction = \"deny\"\n",
+            "[rule.match]\ncreated_by_me = true\n",
+        ))
+        .unwrap()
+        .needs_identity());
+
+        // Explicitly access-scoped: identity needed.
+        assert!(Policy::from_toml_str(concat!(
+            "default_action = \"deny\"\n",
+            "[[rule]]\nname = \"mine\"\naction = \"restrict\"\n",
+            "capabilities = [\"read\"]\noperations = [\"access\"]\n",
+            "[rule.match]\ncreated_by_me = true\n",
+        ))
+        .unwrap()
+        .needs_identity());
+
+        // A create-scoped-ONLY identity rule never needs identity: the
+        // create gate forces created_by_me without any lookup.
+        assert!(!Policy::from_toml_str(concat!(
+            "[[rule]]\nname = \"no-self-filing\"\naction = \"deny\"\n",
+            "operations = [\"create\"]\n",
+            "[rule.match]\ncreated_by_me = true\n",
+        ))
+        .unwrap()
+        .needs_identity());
     }
 
     // ---------- Policy::load ----------
@@ -2397,19 +2637,22 @@ capabilities = ["summary", "create", "attach"]
 
     #[test]
     fn bugmeta_from_json_full_object() {
-        let m = BugMeta::from_json(&json!({
-            "id": 7,
-            "summary": "boom",
-            "product": "P",
-            "component": "C",
-            "status": "NEW",
-            "severity": "Major",
-            "priority": "P1",
-            "keywords": ["k1", "k2"],
-            "groups": ["g1"],
-            "whiteboard": "wb-text",
-            "creation_time": "2025-01-02T03:04:05Z"
-        }));
+        let m = BugMeta::from_json(
+            &json!({
+                "id": 7,
+                "summary": "boom",
+                "product": "P",
+                "component": "C",
+                "status": "NEW",
+                "severity": "Major",
+                "priority": "P1",
+                "keywords": ["k1", "k2"],
+                "groups": ["g1"],
+                "whiteboard": "wb-text",
+                "creation_time": "2025-01-02T03:04:05Z"
+            }),
+            None,
+        );
         assert_eq!(m.id, 7);
         assert_eq!(m.summary.as_deref(), Some("boom"));
         assert_eq!(m.product.as_deref(), Some("P"));
@@ -2426,18 +2669,18 @@ capabilities = ["summary", "create", "attach"]
     #[test]
     fn bugmeta_component_string_or_array() {
         assert_eq!(
-            BugMeta::from_json(&json!({"component": "One"})).components,
+            BugMeta::from_json(&json!({"component": "One"}), None).components,
             Some(vec!["One".to_string()])
         );
         assert_eq!(
-            BugMeta::from_json(&json!({"component": ["One", "Two"]})).components,
+            BugMeta::from_json(&json!({"component": ["One", "Two"]}), None).components,
             Some(vec!["One".to_string(), "Two".to_string()])
         );
     }
 
     #[test]
     fn bugmeta_group_objects_with_name_key() {
-        let m = BugMeta::from_json(&json!({"groups": [{"name": "sec"}, "plain"]}));
+        let m = BugMeta::from_json(&json!({"groups": [{"name": "sec"}, "plain"]}), None);
         assert_eq!(m.groups, Some(vec!["sec".to_string(), "plain".to_string()]));
     }
 
@@ -2452,19 +2695,19 @@ capabilities = ["summary", "create", "attach"]
             json!({"groups": [{"name": "sec"}, {"id": 9}]}),
             json!({"groups": [null]}),
         ] {
-            let m = BugMeta::from_json(&shape);
+            let m = BugMeta::from_json(&shape, None);
             assert_eq!(m.groups, None, "shape {shape}");
         }
         // An empty list is fully readable: the bug really is world-readable.
         assert_eq!(
-            BugMeta::from_json(&json!({"groups": []})).groups,
+            BugMeta::from_json(&json!({"groups": []}), None).groups,
             Some(vec![])
         );
     }
 
     #[test]
     fn bugmeta_missing_fields_are_unknown_not_empty() {
-        let m = BugMeta::from_json(&json!({}));
+        let m = BugMeta::from_json(&json!({}), None);
         assert_eq!(m.id, 0);
         assert!(m.summary.is_none());
         assert!(m.product.is_none());
@@ -2474,16 +2717,19 @@ capabilities = ["summary", "create", "attach"]
         assert!(m.whiteboard.is_none());
         assert!(m.creation_time.is_none());
         // Even a non-object is tolerated.
-        let m = BugMeta::from_json(&Value::Null);
+        let m = BugMeta::from_json(&Value::Null, None);
         assert_eq!(m.id, 0);
         assert!(m.groups.is_none());
     }
 
     #[test]
     fn bugmeta_present_but_empty_is_knowledge() {
-        let m = BugMeta::from_json(&json!({
-            "summary": "", "groups": [], "whiteboard": ""
-        }));
+        let m = BugMeta::from_json(
+            &json!({
+                "summary": "", "groups": [], "whiteboard": ""
+            }),
+            None,
+        );
         assert_eq!(m.summary.as_deref(), Some(""));
         assert_eq!(m.groups, Some(vec![]));
         assert_eq!(m.whiteboard.as_deref(), Some(""));
@@ -2493,16 +2739,22 @@ capabilities = ["summary", "create", "attach"]
     fn bugmeta_wrong_typed_fields_are_unknown() {
         // null or an unexpected type is not "empty" — the policy cannot read
         // it, so it must not be mistaken for a bug that carries nothing.
-        let m = BugMeta::from_json(&json!({
-            "summary": null, "groups": null, "whiteboard": null, "product": null
-        }));
+        let m = BugMeta::from_json(
+            &json!({
+                "summary": null, "groups": null, "whiteboard": null, "product": null
+            }),
+            None,
+        );
         assert!(m.summary.is_none());
         assert!(m.groups.is_none());
         assert!(m.whiteboard.is_none());
         assert!(m.product.is_none());
-        let m = BugMeta::from_json(&json!({
-            "summary": 7, "groups": {"name": "sec"}, "whiteboard": ["a"], "status": true
-        }));
+        let m = BugMeta::from_json(
+            &json!({
+                "summary": 7, "groups": {"name": "sec"}, "whiteboard": ["a"], "status": true
+            }),
+            None,
+        );
         assert!(m.summary.is_none());
         assert!(m.groups.is_none());
         assert!(m.whiteboard.is_none());
@@ -2510,28 +2762,62 @@ capabilities = ["summary", "create", "attach"]
     }
 
     #[test]
+    fn bugmeta_created_by_me_needs_both_creator_and_caller() {
+        let caller = Some("reporter@example.com");
+
+        // Equal: the caller authored the bug.
+        let m = BugMeta::from_json(&json!({"creator": "reporter@example.com"}), caller);
+        assert_eq!(m.created_by_me, Some(true));
+
+        // Unequal: somebody else's bug — knowledge, not ignorance.
+        let m = BugMeta::from_json(&json!({"creator": "other@example.com"}), caller);
+        assert_eq!(m.created_by_me, Some(false));
+
+        // Case-insensitively equal, matching the glob normalization.
+        let m = BugMeta::from_json(&json!({"creator": "Reporter@Example.COM"}), caller);
+        assert_eq!(m.created_by_me, Some(true));
+
+        // Creator absent: the relationship cannot be established.
+        let m = BugMeta::from_json(&json!({}), caller);
+        assert_eq!(m.created_by_me, None);
+
+        // Creator present but not a string: unreadable, not "nobody".
+        for creator in [json!(7), json!(null), json!({"name": "x"}), json!(["x"])] {
+            let m = BugMeta::from_json(&json!({ "creator": creator }), caller);
+            assert_eq!(m.created_by_me, None, "creator {creator}");
+        }
+
+        // Caller unresolved: unknown even with a perfectly readable creator.
+        let m = BugMeta::from_json(&json!({"creator": "reporter@example.com"}), None);
+        assert_eq!(m.created_by_me, None);
+    }
+
+    #[test]
     fn bugmeta_bad_creation_time_is_none() {
-        let m = BugMeta::from_json(&json!({"creation_time": "yesterday"}));
+        let m = BugMeta::from_json(&json!({"creation_time": "yesterday"}), None);
         assert!(m.creation_time.is_none());
-        let m = BugMeta::from_json(&json!({"creation_time": 1700000000}));
+        let m = BugMeta::from_json(&json!({"creation_time": 1700000000}), None);
         assert!(m.creation_time.is_none());
     }
 
     #[test]
     fn bugmeta_status_whiteboard_fallback() {
-        let m = BugMeta::from_json(&json!({"status_whiteboard": "legacy"}));
+        let m = BugMeta::from_json(&json!({"status_whiteboard": "legacy"}), None);
         assert_eq!(m.whiteboard.as_deref(), Some("legacy"));
         // "whiteboard" wins when both are present.
-        let m = BugMeta::from_json(&json!({"whiteboard": "new", "status_whiteboard": "old"}));
+        let m = BugMeta::from_json(
+            &json!({"whiteboard": "new", "status_whiteboard": "old"}),
+            None,
+        );
         assert_eq!(m.whiteboard.as_deref(), Some("new"));
         // An empty primary falls back to the legacy key.
-        let m = BugMeta::from_json(&json!({"whiteboard": "", "status_whiteboard": "old"}));
+        let m = BugMeta::from_json(&json!({"whiteboard": "", "status_whiteboard": "old"}), None);
         assert_eq!(m.whiteboard.as_deref(), Some("old"));
         // An unreadable key on either side makes the whiteboard unknown: the
         // text that could not be read may have held the marker.
-        let m = BugMeta::from_json(&json!({"whiteboard": 7, "status_whiteboard": ""}));
+        let m = BugMeta::from_json(&json!({"whiteboard": 7, "status_whiteboard": ""}), None);
         assert!(m.whiteboard.is_none());
-        let m = BugMeta::from_json(&json!({"whiteboard": "", "status_whiteboard": 7}));
+        let m = BugMeta::from_json(&json!({"whiteboard": "", "status_whiteboard": 7}), None);
         assert!(m.whiteboard.is_none());
     }
 }

--- a/crates/bugwarden-core/tests/guard_wiremock.rs
+++ b/crates/bugwarden-core/tests/guard_wiremock.rs
@@ -10,7 +10,7 @@ use bugwarden_core::client::BugzillaClient;
 use bugwarden_core::guard::{Guard, SearchRequest};
 use bugwarden_core::policy::{Access, Capability, Policy};
 use serde_json::json;
-use wiremock::matchers::{method, path, query_param};
+use wiremock::matchers::{method, path, query_param, query_param_contains};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
 /// Deliberately distinctive so a leak into any error text is unmistakable (I12).
@@ -66,7 +66,7 @@ groups = ["*security*", "*embargo*"]
 "#,
     );
     let bz = client(&server);
-    let out = g.assess(&bz, KEY, &[1, 2]).await;
+    let out = g.assess(&bz, KEY, &[1, 2], None).await;
 
     assert!(matches!(out[&1].0, Access::Denied { .. }));
     assert!(out[&2].0.allows(Capability::Read));
@@ -94,7 +94,7 @@ async fn assess_min_bug_age_denies_young_and_missing_creation_time() {
 
     let g = guard("[global]\nmin_bug_age_days = 7\n");
     let bz = client(&server);
-    let out = g.assess(&bz, KEY, &[1, 2, 3]).await;
+    let out = g.assess(&bz, KEY, &[1, 2, 3], None).await;
 
     assert!(matches!(out[&1].0, Access::Denied { .. }), "young bug");
     assert!(out[&2].0.allows(Capability::Read), "old bug");
@@ -139,7 +139,7 @@ async fn assess_costs_one_request_per_distinct_id_whatever_the_answer() {
 
     let g = guard(""); // default allow-all policy
     let bz = client(&server);
-    let out = g.assess(&bz, KEY, &[1, 2, 3]).await;
+    let out = g.assess(&bz, KEY, &[1, 2, 3], None).await;
 
     assert_eq!(out.len(), 3, "every requested id has an entry (I4)");
     assert!(out[&1].0.allows(Capability::Read));
@@ -183,7 +183,7 @@ async fn assess_never_batches_so_one_bad_id_cannot_poison_the_others() {
 
     let g = guard("");
     let bz = client(&server);
-    let out = g.assess(&bz, KEY, &[9, 1]).await;
+    let out = g.assess(&bz, KEY, &[9, 1], None).await;
 
     assert!(out[&1].0.allows(Capability::Read), "healthy id survives");
     match &out[&9].0 {
@@ -209,7 +209,7 @@ async fn assess_fan_out_is_bounded_and_the_excess_is_denied() {
     let ids: Vec<u64> = (1..=Guard::MAX_ASSESS_IDS as u64 * 4).collect();
     let g = guard("");
     let bz = client(&server);
-    let out = g.assess(&bz, KEY, &ids).await;
+    let out = g.assess(&bz, KEY, &ids, None).await;
 
     assert_eq!(out.len(), ids.len(), "every id still gets an entry (I4)");
     for id in &ids {
@@ -237,7 +237,7 @@ async fn assess_repeated_ids_are_fetched_once() {
 
     let g = guard("");
     let bz = client(&server);
-    let out = g.assess(&bz, KEY, &[5, 5, 5]).await;
+    let out = g.assess(&bz, KEY, &[5, 5, 5], None).await;
 
     assert_eq!(out.len(), 1);
     assert!(out[&5].0.allows(Capability::Read));
@@ -260,7 +260,7 @@ async fn assess_id_absent_from_its_own_response_is_denied() {
 
     let g = guard("");
     let bz = client(&server);
-    let out = g.assess(&bz, KEY, &[1, 2]).await;
+    let out = g.assess(&bz, KEY, &[1, 2], None).await;
 
     assert!(out[&1].0.allows(Capability::Read));
     match &out[&2].0 {
@@ -289,7 +289,7 @@ async fn assess_single_id_failure_makes_exactly_one_request() {
 
     let g = guard(""); // default allow-all policy
     let bz = client(&server);
-    let out = g.assess(&bz, KEY, &[7]).await;
+    let out = g.assess(&bz, KEY, &[7], None).await;
 
     assert_eq!(out.len(), 1, "the requested id has an entry (I4)");
     match &out[&7].0 {
@@ -517,7 +517,7 @@ capabilities = ["summary"]
 "#,
     );
     let bz = client(&server);
-    let out = g.assess(&bz, KEY, &[1]).await;
+    let out = g.assess(&bz, KEY, &[1], None).await;
 
     let (access, raw) = &out[&1];
     assert!(access.allows(Capability::Summary));
@@ -620,7 +620,7 @@ async fn quicksearch_window_pages_have_no_holes_when_bugs_are_hidden() {
     let mut seen = Vec::new();
     for page in 0..4u32 {
         let got = g
-            .quicksearch_window(&bz, KEY, &search("q", 5, page * 5))
+            .quicksearch_window(&bz, KEY, &search("q", 5, page * 5), None)
             .await
             .expect("search succeeds");
         assert_eq!(
@@ -656,13 +656,13 @@ async fn quicksearch_window_pages_are_disjoint_and_gapless() {
     let mut paged = Vec::new();
     for page in 0..8u32 {
         let got = g
-            .quicksearch_window(&bz, KEY, &search("q", 4, page * 4))
+            .quicksearch_window(&bz, KEY, &search("q", 4, page * 4), None)
             .await
             .expect("search succeeds");
         paged.extend(ids_of(&got));
     }
     let whole = g
-        .quicksearch_window(&bz, KEY, &search("q", 32, 0))
+        .quicksearch_window(&bz, KEY, &search("q", 32, 0), None)
         .await
         .expect("search succeeds");
     assert_eq!(
@@ -688,11 +688,11 @@ async fn quicksearch_window_page_is_identical_whether_or_not_bugs_are_hidden() {
 
     let g = guard(EMBARGO_POLICY);
     let clean = g
-        .quicksearch_window(&client(&server_clean), KEY, &search("q", 4, 2))
+        .quicksearch_window(&client(&server_clean), KEY, &search("q", 4, 2), None)
         .await
         .expect("search succeeds");
     let mixed = g
-        .quicksearch_window(&client(&server_mixed), KEY, &search("q", 4, 2))
+        .quicksearch_window(&client(&server_mixed), KEY, &search("q", 4, 2), None)
         .await
         .expect("search succeeds");
     // Clean: visible are 1..12, so offset 2 limit 4 => 3,4,5,6.
@@ -719,12 +719,12 @@ async fn quicksearch_window_runs_out_like_a_normal_end_of_results() {
     let bz = client(&server);
 
     let tail = g
-        .quicksearch_window(&bz, KEY, &search("q", 10, 4))
+        .quicksearch_window(&bz, KEY, &search("q", 10, 4), None)
         .await
         .expect("search succeeds");
     assert_eq!(ids_of(&tail), vec![6, 7]);
     let past = g
-        .quicksearch_window(&bz, KEY, &search("q", 10, 50))
+        .quicksearch_window(&bz, KEY, &search("q", 10, 50), None)
         .await
         .expect("search succeeds");
     assert!(past.is_empty());
@@ -741,7 +741,7 @@ async fn quicksearch_window_scan_is_bounded() {
     let g = guard(EMBARGO_POLICY);
 
     let got = g
-        .quicksearch_window(&client(&server), KEY, &search("q", 50, 0))
+        .quicksearch_window(&client(&server), KEY, &search("q", 50, 0), None)
         .await
         .expect("search succeeds");
     assert!(got.is_empty(), "everything was hidden");
@@ -765,7 +765,7 @@ async fn quicksearch_window_deep_offset_is_empty_whether_or_not_bugs_are_hidden(
         let g = guard(EMBARGO_POLICY);
         for offset in [1_001u32, 1_010, 1_200, u32::MAX] {
             let got = g
-                .quicksearch_window(&client(&server), KEY, &search("q", 1, offset))
+                .quicksearch_window(&client(&server), KEY, &search("q", 1, offset), None)
                 .await
                 .expect("a deep offset is not an error");
             assert!(
@@ -791,7 +791,7 @@ async fn quicksearch_window_scan_target_does_not_track_the_requested_limit() {
         corpus_counted(&server, 1_000, &hidden).await;
         let g = guard(EMBARGO_POLICY);
         let _ = g
-            .quicksearch_window(&client(&server), KEY, &search("q", limit, 0))
+            .quicksearch_window(&client(&server), KEY, &search("q", limit, 0), None)
             .await
             .expect("search succeeds");
         counts.push(requests_to(&server).await);
@@ -821,7 +821,7 @@ async fn quicksearch_window_drops_rows_without_a_readable_id() {
 
     let g = guard(EMBARGO_POLICY);
     let got = g
-        .quicksearch_window(&client(&server), KEY, &search("q", 10, 0))
+        .quicksearch_window(&client(&server), KEY, &search("q", 10, 0), None)
         .await
         .expect("search succeeds");
     assert_eq!(ids_of(&got), vec![1, 2]);
@@ -842,7 +842,7 @@ async fn quicksearch_window_dedupes_rows_repeated_across_chunks() {
 
     let g = guard(EMBARGO_POLICY);
     let got = g
-        .quicksearch_window(&client(&server), KEY, &search("q", 400, 0))
+        .quicksearch_window(&client(&server), KEY, &search("q", 400, 0), None)
         .await
         .expect("search succeeds");
     let ids = ids_of(&got);
@@ -857,7 +857,7 @@ async fn quicksearch_window_zero_limit_touches_nothing() {
     // No mock is mounted: any upstream request would fail the call.
     let g = guard(EMBARGO_POLICY);
     let got = g
-        .quicksearch_window(&client(&server), KEY, &search("q", 0, 0))
+        .quicksearch_window(&client(&server), KEY, &search("q", 0, 0), None)
         .await
         .expect("zero limit is not an error");
     assert!(got.is_empty());
@@ -871,9 +871,173 @@ async fn quicksearch_window_returns_the_classified_objects() {
     corpus(&server, 3, &[2]).await;
     let g = guard(EMBARGO_POLICY);
     let got = g
-        .quicksearch_window(&client(&server), KEY, &search("q", 10, 0))
+        .quicksearch_window(&client(&server), KEY, &search("q", 10, 0), None)
         .await
         .expect("search succeeds");
     assert_eq!(ids_of(&got), vec![1, 3]);
     assert_eq!(got[0]["summary"], json!("test bug"), "full object returned");
+}
+
+// ---------------------------------------------------------------------------
+// whoami + resolve_caller (identity resolution for created_by_me)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn client_whoami_returns_the_login_name() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/whoami"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 4242, "name": "reporter@example.com", "real_name": "Reporter",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let bz = client(&server);
+    assert_eq!(bz.whoami(KEY).await.unwrap(), "reporter@example.com");
+}
+
+#[tokio::test]
+async fn client_whoami_missing_non_string_or_blank_name_is_a_failure() {
+    // A login that cannot be read is a FAILED resolution, never an empty
+    // one — and a blank login IS unreadable: accepting "" would let a
+    // degenerate empty caller compare equal to a blank creator field and
+    // grant on no evidence. resolve_caller maps the failure to None and
+    // identity stays unknown (I4).
+    for body in [
+        json!({ "id": 1 }),
+        json!({ "id": 1, "name": 7 }),
+        json!({ "id": 1, "name": "" }),
+        json!({ "id": 1, "name": "   " }),
+    ] {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/whoami"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body.clone()))
+            .mount(&server)
+            .await;
+        let bz = client(&server);
+        let err = bz.whoami(KEY).await.unwrap_err();
+        assert!(
+            err.to_string().contains("name"),
+            "unexpected error for body {body}: {err:#}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn whoami_api_key_absent_from_transport_error_i12() {
+    // Same pattern as api_key_absent_from_transport_error_i12: a connect
+    // error's URL would carry api_key=... — sanitize must strip it.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    drop(listener); // free the port so the connection is refused
+    let bz = BugzillaClient::new(&format!("http://{addr}"), false).expect("client");
+
+    let err = bz.whoami(KEY).await.unwrap_err();
+    let full = format!("{err:#} {err:?}");
+    assert!(
+        !full.contains(KEY),
+        "API key leaked into whoami transport error: {full}"
+    );
+}
+
+#[tokio::test]
+async fn resolve_caller_is_lazy_and_maps_failure_to_none() {
+    // No identity criterion in the policy: no request at all — the
+    // .expect(0) is verified when the mock server drops.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/whoami"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "name": "x@y" })))
+        .expect(0)
+        .mount(&server)
+        .await;
+    let g = guard(
+        "[[rule]]\nname = \"embargo\"\naction = \"deny\"\n[rule.match]\ngroups = [\"*security*\"]\n",
+    );
+    assert_eq!(g.resolve_caller(&client(&server), KEY).await, None);
+    drop(server);
+
+    let identity = concat!(
+        "[[rule]]\nname = \"mine\"\naction = \"restrict\"\ncapabilities = [\"read\"]\n",
+        "operations = [\"access\"]\n[rule.match]\ncreated_by_me = true\n",
+        "[[rule]]\nname = \"rest\"\naction = \"deny\"\n",
+    );
+
+    // Identity policy, working endpoint: exactly one lookup, login returned.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/whoami"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 1, "name": "reporter@example.com",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let g = guard(identity);
+    assert_eq!(
+        g.resolve_caller(&client(&server), KEY).await,
+        Some("reporter@example.com".to_string())
+    );
+    drop(server);
+
+    // Identity policy, failing endpoint: None, not an error — the caller
+    // stays unknown and classification fails closed downstream (I4).
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/whoami"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
+            "error": true, "message": "boom"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let g = guard(identity);
+    assert_eq!(g.resolve_caller(&client(&server), KEY).await, None);
+}
+
+#[tokio::test]
+async fn classification_fetch_requests_the_creator_field() {
+    // Pins `creator` in CLASSIFY_FIELDS end to end: the bug mock below only
+    // answers a classify fetch whose projection asks for the creator column,
+    // so dropping the field from CLASSIFY_FIELDS un-matches the mock, the
+    // fetch fails, the caller's own bug collapses to the uniform denial
+    // (fail closed, I4) — and this test fails. Response-side fixtures alone
+    // cannot pin this: they return `creator` whether or not it was asked
+    // for.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/whoami"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 1, "name": "reporter@example.com", "real_name": "Reporter",
+        })))
+        .mount(&server)
+        .await;
+    let mut own = bug(7, &["secteam"], OLD);
+    own["creator"] = json!("reporter@example.com");
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "7"))
+        .and(query_param_contains("include_fields", "creator"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [own] })))
+        .mount(&server)
+        .await;
+
+    let g = guard(concat!(
+        "[[rule]]\nname = \"my-own-reports\"\naction = \"restrict\"\n",
+        "capabilities = [\"read\"]\noperations = [\"access\"]\n",
+        "[rule.match]\ncreated_by_me = true\n",
+        "[[rule]]\nname = \"group-restricted\"\naction = \"deny\"\n",
+        "[rule.match]\ngroup_restricted = true\n",
+    ));
+    let bz = client(&server);
+    let caller = g.resolve_caller(&bz, KEY).await;
+    assert_eq!(caller.as_deref(), Some("reporter@example.com"));
+    let out = g.assess(&bz, KEY, &[7], caller.as_deref()).await;
+    assert!(
+        out[&7].0.allows(Capability::Read),
+        "the caller's own bug must classify from a creator-carrying projection"
+    );
 }

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -277,11 +277,17 @@ async fn record_event(
 /// summary-only is served as a summary view, matching what a fresh call would
 /// return. Anything that no longer classifies at all becomes the uniform
 /// restricted entry, byte-identical to a bug that never existed (I2).
+///
+/// `caller` is the SAME identity the up-front assessment used — resolved
+/// once per tool call and threaded here, so a bug the assessment granted on
+/// the caller's authorship cannot be dropped by a re-check running without
+/// that identity.
 fn assemble_bug_info(
     guard: &Guard,
     ids: &[u64],
     assessments: &BTreeMap<u64, (Access, Value)>,
     full: &BTreeMap<u64, Value>,
+    caller: Option<&str>,
 ) -> Value {
     let mut bugs: Vec<Value> = Vec::new();
     let mut restricted: Vec<Value> = Vec::new();
@@ -291,7 +297,7 @@ fn assemble_bug_info(
                 .get(id)
                 // Absent from the body response => fail closed (I4).
                 .and_then(|body| {
-                    let (kept, dropped) = guard.filter_bug_list(vec![body.clone()]);
+                    let (kept, dropped) = guard.filter_bug_list(vec![body.clone()], caller);
                     if dropped > 0 {
                         // The verdict flipped between the two fetches — the
                         // anomaly this re-check exists for. Server-side only
@@ -882,9 +888,17 @@ impl BugWarden {
         }
     }
 
-    /// Guard assessment for the given ids (fail closed, I4).
-    async fn assess(&self, key: &str, ids: &[u64]) -> BTreeMap<u64, (Access, Value)> {
-        self.guard.assess(&self.bz, key, ids).await
+    /// Guard assessment for the given ids (fail closed, I4). `caller` is
+    /// the identity resolved once at the tool entry
+    /// (`Guard::resolve_caller`) — never resolved here, so a tool call
+    /// costs at most one whoami lookup however many assessments it runs.
+    async fn assess(
+        &self,
+        key: &str,
+        ids: &[u64],
+        caller: Option<&str>,
+    ) -> BTreeMap<u64, (Access, Value)> {
+        self.guard.assess(&self.bz, key, ids, caller).await
     }
 
     /// Assess a single bug id and require `cap`. Returns `Some(denial)` when
@@ -896,9 +910,10 @@ impl BugWarden {
         key: &str,
         id: u64,
         cap: Capability,
+        caller: Option<&str>,
         ctx: &RequestContext<RoleServer>,
     ) -> Option<CallToolResult> {
-        let assessments = self.assess(key, &[id]).await;
+        let assessments = self.assess(key, &[id], caller).await;
         let entry = assessments.get(&id);
         let allowed = entry.is_some_and(|(access, _)| access.allows(cap));
         if let Some(cell) = audit_cell(ctx) {
@@ -952,7 +967,12 @@ impl BugWarden {
             return Ok(refusal);
         }
 
-        let assessments = self.assess(&key, &ids).await;
+        // Resolved at most once per tool call and threaded to EVERY
+        // classification below — the assessment, the assemble re-check and
+        // the link disclosure — so one verdict cannot be made with the
+        // identity and another without it.
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
+        let assessments = self.assess(&key, &ids, caller.as_deref()).await;
 
         // Full fetch only for Read-granted ids.
         let read_ids: Vec<u64> = ids
@@ -994,7 +1014,8 @@ impl BugWarden {
         // batched assessment covers them all; anything that fails to earn a
         // summary is removed before the body is served (I2, and the same bar
         // update_bug_dependencies applies before WRITING such a link).
-        let mut envelope = assemble_bug_info(&self.guard, &ids, &assessments, &full);
+        let mut envelope =
+            assemble_bug_info(&self.guard, &ids, &assessments, &full, caller.as_deref());
         let base_url = self.bz.base_url();
         // Only ids actually SERVED in this envelope are already answered for.
         // A requested id that was denied must not be whitelisted: asking
@@ -1019,7 +1040,10 @@ impl BugWarden {
         // every link is hidden would make "no links" and "links, all hidden"
         // cost different round trips (I2). download_attachment pads the same
         // way.
-        let mut allowed = self.guard.disclosable(&self.bz, &key, &named).await;
+        let mut allowed = self
+            .guard
+            .disclosable(&self.bz, &key, &named, caller.as_deref())
+            .await;
         allowed.extend(served);
         if let Some(bugs) = envelope.get_mut("bugs").and_then(Value::as_array_mut) {
             for bug in bugs.iter_mut() {
@@ -1090,8 +1114,9 @@ impl BugWarden {
     ) -> Result<CallToolResult, McpError> {
         tracing::info!(id = p.id, new_since = ?p.new_since, "tool: bug_history");
         let key = self.api_key(&ctx)?;
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
         if let Some(denied) = self
-            .deny_unless(&key, p.id, Capability::History, &ctx)
+            .deny_unless(&key, p.id, Capability::History, caller.as_deref(), &ctx)
             .await
         {
             return Ok(denied);
@@ -1103,7 +1128,10 @@ impl BugWarden {
                 // way to read out the existence of bugs the policy hides.
                 let base_url = self.bz.base_url();
                 let named = Guard::history_bug_ids(&history, base_url);
-                let disclosable = self.guard.disclosable(&self.bz, &key, &named).await;
+                let disclosable = self
+                    .guard
+                    .disclosable(&self.bz, &key, &named, caller.as_deref())
+                    .await;
                 if let Some(cell) = audit_cell(&ctx) {
                     let hidden: Vec<u64> = named.difference(&disclosable).copied().collect();
                     if !hidden.is_empty() {
@@ -1139,8 +1167,9 @@ impl BugWarden {
             "tool: bug_comments"
         );
         let key = self.api_key(&ctx)?;
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
         if let Some(denied) = self
-            .deny_unless(&key, p.id, Capability::Comments, &ctx)
+            .deny_unless(&key, p.id, Capability::Comments, caller.as_deref(), &ctx)
             .await
         {
             return Ok(denied);
@@ -1153,7 +1182,10 @@ impl BugWarden {
                 // of this bug ***" itself, so a hidden bug can name itself in
                 // the comments of one the client may read (I2).
                 let named = Guard::duplicate_marker_ids(&filtered);
-                let disclosable = self.guard.disclosable(&self.bz, &key, &named).await;
+                let disclosable = self
+                    .guard
+                    .disclosable(&self.bz, &key, &named, caller.as_deref())
+                    .await;
                 if let Some(cell) = audit_cell(&ctx) {
                     // Dropped private comments have no bug id: count only.
                     // Scrubbed duplicate-marker ids are the hidden bugs.
@@ -1208,6 +1240,7 @@ impl BugWarden {
 
         // limit/offset address the bugs the client may see; the guard scans
         // and filters upstream rows to fill that window (I2/I3).
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
         let kept = match self
             .guard
             .quicksearch_window(
@@ -1220,6 +1253,7 @@ impl BugWarden {
                     limit: p.limit,
                     offset: p.offset,
                 },
+                caller.as_deref(),
             )
             .await
         {
@@ -1246,7 +1280,10 @@ impl BugWarden {
             .flat_map(|b| Guard::linked_bug_ids(b, base_url))
             .filter(|id| !served.contains(id))
             .collect();
-        let mut allowed = self.guard.disclosable(&self.bz, &key, &named).await;
+        let mut allowed = self
+            .guard
+            .disclosable(&self.bz, &key, &named, caller.as_deref())
+            .await;
         allowed.extend(served);
         for bug in projected.iter_mut() {
             Guard::scrub_bug_links(bug, base_url, &allowed);
@@ -1344,7 +1381,11 @@ impl BugWarden {
         // COUNT, not the upstream handler's exact latency (a GET classify
         // vs a rejected POST), the same residual the download path accepts.
         if !self.guard.may_create(&payload) {
-            let _ = self.assess(&key, &[0]).await;
+            // No whoami on the create path, ever: the create gate forces
+            // created_by_me itself, and the padding classify against bug id
+            // 0 decides nothing — caller identity is deliberately None so
+            // the refused path keeps costing exactly one upstream request.
+            let _ = self.assess(&key, &[0], None).await;
             tracing::info!(product = %p.product, "guard denied bug creation");
             note_refused(&ctx);
             return Ok(err_text(Guard::create_denial()));
@@ -1387,8 +1428,9 @@ impl BugWarden {
             "tool: add_attachment"
         );
         let key = self.api_key(&ctx)?;
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
         if let Some(denied) = self
-            .deny_unless(&key, p.bug_id, Capability::Attach, &ctx)
+            .deny_unless(&key, p.bug_id, Capability::Attach, caller.as_deref(), &ctx)
             .await
         {
             return Ok(denied);
@@ -1446,8 +1488,9 @@ impl BugWarden {
             "tool: add_comment"
         );
         let key = self.api_key(&ctx)?;
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
         if let Some(denied) = self
-            .deny_unless(&key, p.bug_id, Capability::Comment, &ctx)
+            .deny_unless(&key, p.bug_id, Capability::Comment, caller.as_deref(), &ctx)
             .await
         {
             return Ok(denied);
@@ -1490,8 +1533,9 @@ impl BugWarden {
             ));
         }
         let key = self.api_key(&ctx)?;
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
         if let Some(denied) = self
-            .deny_unless(&key, p.bug_id, Capability::Status, &ctx)
+            .deny_unless(&key, p.bug_id, Capability::Status, caller.as_deref(), &ctx)
             .await
         {
             return Ok(denied);
@@ -1533,8 +1577,9 @@ impl BugWarden {
     ) -> Result<CallToolResult, McpError> {
         tracing::info!(bug_id = p.bug_id, assignee = %p.assignee, "tool: assign_bug");
         let key = self.api_key(&ctx)?;
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
         if let Some(denied) = self
-            .deny_unless(&key, p.bug_id, Capability::Assign, &ctx)
+            .deny_unless(&key, p.bug_id, Capability::Assign, caller.as_deref(), &ctx)
             .await
         {
             return Ok(denied);
@@ -1607,8 +1652,9 @@ impl BugWarden {
         attach_comment(&mut payload, &p.comment);
 
         let key = self.api_key(&ctx)?;
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
         if let Some(denied) = self
-            .deny_unless(&key, p.bug_id, Capability::Fields, &ctx)
+            .deny_unless(&key, p.bug_id, Capability::Fields, caller.as_deref(), &ctx)
             .await
         {
             return Ok(denied);
@@ -1688,8 +1734,9 @@ impl BugWarden {
         }
 
         let key = self.api_key(&ctx)?;
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
         let cell = audit_cell(&ctx);
-        let assessments = self.assess(&key, &ids).await;
+        let assessments = self.assess(&key, &ids, caller.as_deref()).await;
         let note = |id: u64, verdict: Verdict| {
             if let Some(cell) = &cell {
                 match assessments.get(&id) {
@@ -1744,7 +1791,11 @@ impl BugWarden {
     ) -> Result<CallToolResult, McpError> {
         tracing::info!(bug_id = p.bug_id, cc_email = %p.cc_email, "tool: add_cc_to_bug");
         let key = self.api_key(&ctx)?;
-        if let Some(denied) = self.deny_unless(&key, p.bug_id, Capability::Cc, &ctx).await {
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
+        if let Some(denied) = self
+            .deny_unless(&key, p.bug_id, Capability::Cc, caller.as_deref(), &ctx)
+            .await
+        {
             return Ok(denied);
         }
         let payload = json!({ "cc": { "add": [p.cc_email] } });
@@ -1781,8 +1832,9 @@ impl BugWarden {
         } else {
             vec![p.bug_id, p.duplicate_of]
         };
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
         let cell = audit_cell(&ctx);
-        let assessments = self.assess(&key, &ids).await;
+        let assessments = self.assess(&key, &ids, caller.as_deref()).await;
         let note = |id: u64, verdict: Verdict| {
             if let Some(cell) = &cell {
                 match assessments.get(&id) {
@@ -1843,8 +1895,15 @@ impl BugWarden {
             "tool: list_attachments"
         );
         let key = self.api_key(&ctx)?;
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
         if let Some(denied) = self
-            .deny_unless(&key, p.bug_id, Capability::Attachments, &ctx)
+            .deny_unless(
+                &key,
+                p.bug_id,
+                Capability::Attachments,
+                caller.as_deref(),
+                &ctx,
+            )
             .await
         {
             return Ok(denied);
@@ -1919,7 +1978,11 @@ impl BugWarden {
             .and_then(|m| m.get("bug_id"))
             .and_then(Value::as_u64)
             .unwrap_or(0);
-        let assessments = self.assess(&key, &[assess_id]).await;
+        // Resolved whatever `assess_id` turned out to be: the whoami count
+        // is a function of the policy alone, never of what the metadata
+        // fetch found (I2).
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
+        let assessments = self.assess(&key, &[assess_id], caller.as_deref()).await;
         let allowed = assessments
             .get(&assess_id)
             .is_some_and(|(access, _)| access.allows(Capability::Attachments));
@@ -2133,8 +2196,9 @@ impl BugWarden {
     ) -> Result<CallToolResult, McpError> {
         tracing::info!(id = p.id, "tool: summarize_bug");
         let key = self.api_key(&ctx)?;
+        let caller = self.guard.resolve_caller(&self.bz, &key).await;
         if let Some(denied) = self
-            .deny_unless(&key, p.id, Capability::Comments, &ctx)
+            .deny_unless(&key, p.id, Capability::Comments, caller.as_deref(), &ctx)
             .await
         {
             return Ok(denied);
@@ -2150,7 +2214,10 @@ impl BugWarden {
         // Same scrub as bug_comments: otherwise a client that would be
         // scrubbed there just asks for a summary instead (I14).
         let named = Guard::duplicate_marker_ids(&comments);
-        let disclosable = self.guard.disclosable(&self.bz, &key, &named).await;
+        let disclosable = self
+            .guard
+            .disclosable(&self.bz, &key, &named, caller.as_deref())
+            .await;
         if let Some(cell) = audit_cell(&ctx) {
             cell.note_suppressed_count((total - comments.len()) as u64);
             let hidden: Vec<u64> = named.difference(&disclosable).copied().collect();
@@ -2432,7 +2499,7 @@ mod tests {
         let assessments = BTreeMap::from([(7u64, (granted(&[Capability::Read]), Value::Null))]);
         let full = BTreeMap::from([(7u64, body(7, &[]))]);
 
-        let out = assemble_bug_info(&g, &[7], &assessments, &full);
+        let out = assemble_bug_info(&g, &[7], &assessments, &full, None);
         assert_eq!(out["bugs"].as_array().unwrap().len(), 1);
         assert_eq!(out["bugs"][0]["id"], json!(7));
         // The full body is served intact, not a redacted view.
@@ -2450,7 +2517,7 @@ mod tests {
         let assessments = BTreeMap::from([(7u64, (granted(&[Capability::Read]), Value::Null))]);
         let full = BTreeMap::from([(7u64, body(7, &["embargo-security"]))]);
 
-        let out = assemble_bug_info(&g, &[7], &assessments, &full);
+        let out = assemble_bug_info(&g, &[7], &assessments, &full, None);
         assert!(
             out["bugs"].as_array().unwrap().is_empty(),
             "a body that no longer passes must not be served"
@@ -2481,7 +2548,7 @@ mod tests {
         // 1 turns out embargoed, 2 never arrived, 3 was denied up front.
         let full = BTreeMap::from([(1u64, body(1, &["embargo-x"]))]);
 
-        let out = assemble_bug_info(&g, &[1, 2, 3], &assessments, &full);
+        let out = assemble_bug_info(&g, &[1, 2, 3], &assessments, &full, None);
         assert!(out["bugs"].as_array().unwrap().is_empty());
         let entries = out["restricted"].as_array().unwrap();
         assert_eq!(entries.len(), 3);
@@ -2516,7 +2583,7 @@ mod tests {
         let assessments = BTreeMap::from([(9u64, (granted(&[Capability::Read]), Value::Null))]);
         let full = BTreeMap::from([(9u64, body(9, &["internal"]))]);
 
-        let out = assemble_bug_info(&g, &[9], &assessments, &full);
+        let out = assemble_bug_info(&g, &[9], &assessments, &full, None);
         let served = &out["bugs"][0];
         assert_eq!(served["_redacted"], json!(true), "served redacted");
         assert!(
@@ -2541,7 +2608,7 @@ mod tests {
         let assessments = BTreeMap::from([(3u64, (granted(&[Capability::Read]), Value::Null))]);
         let full = BTreeMap::from([(3u64, body(3, &["internal"]))]);
 
-        let out = assemble_bug_info(&g, &[3], &assessments, &full);
+        let out = assemble_bug_info(&g, &[3], &assessments, &full, None);
         assert!(out["bugs"].as_array().unwrap().is_empty());
         assert_eq!(out["restricted"][0]["note"], json!(Guard::denial(3)));
     }
@@ -2567,7 +2634,7 @@ mod tests {
         ]);
         let full = BTreeMap::from([(5u64, body(5, &[])), (6u64, body(6, &["embargo-late"]))]);
 
-        let out = assemble_bug_info(&g, &[5, 6, 8], &assessments, &full);
+        let out = assemble_bug_info(&g, &[5, 6, 8], &assessments, &full, None);
         assert_eq!(out["bugs"].as_array().unwrap().len(), 1);
         assert_eq!(out["bugs"][0]["id"], json!(5));
         let restricted = out["restricted"].as_array().unwrap();
@@ -2589,7 +2656,7 @@ mod tests {
         let meta = body(4, &[]);
         let assessments = BTreeMap::from([(4u64, (granted(&[Capability::Summary]), meta.clone()))]);
 
-        let out = assemble_bug_info(&g, &[4], &assessments, &BTreeMap::new());
+        let out = assemble_bug_info(&g, &[4], &assessments, &BTreeMap::new(), None);
         assert_eq!(out["bugs"][0]["id"], json!(4));
         assert_eq!(out["bugs"][0]["_redacted"], json!(true));
     }

--- a/crates/bugwarden/tests/tools_wiremock.rs
+++ b/crates/bugwarden/tests/tools_wiremock.rs
@@ -788,3 +788,400 @@ async fn list_tools_serves_the_pruned_instance_router_i13() {
         "a read tool stays listed: {names:?}"
     );
 }
+
+// ---------- created_by_me (identity-relative matcher, issue #33) ----------
+
+/// The issue's policy shape: the caller's own reports carved out of a
+/// blanket group_restricted deny. `operations = ["access"]` keeps the
+/// carve-out away from the create gate.
+const IDENTITY_POLICY: &str = concat!(
+    "[[rule]]\nname = \"my-own-reports\"\naction = \"restrict\"\n",
+    "capabilities = [\"read\", \"comments\", \"history\", \"attachments\"]\n",
+    "operations = [\"access\"]\n",
+    "[rule.match]\ncreated_by_me = true\n",
+    "[[rule]]\nname = \"group-restricted\"\naction = \"deny\"\n",
+    "[rule.match]\ngroup_restricted = true\n",
+);
+
+/// A group-restricted bug with an explicit creator.
+fn restricted_bug(id: u64, creator: &str) -> Value {
+    let mut bug = world_readable_bug(id);
+    bug["groups"] = json!(["secteam"]);
+    bug["creator"] = json!(creator);
+    bug
+}
+
+/// Mount `GET /rest/whoami` answering with `login`, expected `hits` times.
+async fn mount_whoami(mock: &MockServer, login: &str, hits: u64) {
+    Mock::given(method("GET"))
+        .and(path("/rest/whoami"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 1, "name": login, "real_name": "Reporter",
+        })))
+        .expect(hits)
+        .mount(mock)
+        .await;
+}
+
+/// Mount the classification/full fetch for `bug` (unbounded — bug_info
+/// fetches a Read-granted id twice) and the id=0 link-disclosure padding.
+async fn mount_bug_and_padding(mock: &MockServer, bug: Value) {
+    let id = bug["id"].as_u64().expect("bug fixture has an id");
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", id.to_string()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [bug] })))
+        .mount(mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .mount(mock)
+        .await;
+}
+
+#[tokio::test]
+async fn created_by_me_carves_own_reports_out_of_a_group_restricted_deny() {
+    // The issue's scenario end to end: under a policy whose blanket rule
+    // denies every group-restricted bug, the caller can still read the
+    // group-restricted bug their own account filed — and nobody else's.
+    let mock = MockServer::start().await;
+    mount_whoami(&mock, "reporter@example.com", 2).await;
+    mount_bug_and_padding(&mock, restricted_bug(7, "reporter@example.com")).await;
+    mount_bug_and_padding(&mock, restricted_bug(8, "other.person@example.com")).await;
+    let client = client_for(IDENTITY_POLICY, &mock).await;
+
+    let own = call(&client, "bug_info", json!({ "bug_ids": [7] })).await;
+    assert!(
+        !is_error(&own),
+        "own report must be served: {}",
+        text_of(&own)
+    );
+    let own: Value = serde_json::from_str(&text_of(&own)).expect("bug_info returns JSON");
+    assert_eq!(
+        own["bugs"][0]["id"],
+        json!(7),
+        "the caller's own group-restricted bug is readable"
+    );
+    assert!(own["restricted"].as_array().unwrap().is_empty());
+
+    let foreign = call(&client, "bug_info", json!({ "bug_ids": [8] })).await;
+    let foreign: Value = serde_json::from_str(&text_of(&foreign)).expect("bug_info returns JSON");
+    assert!(foreign["bugs"].as_array().unwrap().is_empty());
+    assert_eq!(
+        foreign["restricted"][0]["note"],
+        json!("Bug 8 is not accessible through this server"),
+        "someone else's restricted bug takes the uniform denial (I2)"
+    );
+}
+
+#[tokio::test]
+async fn created_by_me_whoami_failure_yields_the_same_uniform_denial() {
+    // whoami down: the caller's own bug must come back with EXACTLY the
+    // bytes a foreign bug gets under a working whoami — no different text,
+    // no different shape, no oracle for "denied because identity failed".
+    let broken = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/whoami"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
+            "error": true, "message": "internal server error"
+        })))
+        .mount(&broken)
+        .await;
+    mount_bug_and_padding(&broken, restricted_bug(7, "reporter@example.com")).await;
+    let client = client_for(IDENTITY_POLICY, &broken).await;
+    let under_outage = call(&client, "bug_info", json!({ "bug_ids": [7] })).await;
+
+    let healthy = MockServer::start().await;
+    mount_whoami(&healthy, "reporter@example.com", 1).await;
+    mount_bug_and_padding(&healthy, restricted_bug(7, "other.person@example.com")).await;
+    let client = client_for(IDENTITY_POLICY, &healthy).await;
+    let foreign = call(&client, "bug_info", json!({ "bug_ids": [7] })).await;
+
+    assert_eq!(
+        serde_json::to_string(&under_outage).unwrap(),
+        serde_json::to_string(&foreign).unwrap(),
+        "a whoami outage must be indistinguishable from a foreign bug (I2/I4)"
+    );
+    let envelope: Value = serde_json::from_str(&text_of(&under_outage)).expect("JSON");
+    assert_eq!(
+        envelope["restricted"][0]["note"],
+        json!("Bug 7 is not accessible through this server")
+    );
+}
+
+#[tokio::test]
+async fn whoami_is_called_once_per_tool_call_under_an_identity_policy() {
+    // The per-call contract: ONE whoami for one tool call, however many
+    // classifications the call runs (assessment, re-check, link
+    // disclosure). The .expect(1) is verified when the mock server drops.
+    let mock = MockServer::start().await;
+    mount_whoami(&mock, "reporter@example.com", 1).await;
+    mount_bug_and_padding(&mock, restricted_bug(7, "reporter@example.com")).await;
+    let client = client_for(IDENTITY_POLICY, &mock).await;
+    let result = call(&client, "bug_info", json!({ "bug_ids": [7] })).await;
+    assert!(!is_error(&result));
+}
+
+#[tokio::test]
+async fn whoami_is_never_called_under_a_policy_without_identity_criteria() {
+    // The laziness contract: a policy that never consults created_by_me
+    // costs ZERO whoami lookups — pre-identity deployments keep their
+    // exact upstream request pattern.
+    let mock = MockServer::start().await;
+    mount_whoami(&mock, "reporter@example.com", 0).await;
+    mount_bug_and_padding(&mock, world_readable_bug(7)).await;
+    let client = client_for(
+        concat!(
+            "[[rule]]\nname = \"group-restricted\"\naction = \"deny\"\n",
+            "[rule.match]\ngroup_restricted = true\n",
+        ),
+        &mock,
+    )
+    .await;
+    let result = call(&client, "bug_info", json!({ "bug_ids": [7] })).await;
+    assert!(!is_error(&result));
+}
+
+#[tokio::test]
+async fn created_by_me_keeps_own_reports_in_quicksearch_results() {
+    // The caller must reach the guard's search scan, not only bug_info:
+    // under the identity policy the caller's own group-restricted bug stays
+    // in the served window while a foreign one is silently dropped (I3) —
+    // and the whole tool call still costs exactly one whoami lookup.
+    let mock = MockServer::start().await;
+    mount_whoami(&mock, "reporter@example.com", 1).await;
+    mount_search(
+        &mock,
+        vec![
+            restricted_bug(101, "reporter@example.com"),
+            restricted_bug(102, "other.person@example.com"),
+        ],
+    )
+    .await;
+    let client = client_for(IDENTITY_POLICY, &mock).await;
+
+    let served = quicksearch_json(&client, "kernel crash").await;
+    let ids: Vec<u64> = served["bugs"]
+        .as_array()
+        .expect("quicksearch returns a bugs array")
+        .iter()
+        .filter_map(|b| b["id"].as_u64())
+        .collect();
+    assert_eq!(
+        ids,
+        vec![101],
+        "search must keep the caller's own restricted bug and drop the foreign one: {served}"
+    );
+}
+
+#[tokio::test]
+async fn created_by_me_carves_own_reports_out_for_bug_comments_too() {
+    // deny_unless gets the same caller threading as bug_info: the caller's
+    // own group-restricted bug serves its comments, a foreign one takes the
+    // uniform denial before anything is fetched — one whoami per tool call
+    // either way (the .expect counts are verified when the mock drops).
+    let mock = MockServer::start().await;
+    mount_whoami(&mock, "reporter@example.com", 2).await;
+    mount_bug_and_padding(&mock, restricted_bug(7, "reporter@example.com")).await;
+    mount_bug_and_padding(&mock, restricted_bug(8, "other.person@example.com")).await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/7/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "bugs": { "7": { "comments": [
+                { "id": 1, "bug_id": 7, "text": "first comment", "is_private": false },
+            ] } }
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/8/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "bugs": { "8": { "comments": [] } }
+        })))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    let client = client_for(IDENTITY_POLICY, &mock).await;
+
+    let own = call(&client, "bug_comments", json!({ "id": 7 })).await;
+    assert!(
+        !is_error(&own),
+        "the caller's own report must serve its comments: {}",
+        text_of(&own)
+    );
+    assert!(text_of(&own).contains("first comment"));
+
+    let foreign = call(&client, "bug_comments", json!({ "id": 8 })).await;
+    assert!(is_error(&foreign));
+    assert_eq!(
+        text_of(&foreign),
+        "Bug 8 is not accessible through this server",
+        "someone else's restricted bug takes the uniform denial (I2)"
+    );
+}
+
+#[tokio::test]
+async fn created_by_me_carves_own_reports_out_for_bug_history_too() {
+    // Every tool threads the caller by hand, so every tool is its own
+    // mutation surface: this pins bug_history the way the test above pins
+    // bug_comments — the caller's own group-restricted bug serves its
+    // history, a foreign one takes the uniform denial before anything is
+    // fetched, and each tool call costs exactly one whoami lookup.
+    let mock = MockServer::start().await;
+    mount_whoami(&mock, "reporter@example.com", 2).await;
+    mount_bug_and_padding(&mock, restricted_bug(7, "reporter@example.com")).await;
+    mount_bug_and_padding(&mock, restricted_bug(8, "other.person@example.com")).await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/7/history"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "bugs": [{ "id": 7, "history": [{
+                "when": "2020-02-01T00:00:00Z",
+                "who": "someone@example.com",
+                "changes": [
+                    { "field_name": "status", "removed": "NEW", "added": "CONFIRMED" },
+                ],
+            }] }]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/8/history"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    let client = client_for(IDENTITY_POLICY, &mock).await;
+
+    let own = call(&client, "bug_history", json!({ "id": 7 })).await;
+    assert!(
+        !is_error(&own),
+        "the caller's own report must serve its history: {}",
+        text_of(&own)
+    );
+    assert!(text_of(&own).contains("CONFIRMED"));
+
+    let foreign = call(&client, "bug_history", json!({ "id": 8 })).await;
+    assert!(is_error(&foreign));
+    assert_eq!(
+        text_of(&foreign),
+        "Bug 8 is not accessible through this server",
+        "someone else's restricted bug takes the uniform denial (I2)"
+    );
+}
+
+/// A carve-out granting a WRITE capability on the caller's own reports.
+/// [`IDENTITY_POLICY`] cannot exercise the write gate: its grant carries
+/// no write capabilities, so a write tool refuses even the caller's own
+/// bug under it — correctly, but uninformatively for threading coverage.
+const IDENTITY_WRITE_POLICY: &str = concat!(
+    "[[rule]]\nname = \"my-own-reports\"\naction = \"restrict\"\n",
+    "capabilities = [\"read\", \"comment\"]\n",
+    "operations = [\"access\"]\n",
+    "[rule.match]\ncreated_by_me = true\n",
+    "[[rule]]\nname = \"group-restricted\"\naction = \"deny\"\n",
+    "[rule.match]\ngroup_restricted = true\n",
+);
+
+#[tokio::test]
+async fn created_by_me_reaches_the_write_gate_add_comment_too() {
+    // The write tools thread the caller through the same deny_unless shape
+    // as the read tools; pin one representative so a dropped caller on a
+    // write site cannot pass unnoticed. Own bug: the comment is POSTed.
+    // Foreign bug: uniform denial, nothing POSTed.
+    let mock = MockServer::start().await;
+    mount_whoami(&mock, "reporter@example.com", 2).await;
+    mount_bug_and_padding(&mock, restricted_bug(7, "reporter@example.com")).await;
+    mount_bug_and_padding(&mock, restricted_bug(8, "other.person@example.com")).await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/7/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 99 })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/8/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 100 })))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    let client = client_for(IDENTITY_WRITE_POLICY, &mock).await;
+
+    let own = call(
+        &client,
+        "add_comment",
+        json!({ "bug_id": 7, "comment": "adding context" }),
+    )
+    .await;
+    assert!(
+        !is_error(&own),
+        "the caller may comment on their own report: {}",
+        text_of(&own)
+    );
+
+    let foreign = call(
+        &client,
+        "add_comment",
+        json!({ "bug_id": 8, "comment": "adding context" }),
+    )
+    .await;
+    assert!(is_error(&foreign));
+    assert_eq!(
+        text_of(&foreign),
+        "Bug 8 is not accessible through this server",
+        "someone else's restricted bug takes the uniform denial (I2)"
+    );
+}
+
+#[tokio::test]
+async fn whoami_transport_error_does_not_leak_the_api_key_i12() {
+    // Point the server at a closed port: the whoami lookup (and everything
+    // after it) fails at the transport level, where the unsanitized error
+    // would carry the request URL with api_key=... in it. Nothing the
+    // client sees may contain the key.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    drop(listener); // free the port so every connection is refused
+
+    let cfg = Arc::new(Cli::parse_from([
+        "bugwarden",
+        "--bugzilla-server",
+        &format!("http://{addr}"),
+        "--transport",
+        "stdio",
+        "--api-key",
+        "SUPERSECRETKEY123",
+    ]));
+    let guard = Arc::new(Guard {
+        policy: Policy::from_toml_str(IDENTITY_POLICY).expect("test policy must parse"),
+    });
+    let bz =
+        Arc::new(BugzillaClient::new(&format!("http://{addr}"), false).expect("client must build"));
+    let server = BugWarden::new(cfg, guard, bz).expect("server must build");
+    let (client_io, server_io) = tokio::io::duplex(1 << 16);
+    tokio::spawn(async move {
+        if let Ok(running) = server.serve(server_io).await {
+            let _ = running.waiting().await;
+        }
+    });
+    let client: RunningService<RoleClient, ()> =
+        ().serve(client_io)
+            .await
+            .expect("MCP handshake must succeed");
+
+    let result = call(&client, "bug_info", json!({ "bug_ids": [7] })).await;
+    let text = serde_json::to_string(&result).unwrap();
+    assert!(
+        !text.contains("SUPERSECRETKEY123"),
+        "API key leaked into a client-visible result: {text}"
+    );
+    // The bug is simply unavailable — the uniform denial, nothing else.
+    let envelope: Value = serde_json::from_str(&text_of(&result)).expect("JSON");
+    assert_eq!(
+        envelope["restricted"][0]["note"],
+        json!("Bug 7 is not accessible through this server")
+    );
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -38,7 +38,11 @@ Dependency direction: `bugwarden -> bugwarden-core`, never the reverse.
   response, or a CONSULTED rule that cannot be decided because the bug object
   did not carry a field that rule asks about (absent, null, wrongly typed, or
   only partially recoverable — including an unparsable `creation_time`) =>
-  Denied. The consulted rules are those whose `operations` cover the
+  Denied. The identity criterion `created_by_me` extends "field the rule asks
+  about" beyond the bug object: it is undecidable when the bug's `creator` is
+  unreadable OR the caller's identity did not resolve (whoami failure), and
+  it resolves through this same machinery with no special case (see
+  "Identity resolution"). The consulted rules are those whose `operations` cover the
   operation being classified (see classify): a rule scoped away from the
   operation is skipped before its matcher runs and can neither grant nor
   deny there — scoping changes which rules are consulted, never how a
@@ -172,6 +176,12 @@ pub struct Matcher {
     #[serde(default)] pub summary_contains: Vec<String>,   // case-insensitive substrings in the one-line summary
     #[serde(default)] pub group_restricted: Option<bool>,  // true: readable only via >=1 Bugzilla group; false: world-readable
     #[serde(default)] pub younger_than_days: Option<i64>,  // creation_time newer than now-N days
+    // The one identity-relative criterion: true selects bugs AUTHORED by the
+    // requesting account, false everyone else's (see "Identity resolution").
+    // TOML spelling `created_by_me = true|false`; absent = not consulted.
+    // Older bugwarden versions reject a policy carrying the key at startup
+    // (strict parsing fails closed) — same story as `operations`.
+    #[serde(default)] pub created_by_me: Option<bool>,
 }
 pub enum MatchOutcome { Yes, No, Unknown }
 
@@ -260,6 +270,11 @@ impl Policy {
     // both the intended filing grant and the reads the capability list
     // withholds). Unknown operation names are rejected by serde.
     pub fn classify(&self, bug: &BugMeta, now: chrono::DateTime<chrono::Utc>, op: Operation) -> Access;
+    // Whether any rule consulted for Operation::Access carries a
+    // created_by_me criterion — the laziness gate for whoami (see
+    // "Identity resolution"). A rule scoped to ONLY `create` does not
+    // count: the create gate forces created_by_me without any lookup.
+    pub fn needs_identity(&self) -> bool;
     // order: global min_bug_age_days first (missing creation_time => Denied, I4;
     // the gate is global, never operation-scoped — it deliberately refuses
     // creation too, since may_create dates the prospective bug NOW), then
@@ -290,12 +305,19 @@ pub struct BugMeta {
     pub groups: Option<Vec<String>>,     // group names; Some(vec![]) = world-readable
     pub whiteboard: Option<String>,      // "whiteboard", falling back to "status_whiteboard"
     pub creation_time: Option<chrono::DateTime<chrono::Utc>>,
+    // Some(true/false) = established bug–caller relationship; None = it
+    // cannot be known (creator unreadable OR caller identity unresolved).
+    pub created_by_me: Option<bool>,
 }
 impl BugMeta {
     // Tolerant on SHAPE (component as string or array, group elements as
     // names or {name} objects, either whiteboard key) but never invents a
     // value: a list with an unreadable element is None, not a shorter list.
-    pub fn from_json(v: &serde_json::Value) -> BugMeta;
+    // `caller` is the requesting account's login (Guard::resolve_caller);
+    // created_by_me = Some(login ==(case-insensitively, to_lowercase — the
+    // glob normalization) bug "creator") only when BOTH the caller and a
+    // string-typed creator are known, else None.
+    pub fn from_json(v: &serde_json::Value, caller: Option<&str>) -> BugMeta;
 }
 
 #[derive(Debug, Clone)]
@@ -353,7 +375,7 @@ impl Guard {
     // the clock). Summary bar, the same one the write paths use.
     pub const LINKED_ID_FIELDS: &[&str];
     pub async fn disclosable(&self, bz: &BugzillaClient, key: &str,
-        ids: &BTreeSet<u64>) -> BTreeSet<u64>;
+        ids: &BTreeSet<u64>, caller: Option<&str>) -> BTreeSet<u64>;
     pub fn linked_bug_ids(bug: &Value, base_url: &str) -> BTreeSet<u64>;
     pub fn scrub_bug_links(bug: &mut Value, base_url: &str, ok: &BTreeSet<u64>);
     pub fn history_bug_ids(history: &Value, base_url: &str) -> BTreeSet<u64>;
@@ -362,10 +384,22 @@ impl Guard {
     pub fn duplicate_marker_ids(comments: &[Value]) -> BTreeSet<u64>;
     pub fn scrub_duplicate_markers(comments: Vec<Value>, ok: &BTreeSet<u64>) -> Vec<Value>;
     pub async fn quicksearch_window(&self, bz: &BugzillaClient, key: &str,
-        req: &SearchRequest<'_>) -> anyhow::Result<Vec<serde_json::Value>>;
+        req: &SearchRequest<'_>, caller: Option<&str>) -> anyhow::Result<Vec<serde_json::Value>>;
 
-    pub async fn assess(&self, bz: &crate::client::BugzillaClient, key: &str, ids: &[u64])
+    // The `caller` parameter on assess/quicksearch_window/disclosable/
+    // filter_bug_list is the identity resolved ONCE per tool call by
+    // resolve_caller and threaded to every classification within that call
+    // — none of these methods performs a lookup of its own (see "Identity
+    // resolution").
+    pub async fn assess(&self, bz: &crate::client::BugzillaClient, key: &str, ids: &[u64],
+        caller: Option<&str>)
         -> std::collections::BTreeMap<u64, (Access, serde_json::Value)>;
+
+    /// Lazy per-tool-call identity resolution: None WITHOUT any HTTP
+    /// request when !policy.needs_identity(); otherwise exactly one
+    /// GET /rest/whoami, with every failure mapped to None (sanitized
+    /// error debug-logged only, I12). See "Identity resolution".
+    pub async fn resolve_caller(&self, bz: &BugzillaClient, key: &str) -> Option<String>;
 
     /// SUMMARY_FIELDS projection of a bug object + "_redacted": true marker.
     pub fn summary_view(bug: &serde_json::Value) -> serde_json::Value;
@@ -373,7 +407,7 @@ impl Guard {
     /// Classify each bug: full read kept as-is, summary-only replaced by
     /// summary_view, denied dropped. Returns (kept, dropped_count) — the count
     /// is for server-side logging ONLY, never sent to the client (I3).
-    pub fn filter_bug_list(&self, bugs: Vec<serde_json::Value>) -> (Vec<serde_json::Value>, usize);
+    pub fn filter_bug_list(&self, bugs: Vec<serde_json::Value>, caller: Option<&str>) -> (Vec<serde_json::Value>, usize);
 
     /// Drops is_private comments unless include_private && policy allows (I5).
     pub fn filter_comments(&self, comments: Vec<serde_json::Value>, include_private: bool) -> Vec<serde_json::Value>;
@@ -421,6 +455,13 @@ impl Guard {
     /// rule for the product's existing bugs (issue #26). creation_time is
     /// forced to NOW, whatever the payload claims, so an age rule refuses
     /// creation wherever it would immediately hide the result.
+    /// created_by_me is forced to Some(true) unconditionally — the creator
+    /// of a bug being filed is definitionally the caller (Bugzilla assigns
+    /// `creator` server-side; the typed create params cannot claim it), so
+    /// NO whoami is ever performed for the create gate. Consequence: a
+    /// create-covering rule with created_by_me = true matches every create
+    /// request that reaches it; with created_by_me = false it can never
+    /// match a create.
     pub fn may_create(&self, requested: &Value) -> bool;
 
     /// Uniform refusal for a bug that was not filed: one fixed text, naming
@@ -437,13 +478,14 @@ impl Guard {
 
 ```rust
 pub const CLASSIFY_FIELDS: &str =
-    "id,summary,product,component,status,resolution,severity,priority,keywords,groups,whiteboard,creation_time,last_change_time";
+    "id,summary,product,component,status,resolution,severity,priority,keywords,groups,whiteboard,creation_time,last_change_time,creator";
 
 pub struct BugzillaClient { /* base_url, api_url = base_url + "/rest", reqwest::Client (30s timeout), use_auth_header */ }
 impl BugzillaClient {
     pub fn new(base_url: &str, use_auth_header: bool) -> anyhow::Result<Self>; // trims trailing '/'
     pub fn base_url(&self) -> &str;
     pub async fn version(&self, key: &str) -> anyhow::Result<String>;
+    pub async fn whoami(&self, key: &str) -> anyhow::Result<String>; // login; missing/non-string/blank "name" = failure
     pub async fn server_info(&self, key: &str) -> anyhow::Result<serde_json::Value>;
     pub async fn get_bugs(&self, key: &str, ids: &[u64], include_fields: Option<&str>) -> anyhow::Result<serde_json::Value>;
     pub async fn bug_history(&self, key: &str, id: u64, new_since: Option<chrono::DateTime<chrono::Utc>>) -> anyhow::Result<serde_json::Value>;
@@ -465,7 +507,8 @@ Endpoint mapping:
 | method | request | returns |
 |---|---|---|
 | version | GET /rest/version | `.version` string |
-| server_info | concurrent GET /rest/version, /rest/extensions, /rest/time, /rest/parameters | `{url, version, extensions, timezone: tz_name, time: web_time, parameters}` |
+| whoami | GET /rest/whoami | `.name` string (the account's login); missing/non-string/blank = error |
+| server_info | sequential GET /rest/version, /rest/extensions, /rest/time, /rest/parameters | `{url, version, extensions, timezone: tz_name, time: web_time, parameters}` |
 | get_bugs | GET /rest/bug?id=1,2,3[&include_fields=..] | whole envelope |
 | bug_history | GET /rest/bug/{id}/history[?new_since=%Y-%m-%dT%H:%M:%SZ] | `bugs[0].history` array as Value |
 | bug_comments | GET /rest/bug/{id}/comment[?new_since=..] | `bugs.{id}.comments` as Vec<Value> |
@@ -484,6 +527,67 @@ query param `api_key={key}`. Always `Accept: application/json`.
 Errors: non-2xx status or body `{"error": true}` => anyhow error containing the
 HTTP status and Bugzilla `message` field; reqwest errors sanitized with
 `.without_url()` (I12).
+
+## Identity resolution (the `created_by_me` matcher)
+
+`created_by_me` is the one identity-relative matcher criterion: it describes
+the bug–caller relationship (did the requesting account author this bug?)
+where every other criterion describes bug content. Decisions, all deliberate:
+
+- **Source.** The caller's login comes from `GET /rest/whoami` (the `name`
+  field; a missing, non-string, or blank — empty or all-whitespace — value
+  is a FAILED resolution, never an empty login: a blank identity must not
+  compare equal to a blank `creator` and grant on no evidence),
+  authenticated and error-sanitized exactly like every other client
+  call (I12). It is compared case-insensitively (`to_lowercase`, the same
+  normalization the glob matcher applies) against the bug's `creator`
+  field, which joined `CLASSIFY_FIELDS` for this purpose. A non-string
+  `creator` leaves the relationship unknown.
+- **Laziness.** `Policy::needs_identity()` = some rule whose `operations`
+  cover `Operation::Access` carries a `created_by_me` criterion. When it is
+  false, `Guard::resolve_caller` returns `None` without any HTTP request —
+  a policy that never consults identity costs ZERO whoami lookups, so
+  pre-identity deployments keep their exact upstream request pattern. A
+  create-scoped-only identity rule does not trigger lookups either: the
+  create gate forces the answer (below).
+- **At most once per MCP tool call.** Each tool resolves the caller at most
+  once, near its entry, and threads the result to EVERY classification in
+  that call — `Guard::assess`, `quicksearch_window`, `disclosable`,
+  `filter_bug_list`, including the synchronous re-check inside
+  `assemble_bug_info`. The threading is load-bearing: if that re-check ran
+  with `caller = None` under an identity policy, a bug the assessment
+  granted on the caller's authorship would be dropped by the re-check.
+  Nothing is cached across tool calls (uniform for stdio and http; a
+  per-session cache is a possible future optimization, deliberately not
+  done now). The whoami count is a function of the policy alone — never of
+  verdicts or upstream answers — so it opens no timing oracle.
+- **Failure => Unknown => I4, no special case.** A whoami failure maps the
+  caller to `None`; a `created_by_me` criterion evaluated without a caller
+  (or without a readable creator) yields `MatchOutcome::Unknown`, and the
+  existing I4 machinery resolves it: a consulted rule that cannot be
+  decided denies the bug, whatever its action. Consequence, INTENDED: if
+  the policy consults identity and whoami fails, every classification
+  consulting the rule denies — a policy that leads with an identity rule
+  blacks out on whoami failure. This is the only uniformly fail-closed
+  reading. The alternative — resolving identity-unknown as "criterion
+  fails" — would let a `created_by_me = true` DENY rule be dodged by
+  making whoami fail (fail open), exactly the asymmetry I4 exists to
+  forbid.
+- **Create gate: forced true, no lookup.** `may_create` forces the
+  prospective bug's `created_by_me` to `Some(true)` unconditionally: the
+  creator of a bug being filed is definitionally the caller — Bugzilla
+  assigns `creator` server-side from the authenticating account, and
+  bugwarden's typed `create_bug` parameters cannot claim it. No whoami is
+  ever performed for the create gate. So a create-covering rule with
+  `created_by_me = true` matches every create request that reaches it, and
+  one with `created_by_me = false` can never match a create.
+- **Cannot widen exposure beyond the credential.** Bugzilla still enforces
+  its own access control on every fetch, so an authorship rule only
+  surfaces bugs the API key's account could already read — it narrows the
+  guard-credential gap, never escapes it.
+- **Deliberately not implemented.** `assigned_to_me` and `cc_me` are the
+  natural extensions of this mechanism; they are intentionally absent, not
+  forgotten.
 
 ## MCP tool surface (crates/bugwarden/src/server.rs)
 
@@ -639,7 +743,26 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   embargo-marked title everywhere, refuses filing elsewhere (omitted and
   claimed group lists alike), keeps existing world-readable desktop bugs
   fully readable (the issue-#26 regression surface), and keeps
-  group-restricted desktop bugs denied.
+  group-restricted desktop bugs denied; created_by_me — the TOML spelling
+  `created_by_me = true|false` is pinned and an absent key is None;
+  evaluate semantics ((true, Some(true)) holds, (true, Some(false)) fails,
+  (true, None) is Unknown and a consulted rule then denies for a deny rule
+  AND a restrict rule alike — the uniformity is pinned — and
+  (false, Some(false)) holds); BugMeta::from_json establishes
+  created_by_me only from a string creator plus a resolved caller (equal,
+  unequal, case-insensitively equal; absent/non-string creator and a None
+  caller are all None); needs_identity is false for a policy without
+  identity criteria, true for an access-covering identity rule, and FALSE
+  when the only identity rule is operations = ["create"]; may_create
+  forces created_by_me true without any client or whoami (a create-covering
+  deny rule on created_by_me = true refuses creation, one on
+  created_by_me = false never matches a create); and the shipped-example
+  pin extends to identity: with the caller known, a group-restricted bug
+  the caller authored grants exactly read/comments/history/attachments and
+  no write, the same bug authored by someone else stays Denied, and with
+  identity UNKNOWN both it and a world-readable desktop bug are Denied —
+  the whoami-failure blackout is pinned so it cannot be "fixed" into
+  fail-open later.
 - Unit tests (#[cfg(test)] in crates/bugwarden/src/server.rs): assemble_bug_info
   re-classification — a body embargoed after the verdict is refused, a body
   that now earns only summary is downgraded, a body granting neither read nor
@@ -662,7 +785,15 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   ids fetched once, no batch to poison; per-id
   fallback fail closed; comment privacy; error mapping; API key absent from
   error text (I12); create_bug and add_attachment endpoint mapping (payload
-  travels untouched to POST /rest/bug and /rest/bug/{id}/attachment).
+  travels untouched to POST /rest/bug and /rest/bug/{id}/attachment);
+  whoami endpoint mapping (GET /rest/whoami => the `name` login; a missing,
+  non-string, or blank — empty/whitespace-only — name is a failure), the
+  API key absent from a whoami transport error (I12), resolve_caller's
+  laziness (zero requests without an identity criterion, one request with,
+  failure mapped to None), and the classify projection itself — the bug
+  mock answers only an include_fields carrying `creator`, so dropping the
+  field from CLASSIFY_FIELDS fails the caller's-own-bug classification
+  instead of passing on a fixture that volunteers fields nobody requested.
 - Integration tests (crates/bugwarden/tests/tools_wiremock.rs, wiremock +
   rmcp client over an in-memory duplex transport): the tools are CALLED
   through a real MCP session, so a tool that stops calling its guard fails
@@ -676,9 +807,26 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   POST is reached) and leaves existing bugs in them searchable
   (issue #26); add_attachment refuses on a
   grant carrying `attachments` (read) without `attach` (write) and uploads
-  on `attach`; the upload size cap refuses before anything is POSTed; and
-  the attachment `comment` travels as a plain string (Bug.add_attachment
-  API shape), pinned by a wiremock body matcher.
+  on `attach`; the upload size cap refuses before anything is POSTed; the
+  attachment `comment` travels as a plain string (Bug.add_attachment
+  API shape), pinned by a wiremock body matcher; and identity end to end —
+  issue #33's exact scenario (a my-own-reports restrict rule above a
+  group_restricted deny: with whoami answering the caller, a
+  group-restricted bug the caller authored is readable through bug_info
+  while the same bug under a foreign creator takes the uniform denial), a
+  whoami 500 makes the caller's own bug byte-identical to the
+  foreign-creator denial (no oracle), the call-count contract (wiremock
+  expect(1) whoami hits for one tool call under an identity policy,
+  expect(0) under a policy without identity criteria), the caller threading
+  beyond bug_info (the caller's own group-restricted bug stays in a
+  bugs_quicksearch window while a foreign one is dropped, and serves its
+  comments through bug_comments and its history through bug_history while
+  a foreign one takes the uniform denial — every tool threads the caller
+  by hand, so each pinned tool is its own mutation surface), the caller
+  reaching a write gate (a carve-out granting `comment` on the caller's
+  own reports POSTs the comment for the caller's bug and refuses a
+  foreign one with nothing POSTed), and a whoami transport error leaking
+  no API key into any client-visible text (I12).
 - Audit tests (crates/bugwarden/tests/audit_wiremock.rs + #[cfg(test)] in
   server.rs and audit.rs): one record per call for EVERY routed tool,
   refusal paths and protocol errors included; the refusal map is total

--- a/examples/policy.toml
+++ b/examples/policy.toml
@@ -3,15 +3,25 @@
 #
 # The scenario this file implements:
 #
-#   * undisclosed (embargoed) security bugs are completely invisible, always;
-#   * so is every bug that is not world-readable — see rule 1, which is
-#     deliberately broader than "security" and can be narrowed;
+#   * the caller's OWN bug reports — bugs authored by the account whose API
+#     key makes the request — are always readable (read, comments, history,
+#     attachments; no writes), even when a rule below would hide them: see
+#     "my-own-reports" in section 0b, an explicit opt-in that is evaluated
+#     before every deny rule and comes with a documented whoami-failure
+#     blackout;
+#   * undisclosed (embargoed) security bugs are otherwise completely
+#     invisible;
+#   * so is every other bug that is not world-readable — see rule 1, which
+#     is deliberately broader than "security" and can be narrowed;
 #   * bugs in groups NAMED like security groups are invisible in their own
-#     right — see "security-groups", which keeps denying them even after
-#     rule 1 is narrowed or removed;
+#     right (except the caller's own — section 0b matches first) — see
+#     "security-groups", which keeps denying them even after rule 1 is
+#     narrowed or removed;
 #   * bugs labelled "security" are invisible while they are fresher than
-#     5 days (the window in which details are typically still unreviewed);
-#   * every other bug is shown to the user in full;
+#     5 days (the window in which details are typically still unreviewed),
+#     again excepting the caller's own;
+#   * every other bug (not the caller's own — those take the read-only
+#     grant of "my-own-reports" first) is shown to the user in full;
 #   * new bug reports are accepted into the desktop products ONLY — see the
 #     "reporters" rule in section 0, whose `operations = ["create"]` scope
 #     grants filing without touching what may be read — except that a title
@@ -39,6 +49,7 @@
 #
 # Unreadable metadata: if a bug object does not carry a field some rule asks
 # about — absent, null, wrongly typed, or a list with an unreadable element —
+# and, for `created_by_me`, if the caller's identity could not be resolved —
 # that rule cannot be decided and the bug is DENIED, whatever the rule's
 # action. This holds for every criterion of every rule CONSULTED for the
 # operation at hand — an operation-scoped rule (section 0) is skipped before
@@ -145,7 +156,66 @@ operations = ["create"]
 products = ["GNOME*", "KDE*"]
 
 # ---------------------------------------------------------------------------
-# 1. Undisclosed security bugs: fully invisible, at any age.
+# 0b. The caller's own reports: readable even where the rules below would
+#     hide them.
+#
+# `created_by_me = true` matches bugs AUTHORED by the account whose API key
+# makes the request — the one identity-relative criterion. The server
+# resolves the caller's login at most once per tool call (GET /rest/whoami,
+# only when a policy actually uses this criterion) and compares it
+# case-insensitively against the bug's creator. Placed ABOVE the deny rules,
+# this rule carves the caller's own reports out of them: people keep
+# following the bugs they themselves filed — group-restricted ones included
+# — while everyone else's hidden bugs stay hidden. Reading is granted,
+# writing is not, so "follow your own report" does not become "edit your
+# own report". Note the flip side of first-match-wins: the caller's own
+# WORLD-READABLE bugs also take this rule first and are therefore read-only
+# through this server under this example.
+#
+# This rule is an EXPLICIT OPT-IN — an operator who does not want it simply
+# omits it and keeps today's behaviour. In particular, a deployment whose
+# clients share one service-account API key should NOT carry this rule:
+# there, "created by me" means "created by the service account", a set of
+# bugs no individual user has a personal claim to.
+#
+# The `operations = ["access"]` scope matters: the create gate treats a
+# prospective bug as created by the caller (the account filing a bug IS its
+# creator), so without the scoping this rule would be the create gate's
+# first match for every request and — granting no "create" capability —
+# would refuse ALL filing, section 0 notwithstanding. Scoped to access, it
+# decides reads only and the create gate never consults it (and never
+# performs a whoami lookup).
+#
+# Failure mode, deliberate: if the whoami lookup fails, the caller's
+# identity is unknown, this rule can be decided for NO bug, and an
+# undecidable consulted rule denies whatever its action (see "Unreadable
+# metadata" above). While whoami is down, a policy that leads with this
+# rule therefore denies every read — a blackout — rather than serving what
+# an unverified identity should not see. That is the only uniformly
+# fail-closed reading: treating unknown identity as "criterion fails"
+# would let a created_by_me deny rule be dodged by making whoami fail.
+#
+# This criterion cannot widen exposure beyond the credential: Bugzilla
+# still enforces its own permissions on every fetch, so an authorship rule
+# only surfaces bugs the API key could already read — it narrows the gap
+# between the guard and the credential, never escapes it.
+#
+# NOTE: bugwarden versions without identity support REJECT a policy using
+# `created_by_me` at startup — parsing is strict, so the whole file fails
+# closed instead of the rule being silently ignored.
+
+[[rule]]
+name = "my-own-reports"
+description = "Bugs the caller's own account filed stay readable, never writable"
+action = "restrict"
+capabilities = ["read", "comments", "history", "attachments"]
+operations = ["access"]
+[rule.match]
+created_by_me = true
+
+# ---------------------------------------------------------------------------
+# 1. Undisclosed security bugs: fully invisible, at any age (the caller's
+#    own excepted, as everywhere below — section 0b matches first).
 #
 # An issue under embargo is one whose public disclosure date has not arrived
 # yet, and it is normally recognisable two ways, independently: the bug is
@@ -227,13 +297,18 @@ keywords = ["security-embargo", "embargo*"]
 #
 # Both criteria are AND-ed, so these rules hide a bug only while it is BOTH
 # security-labelled AND younger than 5 days. Once a world-readable bug ages
-# past the window, no rule matches it any more and default_action ("allow")
-# applies — it becomes fully visible without any policy change. (A
-# group-restricted bug stays hidden at any age: rule 1 catches it first.)
+# past the window, no deny rule matches it any more: unless it is the
+# caller's own (then "my-own-reports" grants it read-only, as at any age),
+# default_action ("allow") applies and it becomes fully visible without any
+# policy change. (A group-restricted bug someone else filed stays hidden at
+# any age: rule 1 catches it first. The caller's own group-restricted bugs
+# take "my-own-reports" first instead — readable, never writable.)
 #
 # Two rules because "security" can be expressed two ways here; drop the one
 # your instance does not use. A group-based variant would be pointless: any
-# bug in a security group is already denied by rule 1.
+# bug in a security group that someone else filed is already denied by
+# rule 1, and the caller's own are already carved out by "my-own-reports",
+# group-based rule or not.
 # ---------------------------------------------------------------------------
 
 [[rule]]


### PR DESCRIPTION
Fixes #33.

## What changed

Rules can now match on the relationship between the bug and the caller:

```toml
[[rule]]
name = "my-own-reports"
action = "restrict"
capabilities = ["read", "comments", "history", "attachments"]
operations = ["access"]
[rule.match]
created_by_me = true
```

`created_by_me = true|false` is resolved against the account that owns the API key used for the request — under `--transport http` the key arrives per request, so "me" cannot be a startup-time property; it is resolved per tool call.

**Lazy whoami.** The caller's login comes from `GET /rest/whoami`, resolved by `Guard::resolve_caller` at most **once per MCP tool call** and threaded to every classification in that call (`assess`, `quicksearch_window`, `disclosable`, `filter_bug_list` including the `assemble_bug_info` re-check). `Policy::needs_identity` gates the lookup: a policy without an access-covering `created_by_me` criterion costs **zero** whoami calls, ever — pre-identity deployments keep their exact upstream request pattern. Nothing is cached across tool calls. A blank login (empty or whitespace name) counts as a failed resolution, exactly like a missing or non-string one: a blank identity must never compare equal to a blank creator and grant on no evidence.

**Unknown-on-unresolved ⇒ I4.** `BugMeta` carries `created_by_me` established only from a string-typed `creator` (now in `CLASSIFY_FIELDS`) plus a resolved caller, compared case-insensitively (the glob normalization). Either side missing leaves the relationship unknown, and a consulted rule that cannot be decided denies whatever its action — the existing fail-closed machinery, no special case. Deliberate consequence, documented loudly in DESIGN.md and the example policy: a policy that leads with an identity rule blacks out on whoami failure. That is the only uniformly fail-closed reading — resolving unknown identity as "criterion fails" would let a `created_by_me = true` **deny** rule be dodged by making whoami fail.

**Create gate forced true.** `may_create` sets `created_by_me = Some(true)` unconditionally: the creator of a bug being filed is definitionally the caller (Bugzilla assigns `creator` server-side; the typed create params cannot claim it), so no whoami ever runs on the create path, and `needs_identity` ignores create-scoped-only identity rules.

The shipped `examples/policy.toml` activates a `my-own-reports` carve-out above the group-restricted deny — composing #26's `operations` scoping with the new criterion exactly as the issue's security notes anticipated — and every absolute visibility claim in the file's prose was qualified to stay true. Strict TOML means older bugwarden versions reject a policy using the new key at startup (fails closed). The criterion cannot widen exposure beyond the credential: Bugzilla still enforces its own access control, so an authorship rule only surfaces bugs the account could already fetch.

Out of scope, deliberately (noted in DESIGN.md as natural extensions): `assigned_to_me`, `cc_me`, `creators = [...]` globs, cross-call identity caching.

## Invariants touched (DESIGN.md updated in this commit)

- **I4** — extended, not weakened: identity-unknown flows through the existing Unknown arm; a consulted rule that cannot be decided still denies whatever its action. New Identity-resolution section states the whoami source, the laziness and at-most-once-per-call contract, the blackout consequence and the fail-open counter-argument for why.
- **I12** — `whoami` uses the same sanitization as every client call; pinned by transport-error tests at both the tools and client level (the key never reaches client-visible text).
- **I1/I2/I3** untouched: no policy introspection added (`mcp_server_info` unchanged), the uniform denial text is byte-identical for identity-denied vs nonexistent (pinned), drop accounting unchanged.

## Adversarial review (before this PR, per AGENTS.md)

Three independent hostile reviews (security-bypass, correctness/fail-closed, docs-vs-code) plus mutation verification, then a fix round; the review gates this PR's opening.

**Security-bypass lens: PASS** — no findings; the forced-true create gate cannot be subverted from the request, no fail-open identity site exists, denial uniformity and I12 hold.

**Findings addressed (1 major, 8 minor, none rebutted):** the major — four sentences of `examples/policy.toml` prose (aging-window visibility, "rule 1 catches it first", the security-groups backstop bullet) became false for caller-authored bugs once the carve-out shipped; all qualified. Minors: blank whoami logins now count as failed resolution (and are pinned by test); identity threading is integration-pinned beyond `bug_info` (added `bug_comments` and quicksearch coverage with whoami call-count assertions); README/DESIGN enumeration and wording fixes; a commit-message miscount; a pre-existing DESIGN.md error adjacent to the diff (server_info described as concurrent; it fetches sequentially) corrected.

**Mutation verification (9 mutations, all now killed):** un-forcing the create gate; the fail-open identity-unknown reading; a case-sensitive login compare; unconditional whoami (laziness broken); a blank caller resolving as an identity; dropping `creator` from `CLASSIFY_FIELDS`; the `assemble_bug_info` re-check losing the caller; `needs_identity` ignoring unscoped rules — plus a free-choice mutation dropping the caller at a single tool's gate. Two initially **survived** and became new tests whose kills were then proven by re-applying each mutation: (1) nothing pinned `creator` staying in the classify projection, because the wiremock fixtures answered whatever was requested — a guard-level test now mocks the bug fetch to match only an `include_fields` carrying `creator`; (2) per-tool caller threading was pinned for only 3 of the 15 classifying tools — `bug_history` and a write-gate representative (`add_comment` under a carve-out granting `comment`) are now pinned, and the kill was verified against mutations at both tool sites. Both survivors were fail-closed feature regressions (own bugs over-denied), not disclosure holes — I4 held under every mutation that compiled.

## Verification

From the repo root on the final tree, independently of the implementing agents: `typos`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --all-targets --locked` (286 passed, 0 failed), `cargo deny check` (advisories/bans/licenses/sources ok). No new dependencies, `Cargo.lock` untouched, MSRV unaffected.
