### PR TITLE
feat(server): server-held Bugzilla API key via --api-key-file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +208,7 @@ dependencies = [
  "bugwarden-core",
  "chrono",
  "clap",
+ "reqwest 0.13.4",
  "rmcp",
  "schemars",
  "serde",
@@ -206,7 +230,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -234,6 +258,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -315,10 +341,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -428,6 +483,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +536,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -906,6 +973,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1179,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -1092,6 +1230,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -1251,6 +1390,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1460,7 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "rand",
+ "reqwest 0.13.4",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -1315,6 +1495,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,12 +1522,25 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1352,11 +1554,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1373,6 +1603,24 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "schemars"
@@ -1399,6 +1647,35 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1510,6 +1787,22 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -1952,6 +2245,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2325,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,12 +2358,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ touched or data is returned.
   (the ones most likely to contain not-yet-triaged sensitive data) invisible.
 - **Read-only mode and tool disabling** remove write tools from the MCP tool
   listing entirely — clients never see them, rather than seeing them error.
-- **Two transports**: streamable HTTP (per-request API key header, suitable for
-  shared deployments) and stdio (subprocess launch by a desktop MCP client).
+- **Two transports**: streamable HTTP (per-request API key header, or a
+  server-held key via `--api-key-file` for fleet deployments) and stdio
+  (subprocess launch by a desktop MCP client).
 - Single static binary, async throughout (tokio + [rmcp](https://crates.io/crates/rmcp)).
 
 ## Security model
@@ -187,12 +188,44 @@ instances that reject the `api_key` query parameter and require
 this affects only server-to-Bugzilla authentication, not the client-facing
 header.
 
+#### Server-held key mode (fleet deployments)
+
+With `--api-key-file` the Bugzilla API key belongs to the *server*: every
+request is served with the key read from that file, clients present no
+credential at all, and the per-request header is not consulted — a request
+that does carry one is served with the server's key, and the header value is
+never read. There is **no fallback between the two modes in either
+direction** (handing clients the real key would let them bypass the guard by
+talking to Bugzilla directly). This fits deployments where the key is
+provisioned as a container secret or a systemd credential
+(`LoadCredential=bugzilla-key:/etc/bugwarden/bugzilla-key` plus
+`--api-key-file ${CREDENTIALS_DIRECTORY}/bugzilla-key`):
+
+```bash
+bugwarden \
+  --bugzilla-server https://bugzilla.opensuse.org \
+  --policy /etc/bugwarden/policy.toml \
+  --api-key-file /run/secrets/bugzilla-key \
+  --host 127.0.0.1 --port 8000
+```
+
+The file's content is trimmed, so a trailing newline is fine; an empty or
+unreadable file is a startup error naming the path (never its contents). The
+file is read exactly once, at startup — rotating the key requires a restart.
+Keep it mode 0600: bugwarden warns when group or others can access it.
+
+One policy consequence to know: in this mode every client authenticates to
+Bugzilla — and resolves identity — as the service account that owns the key,
+so a policy rule matching on `created_by_me` describes that one account's
+bug reports for *all* clients, not each caller's own. bugwarden warns at
+startup when server-held mode meets such a policy.
+
 ### stdio transport
 
 For MCP clients that launch the server as a subprocess and speak over
 stdin/stdout. There are no per-request HTTP headers here, so the API key must
-be provided up front via `--api-key` or `BUGZILLA_API_KEY` (starting without
-one is an error):
+be provided up front via `--api-key` / `BUGZILLA_API_KEY` or `--api-key-file`
+(starting without one is an error):
 
 ```bash
 BUGZILLA_API_KEY=your_api_key \
@@ -233,7 +266,8 @@ Command-line arguments take precedence over environment variables.
 | `--host <ADDRESS>` | `MCP_HOST` | `127.0.0.1` | Listen address (http transport only) |
 | `--port <PORT>` | `MCP_PORT` | `8000` | Listen port (http transport only) |
 | `--api-key-header <NAME>` | `MCP_API_KEY_HEADER` | `ApiKey` | HTTP header name in which clients send the Bugzilla API key (http transport only) |
-| `--api-key <KEY>` | `BUGZILLA_API_KEY` | — | Bugzilla API key. **Required** for `--transport stdio`; with `http` it is ignored with a warning (clients send the key per request) |
+| `--api-key <KEY>` | `BUGZILLA_API_KEY` | — | Bugzilla API key. **Required** for `--transport stdio` unless `--api-key-file` provides it; with `http` it is ignored with a warning (clients send the key per request — use `--api-key-file` for a server-held key) |
+| `--api-key-file <PATH>` | `BUGZILLA_API_KEY_FILE` | — | Path to a file holding the Bugzilla API key (container secret, systemd `LoadCredential` path). Mutually exclusive with `--api-key`; an empty value counts as unset. Over `http` this selects server-held key mode: every request is served with this key and the per-request header is not consulted |
 | `--use-auth-header` | — | `false` | Authenticate to Bugzilla with `Authorization: Bearer <key>` instead of the `api_key` query parameter |
 | `--read-only` | `MCP_READ_ONLY` | `false` | Disable all write tools. Tighten-only: ORed with the policy's `global.read_only`; cannot re-enable writes a policy forbids |
 | `--policy <PATH>` | `BUGWARDEN_POLICY` | — | Path to the guard policy TOML. Without it, an allow-all policy applies (with private comments off) |

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -42,9 +42,16 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-# The integration tests drive the tools through a real MCP session over an
-# in-memory duplex transport, so the client half of rmcp is needed here.
-rmcp = { version = "2.2", features = ["client"] }
+# The integration tests drive the tools through a real MCP session — over an
+# in-memory duplex transport (tools_wiremock) and over real streamable HTTP
+# (http_transport_wiremock) — so the client half of rmcp is needed here. The
+# rmcp `reqwest` feature selects rustls, matching the rustls-only workspace.
+rmcp = { version = "2.2", features = [
+    "client",
+    "transport-streamable-http-client-reqwest",
+    "reqwest",
+] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-util"] }
 wiremock = "0.6"

--- a/crates/bugwarden/src/config.rs
+++ b/crates/bugwarden/src/config.rs
@@ -2,24 +2,30 @@
 //!
 //! Precedence: CLI argument > environment variable > hardcoded default.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+use anyhow::Context as _;
+use clap::builder::TypedValueParser as _;
 use clap::{Parser, ValueEnum};
 
 /// Transport for the MCP server.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum Transport {
     /// Streamable HTTP transport (default). Clients send the Bugzilla API key
-    /// per-request via the API key header.
+    /// per-request via the API key header, unless `--api-key-file` selects
+    /// server-held key mode (then the header is not consulted at all).
     Http,
     /// Stdio transport. The API key comes from `--api-key` /
-    /// `BUGZILLA_API_KEY` at startup.
+    /// `BUGZILLA_API_KEY` or `--api-key-file` at startup.
     Stdio,
 }
 
 /// MCP server for Bugzilla interaction, with operator-controlled security
 /// guards.
-#[derive(Debug, Parser)]
+///
+/// `Debug` is implemented by hand to redact `api_key`: the struct holds the
+/// startup key, and key material must never reach logs or error text (I12).
+#[derive(Parser)]
 #[command(name = "bugwarden", version, about)]
 pub struct Cli {
     /// Base URL of the Bugzilla server (e.g., 'https://bugzilla.example.com').
@@ -44,16 +50,31 @@ pub struct Cli {
     pub port: u16,
 
     /// HTTP header for clients to send the Bugzilla API key. Defaults to
-    /// 'ApiKey' or the MCP_API_KEY_HEADER environment variable.
+    /// 'ApiKey' or the MCP_API_KEY_HEADER environment variable. Not consulted
+    /// in server-held key mode (--api-key-file over http).
     #[arg(long, env = "MCP_API_KEY_HEADER", default_value = "ApiKey")]
     pub api_key_header: String,
 
     /// Bugzilla API key. Required for --transport stdio (no HTTP headers
-    /// exist there). Environment variable BUGZILLA_API_KEY can also be used.
-    /// Ignored for --transport http (clients send the key per-request via the
-    /// API key header).
+    /// exist there) unless --api-key-file provides it. Environment variable
+    /// BUGZILLA_API_KEY can also be used. Ignored for --transport http
+    /// (clients send the key per-request via the API key header; use
+    /// --api-key-file for a server-held key).
     #[arg(long, env = "BUGZILLA_API_KEY", hide_env_values = true)]
     pub api_key: Option<String>,
+
+    /// Path to a file holding the Bugzilla API key (e.g. a container secret or
+    /// systemd LoadCredential path). Mutually exclusive with --api-key. Over
+    /// http this selects server-held key mode: every request is served with
+    /// this key and the per-request API key header is not consulted. An empty
+    /// value counts as absent, like --api-key (so `BUGZILLA_API_KEY_FILE=` is
+    /// an unset, not an error).
+    #[arg(
+        long,
+        env = "BUGZILLA_API_KEY_FILE",
+        value_parser = clap::builder::OsStringValueParser::new().map(PathBuf::from)
+    )]
+    pub api_key_file: Option<PathBuf>,
 
     /// Use 'Authorization: Bearer' header instead of the api_key query
     /// parameter (required for some Bugzilla instances).
@@ -77,4 +98,350 @@ pub struct Cli {
     /// Without it no audit stream is written.
     #[arg(long, env = "BUGWARDEN_AUDIT_CONFIG")]
     pub audit_config: Option<PathBuf>,
+}
+
+/// Manual impl so the startup key can never reach a log or error through a
+/// `{:?}` of the config (I12); every other field prints as derived.
+impl std::fmt::Debug for Cli {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Cli")
+            .field("bugzilla_server", &self.bugzilla_server)
+            .field("transport", &self.transport)
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("api_key_header", &self.api_key_header)
+            .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
+            .field("api_key_file", &self.api_key_file)
+            .field("use_auth_header", &self.use_auth_header)
+            .field("read_only", &self.read_only)
+            .field("policy", &self.policy)
+            .field("audit_config", &self.audit_config)
+            .finish()
+    }
+}
+
+/// Who holds the Bugzilla API key, resolved exactly once at startup.
+///
+/// No Debug impl on purpose: the `Server` variant carries the key itself,
+/// and key material must never reach logs or error text (I12).
+#[derive(Clone)]
+pub enum KeyCustody {
+    /// The server owns one key resolved at startup (stdio startup key, or
+    /// http server-held mode). Requests never consult the key header.
+    Server(String),
+    /// http per-request mode: each request must carry the key header.
+    PerRequest,
+}
+
+impl Cli {
+    /// Resolve who holds the Bugzilla API key — the whole table, once, at
+    /// startup.
+    ///
+    /// - `--api-key` and `--api-key-file` together: error (mutually
+    ///   exclusive; there is no fallback between them).
+    /// - `--api-key-file` (any transport): the file's trimmed content is the
+    ///   server-held key; over http the per-request header is not consulted.
+    /// - stdio with `--api-key`: the startup key. Without either source,
+    ///   stdio errors here — at startup, never at first request.
+    /// - http with `--api-key` alone: warn and ignore, stay per-request.
+    ///   Deliberately NOT upgraded to server-held: `BUGZILLA_API_KEY` is a
+    ///   generic env name other Bugzilla tooling sets, and flipping it to
+    ///   server-held would silently change deployed custody semantics.
+    ///
+    /// Errors name the key file's path, never its contents (I12). The log
+    /// line emitted here states mode and source only — no key material.
+    pub fn resolve_key_custody(&self) -> anyhow::Result<KeyCustody> {
+        // An empty --api-key counts as absent, as everywhere else; an empty
+        // --api-key-file path likewise (`BUGZILLA_API_KEY_FILE=` is the
+        // set-but-empty "unset" idiom of systemd units and container specs).
+        let startup_key = self.api_key.as_deref().filter(|k| !k.is_empty());
+        let key_file = self
+            .api_key_file
+            .as_deref()
+            .filter(|p| !p.as_os_str().is_empty());
+        if startup_key.is_some() && key_file.is_some() {
+            anyhow::bail!(
+                "--api-key (BUGZILLA_API_KEY) and --api-key-file (BUGZILLA_API_KEY_FILE) \
+                 are mutually exclusive; pass exactly one"
+            );
+        }
+        if let Some(path) = key_file {
+            let key = read_key_file(path)?;
+            match self.transport {
+                Transport::Stdio => tracing::info!("API key: startup key (stdio)"),
+                Transport::Http => tracing::info!(
+                    "API key: server-held (from {}); the per-request '{}' header \
+                     is not consulted",
+                    path.display(),
+                    self.api_key_header
+                ),
+            }
+            return Ok(KeyCustody::Server(key));
+        }
+        match self.transport {
+            Transport::Stdio => match startup_key {
+                Some(key) => {
+                    tracing::info!("API key: startup key (stdio)");
+                    Ok(KeyCustody::Server(key.to_owned()))
+                }
+                None => anyhow::bail!(
+                    "--transport stdio requires --api-key or the BUGZILLA_API_KEY environment variable"
+                ),
+            },
+            Transport::Http => {
+                if self.api_key.is_some() {
+                    tracing::warn!(
+                        "--api-key / BUGZILLA_API_KEY is set but ignored with --transport http \
+                         (clients send the key per-request via the API key header; use \
+                         --api-key-file for a server-held key). Unset it to clean the config."
+                    );
+                }
+                tracing::info!(
+                    "API key: per-request via the '{}' header",
+                    self.api_key_header
+                );
+                Ok(KeyCustody::PerRequest)
+            }
+        }
+    }
+}
+
+/// Read and trim the API key file. Errors name the path only, never the
+/// file's contents (I12). On unix, warns when the file is readable by group
+/// or others: the key is a credential and should be 0600.
+fn read_key_file(path: &Path) -> anyhow::Result<String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        if let Ok(meta) = std::fs::metadata(path) {
+            let mode = meta.permissions().mode();
+            if mode & 0o077 != 0 {
+                tracing::warn!(
+                    path = %path.display(),
+                    mode = format!("{:o}", mode & 0o777),
+                    "API key file is accessible by group or others; \
+                     restrict it to 0600"
+                );
+            }
+        }
+    }
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read the API key file {}", path.display()))?;
+    let key = raw.trim();
+    if key.is_empty() {
+        anyhow::bail!("the API key file {} is empty", path.display());
+    }
+    Ok(key.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use clap::Parser as _;
+
+    use super::*;
+
+    /// A `Cli` for `transport` with both key sources explicitly cleared, so
+    /// the ambient environment (`BUGZILLA_API_KEY`, `BUGZILLA_API_KEY_FILE`)
+    /// cannot leak into what a test resolves.
+    fn base_cli(transport: &str) -> Cli {
+        let mut cli = Cli::parse_from([
+            "bugwarden",
+            "--bugzilla-server",
+            "https://bugzilla.example.com",
+            "--transport",
+            transport,
+        ]);
+        cli.api_key = None;
+        cli.api_key_file = None;
+        cli
+    }
+
+    fn key_file(content: &str) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().expect("temp key file");
+        file.write_all(content.as_bytes()).expect("write key file");
+        file
+    }
+
+    fn server_key(custody: KeyCustody) -> String {
+        match custody {
+            KeyCustody::Server(key) => key,
+            KeyCustody::PerRequest => panic!("expected the server-held key"),
+        }
+    }
+
+    /// The resolution error, by match: `expect_err` needs the Ok type to be
+    /// Debug, which `KeyCustody` deliberately is not (it carries the key).
+    fn resolve_err(cli: &Cli) -> anyhow::Error {
+        match cli.resolve_key_custody() {
+            Err(e) => e,
+            Ok(_) => panic!("key custody resolution must fail"),
+        }
+    }
+
+    #[test]
+    fn both_key_sources_are_a_startup_error_naming_both_flags() {
+        for transport in ["stdio", "http"] {
+            let file = key_file("file-key\n");
+            let mut cli = base_cli(transport);
+            cli.api_key = Some("flag-key".into());
+            cli.api_key_file = Some(file.path().to_path_buf());
+            let msg = format!("{:#}", resolve_err(&cli));
+            // "--api-key" is a substring of "--api-key-file", so pin each
+            // flag together with its env var — unambiguous per flag.
+            assert!(
+                msg.contains("--api-key (BUGZILLA_API_KEY)"),
+                "unexpected error: {msg}"
+            );
+            assert!(
+                msg.contains("--api-key-file (BUGZILLA_API_KEY_FILE)"),
+                "unexpected error: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn stdio_without_any_key_source_fails_at_resolution() {
+        let cli = base_cli("stdio");
+        let msg = format!("{:#}", resolve_err(&cli));
+        assert!(msg.contains("--transport stdio requires"), "{msg}");
+
+        // An empty --api-key counts as absent.
+        let mut cli = base_cli("stdio");
+        cli.api_key = Some(String::new());
+        assert!(cli.resolve_key_custody().is_err());
+    }
+
+    #[test]
+    fn empty_or_whitespace_key_file_is_an_error_naming_the_path() {
+        for content in ["", " \n\t \n"] {
+            let file = key_file(content);
+            let mut cli = base_cli("http");
+            cli.api_key_file = Some(file.path().to_path_buf());
+            let msg = format!("{:#}", resolve_err(&cli));
+            assert!(
+                msg.contains(&file.path().display().to_string()),
+                "the error must name the path: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn key_file_content_is_trimmed() {
+        let file = key_file("the-key\n");
+        let mut cli = base_cli("http");
+        cli.api_key_file = Some(file.path().to_path_buf());
+        let custody = cli.resolve_key_custody().expect("key file resolves");
+        assert_eq!(server_key(custody), "the-key");
+    }
+
+    #[test]
+    fn unreadable_key_file_is_an_error_naming_the_path() {
+        let mut cli = base_cli("http");
+        cli.api_key_file = Some(PathBuf::from("/nonexistent/bugwarden-key"));
+        let msg = format!("{:#}", resolve_err(&cli));
+        assert!(msg.contains("/nonexistent/bugwarden-key"), "{msg}");
+    }
+
+    #[test]
+    fn stdio_takes_the_key_from_the_file_too() {
+        let file = key_file("stdio-file-key\n");
+        let mut cli = base_cli("stdio");
+        cli.api_key_file = Some(file.path().to_path_buf());
+        let custody = cli.resolve_key_custody().expect("key file resolves");
+        assert_eq!(server_key(custody), "stdio-file-key");
+    }
+
+    #[test]
+    fn http_with_startup_key_alone_stays_per_request() {
+        // Warn-and-ignore, pinned: --api-key over http must NOT silently
+        // upgrade to server-held custody.
+        let mut cli = base_cli("http");
+        cli.api_key = Some("flag-key".into());
+        let custody = cli.resolve_key_custody().expect("http resolves");
+        assert!(
+            matches!(custody, KeyCustody::PerRequest),
+            "http + --api-key must stay per-request"
+        );
+    }
+
+    #[test]
+    fn stdio_startup_key_is_server_custody() {
+        let mut cli = base_cli("stdio");
+        cli.api_key = Some("startup-key".into());
+        let custody = cli.resolve_key_custody().expect("stdio resolves");
+        assert_eq!(server_key(custody), "startup-key");
+    }
+
+    #[test]
+    fn empty_api_key_file_counts_as_absent() {
+        // `BUGZILLA_API_KEY_FILE=` (set but empty, the systemd/container
+        // "unset" idiom) must behave exactly like an unset variable: the
+        // parser accepts the empty value and resolution ignores it —
+        // mirroring the empty --api-key convention.
+        let mut cli = Cli::parse_from([
+            "bugwarden",
+            "--bugzilla-server",
+            "https://bugzilla.example.com",
+            "--transport",
+            "http",
+            "--api-key-file",
+            "",
+        ]);
+        cli.api_key = None;
+        let custody = cli.resolve_key_custody().expect("http resolves");
+        assert!(
+            matches!(custody, KeyCustody::PerRequest),
+            "an empty key file path must not select server-held mode"
+        );
+
+        // On stdio the empty path falls through to the no-key-source error,
+        // not to a read of the path "".
+        let mut cli = base_cli("stdio");
+        cli.api_key_file = Some(PathBuf::new());
+        let msg = format!("{:#}", resolve_err(&cli));
+        assert!(msg.contains("--transport stdio requires"), "{msg}");
+    }
+
+    #[test]
+    fn cli_debug_never_prints_the_startup_key_i12() {
+        let mut cli = base_cli("stdio");
+        cli.api_key = Some("SUPERSECRETKEY123".into());
+        let printed = format!("{cli:?}");
+        assert!(
+            !printed.contains("SUPERSECRETKEY123"),
+            "Debug must redact the key: {printed}"
+        );
+        assert!(printed.contains("<redacted>"), "{printed}");
+    }
+
+    #[test]
+    fn startup_log_states_mode_and_source_never_key_material_i12() {
+        // Acceptance criterion: the resolved custody is visible in the
+        // startup log. Server-held: the line names the mode and the path —
+        // and never the key. Per-request: the line names the header.
+        let file = key_file("hush-key\n");
+        let mut cli = base_cli("http");
+        cli.api_key_file = Some(file.path().to_path_buf());
+        let (custody, logs) = crate::testlog::capture_logs(|| cli.resolve_key_custody());
+        drop(custody.expect("key file resolves"));
+        assert!(logs.contains("server-held"), "startup log: {logs}");
+        assert!(
+            logs.contains(&file.path().display().to_string()),
+            "the log must name the source path: {logs}"
+        );
+        assert!(
+            !logs.contains("hush-key"),
+            "the log must never carry key material (I12): {logs}"
+        );
+
+        let cli = base_cli("http");
+        let (custody, logs) = crate::testlog::capture_logs(|| cli.resolve_key_custody());
+        drop(custody.expect("http resolves"));
+        assert!(
+            logs.contains("per-request via the 'ApiKey' header"),
+            "startup log: {logs}"
+        );
+    }
 }

--- a/crates/bugwarden/src/lib.rs
+++ b/crates/bugwarden/src/lib.rs
@@ -12,3 +12,6 @@
 pub mod audit;
 pub mod config;
 pub mod server;
+
+#[cfg(test)]
+mod testlog;

--- a/crates/bugwarden/src/main.rs
+++ b/crates/bugwarden/src/main.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use anyhow::{bail, Context};
+use anyhow::Context;
 use bugwarden::audit::{
     policy_hash_of, AuditConfig, AuditSink, AuditState, FailMode, TransportKind,
 };
@@ -50,31 +50,18 @@ async fn main() -> anyhow::Result<()> {
     // CLI/env can only tighten policy (I9).
     policy.global.read_only |= cli.read_only;
 
-    match cli.transport {
-        Transport::Stdio => {
-            if cli.api_key.as_deref().is_none_or(str::is_empty) {
-                bail!(
-                    "--transport stdio requires --api-key or the BUGZILLA_API_KEY environment variable"
-                );
-            }
-        }
-        Transport::Http => {
-            if cli.api_key.is_some() {
-                tracing::warn!(
-                    "--api-key / BUGZILLA_API_KEY is set but ignored with --transport http \
-                     (clients send the key per-request via the API key header). \
-                     Unset it to clean the config."
-                );
-            }
-        }
-    }
-
+    // API key custody (stdio-without-key bail, http --api-key warn, key
+    // file handling) is resolved inside BugWarden::new — before the audit
+    // sink below, so a key misconfiguration aborts startup without first
+    // creating or rotating an audit file.
     let bz = Arc::new(
         BugzillaClient::new(&cli.bugzilla_server, cli.use_auth_header)
             .context("failed to build Bugzilla client")?,
     );
     let guard = Arc::new(Guard { policy });
     let cfg = Arc::new(cli);
+    let server =
+        server::BugWarden::new(cfg.clone(), guard, bz).context("failed to build the MCP server")?;
 
     // Audit stream, when configured. The fail mode falls back to the
     // transport-derived default; the policy digest ties every record to
@@ -117,8 +104,6 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
-    let server = server::BugWarden::new(cfg.clone(), guard, bz)
-        .context("failed to build the MCP server from the guard policy")?;
     let server = match audit {
         Some(audit) => server.with_audit(audit),
         None => server,

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -24,7 +24,7 @@ use rmcp::{
 use serde_json::{json, Value};
 
 use crate::audit::{self, AuditCell, AuditState, FailMode, TransportKind, Verdict};
-use crate::config::{Cli, Transport};
+use crate::config::{Cli, KeyCustody, Transport};
 
 /// Names of the tools that modify bug state. These routes are removed from
 /// the router in read-only mode (I13).
@@ -758,6 +758,10 @@ pub struct BugWarden {
     guard: Arc<Guard>,
     bz: Arc<BugzillaClient>,
     tool_router: ToolRouter<Self>,
+    /// Who holds the Bugzilla API key — resolved exactly once, at
+    /// construction. In `Server` custody the running server owns the key
+    /// `String`; it is never re-read from disk per request.
+    key_custody: KeyCustody,
     /// Audit wiring; `None` runs the exact pre-audit request path.
     audit: Option<Arc<AuditState>>,
 }
@@ -770,7 +774,28 @@ impl BugWarden {
     /// would otherwise leave the tool exposed while the operator believes it
     /// disabled — the policy format's "typos are hard startup errors, never
     /// silent fail-open" rule applies here too.
+    ///
+    /// Also resolves API key custody ([`Cli::resolve_key_custody`]) — here,
+    /// on every construction path, so a missing or unreadable key fails at
+    /// startup rather than at the first request.
     pub fn new(cfg: Arc<Cli>, guard: Arc<Guard>, bz: Arc<BugzillaClient>) -> anyhow::Result<Self> {
+        let key_custody = cfg.resolve_key_custody()?;
+        // Identity collapses under server-held http custody: every client
+        // authenticates — and therefore whoamis — as the server's service
+        // account. A policy written for per-request custody, where
+        // `created_by_me` meant each caller's own reports, silently changes
+        // meaning, so say it out loud at startup.
+        if cfg.transport == Transport::Http
+            && matches!(key_custody, KeyCustody::Server(_))
+            && guard.policy.needs_identity()
+        {
+            tracing::warn!(
+                "the policy consults created_by_me, but in server-held key mode every \
+                 client resolves to the service account that owns the key: \
+                 created_by_me describes that one account's bug reports for ALL \
+                 clients, never an individual caller's"
+            );
+        }
         let mut tool_router = Self::tool_router();
         // Validate disabled_tools against the FULL router, before any route
         // removal: a write-tool name stays a valid entry even when read-only
@@ -804,6 +829,7 @@ impl BugWarden {
             guard,
             bz,
             tool_router,
+            key_custody,
             audit: None,
         })
     }
@@ -853,24 +879,16 @@ impl BugWarden {
 
     /// Resolve the Bugzilla API key for the current request.
     ///
-    /// stdio: from the startup configuration. http: from the configured
-    /// (lowercased) header of the underlying HTTP request. A missing key is a
+    /// Server custody (stdio, or http server-held mode): the key resolved at
+    /// startup — the per-request header is never consulted, so a request that
+    /// carries one is served with the server's key and the header value is
+    /// never read. Per-request custody (http): from the configured
+    /// (lowercased) header of the underlying HTTP request; a missing key is a
     /// protocol error (`McpError::invalid_request`), not a tool error.
     fn api_key(&self, ctx: &RequestContext<RoleServer>) -> Result<String, McpError> {
-        match self.cfg.transport {
-            Transport::Stdio => self
-                .cfg
-                .api_key
-                .as_deref()
-                .filter(|k| !k.is_empty())
-                .map(str::to_owned)
-                .ok_or_else(|| {
-                    McpError::invalid_request(
-                        "stdio transport requires --api-key or BUGZILLA_API_KEY env var",
-                        None,
-                    )
-                }),
-            Transport::Http => {
+        match &self.key_custody {
+            KeyCustody::Server(key) => Ok(key.clone()),
+            KeyCustody::PerRequest => {
                 let header_name = self.cfg.api_key_header.to_lowercase();
                 ctx.extensions
                     .get::<axum::http::request::Parts>()
@@ -2747,7 +2765,7 @@ mod tests {
 
     fn parts(policy: &str) -> (Arc<Cli>, Arc<Guard>, Arc<BugzillaClient>) {
         use clap::Parser as _;
-        let cfg = Arc::new(Cli::parse_from([
+        let mut cli = Cli::parse_from([
             "bugwarden",
             "--bugzilla-server",
             "https://bugzilla.example.com",
@@ -2755,7 +2773,11 @@ mod tests {
             "stdio",
             "--api-key",
             "test-key",
-        ]));
+        ]);
+        // The ambient environment (BUGZILLA_API_KEY_FILE) must not leak into
+        // what these tests resolve.
+        cli.api_key_file = None;
+        let cfg = Arc::new(cli);
         let guard = Arc::new(Guard {
             policy: Policy::from_toml_str(policy).expect("test policy must parse"),
         });
@@ -2777,6 +2799,78 @@ mod tests {
         let msg = format!("{err:#}");
         assert!(msg.contains("no_such_tool"), "unexpected error: {msg}");
         assert!(msg.contains("unknown tool"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn new_fails_at_construction_for_stdio_without_a_key() {
+        // Key custody is resolved by BugWarden::new on every construction
+        // path: stdio without any key source must fail at startup, never at
+        // the first request. main.rs no longer duplicates this bail.
+        use clap::Parser as _;
+        let mut cli = Cli::parse_from([
+            "bugwarden",
+            "--bugzilla-server",
+            "https://bugzilla.example.com",
+            "--transport",
+            "stdio",
+        ]);
+        // The ambient environment must not decide this test.
+        cli.api_key = None;
+        cli.api_key_file = None;
+        let guard = Arc::new(Guard {
+            policy: Policy::from_toml_str("").expect("empty policy parses"),
+        });
+        let bz = Arc::new(
+            BugzillaClient::new("https://bugzilla.example.com", false).expect("client must build"),
+        );
+        let err = match BugWarden::new(Arc::new(cli), guard, bz) {
+            Err(e) => e,
+            Ok(_) => panic!("stdio without a key must fail at construction"),
+        };
+        let msg = format!("{err:#}");
+        assert!(msg.contains("--transport stdio requires"), "{msg}");
+    }
+
+    #[test]
+    fn server_held_custody_with_identity_policy_warns_at_startup() {
+        // Under server-held http custody every client whoamis as the service
+        // account that owns the key, so a created_by_me policy written for
+        // per-request custody silently changes meaning — construction must
+        // say so. A policy that never consults identity stays quiet.
+        use clap::Parser as _;
+        use std::io::Write as _;
+        let mut file = tempfile::NamedTempFile::new().expect("temp key file");
+        file.write_all(b"srv-key\n").expect("write key file");
+        let identity_policy = concat!(
+            "[[rule]]\nname = \"own-reports\"\naction = \"allow\"\n",
+            "[rule.match]\ncreated_by_me = true\n",
+        );
+        for (policy, expect_warn) in [(identity_policy, true), ("", false)] {
+            let mut cli = Cli::parse_from([
+                "bugwarden",
+                "--bugzilla-server",
+                "https://bugzilla.example.com",
+                "--transport",
+                "http",
+            ]);
+            cli.api_key = None;
+            cli.api_key_file = Some(file.path().to_path_buf());
+            let guard = Arc::new(Guard {
+                policy: Policy::from_toml_str(policy).expect("test policy must parse"),
+            });
+            let bz = Arc::new(
+                BugzillaClient::new("https://bugzilla.example.com", false)
+                    .expect("client must build"),
+            );
+            let (server, logs) =
+                crate::testlog::capture_logs(|| BugWarden::new(Arc::new(cli), guard, bz));
+            drop(server.expect("server must build"));
+            assert_eq!(
+                logs.contains("created_by_me describes that one account"),
+                expect_warn,
+                "startup logs: {logs}"
+            );
+        }
     }
 
     #[test]
@@ -3000,7 +3094,7 @@ mod tests {
         audit: Option<Arc<AuditState>>,
     ) -> RunningService<RoleClient, ()> {
         use clap::Parser as _;
-        let cfg = Arc::new(Cli::parse_from([
+        let mut cli = Cli::parse_from([
             "bugwarden",
             "--bugzilla-server",
             mock_uri,
@@ -3008,7 +3102,10 @@ mod tests {
             "stdio",
             "--api-key",
             "test-key",
-        ]));
+        ]);
+        // The ambient environment (BUGZILLA_API_KEY_FILE) must not leak in.
+        cli.api_key_file = None;
+        let cfg = Arc::new(cli);
         let guard = Arc::new(Guard {
             policy: Policy::from_toml_str(policy).expect("test policy must parse"),
         });

--- a/crates/bugwarden/src/testlog.rs
+++ b/crates/bugwarden/src/testlog.rs
@@ -1,0 +1,39 @@
+//! Test-only capture of tracing output, for pinning what startup log lines
+//! say — and, per I12, what they must never say.
+
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+
+/// Cloneable in-memory writer handed to the fmt subscriber.
+#[derive(Clone, Default)]
+struct Buffer(Arc<Mutex<Vec<u8>>>);
+
+impl Write for Buffer {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .expect("log buffer lock")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Run `f` with a fresh fmt subscriber as the thread-default and return its
+/// result together with everything it logged.
+pub(crate) fn capture_logs<T>(f: impl FnOnce() -> T) -> (T, String) {
+    let buffer = Buffer::default();
+    let writer = buffer.clone();
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::TRACE)
+        .with_ansi(false)
+        .with_writer(move || writer.clone())
+        .finish();
+    let value = tracing::subscriber::with_default(subscriber, f);
+    let logs = String::from_utf8(buffer.0.lock().expect("log buffer lock").clone())
+        .expect("captured logs are UTF-8");
+    (value, logs)
+}

--- a/crates/bugwarden/tests/audit_wiremock.rs
+++ b/crates/bugwarden/tests/audit_wiremock.rs
@@ -69,7 +69,7 @@ async fn audited_client_with(
         Some("sha256:policy-under-test".to_string()),
     ));
 
-    let cfg = Arc::new(Cli::parse_from([
+    let mut cli = Cli::parse_from([
         "bugwarden",
         "--bugzilla-server",
         &mock.uri(),
@@ -77,7 +77,10 @@ async fn audited_client_with(
         "stdio",
         "--api-key",
         api_key,
-    ]));
+    ]);
+    // The ambient environment (BUGZILLA_API_KEY_FILE) must not leak in.
+    cli.api_key_file = None;
+    let cfg = Arc::new(cli);
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(policy).expect("test policy must parse"),
     });
@@ -102,7 +105,7 @@ async fn audited_client_with(
 
 /// An un-audited server over the same transport, for comparisons.
 async fn plain_client_for(policy: &str, mock: &MockServer) -> RunningService<RoleClient, ()> {
-    let cfg = Arc::new(Cli::parse_from([
+    let mut cli = Cli::parse_from([
         "bugwarden",
         "--bugzilla-server",
         &mock.uri(),
@@ -110,7 +113,10 @@ async fn plain_client_for(policy: &str, mock: &MockServer) -> RunningService<Rol
         "stdio",
         "--api-key",
         "test-key",
-    ]));
+    ]);
+    // The ambient environment (BUGZILLA_API_KEY_FILE) must not leak in.
+    cli.api_key_file = None;
+    let cfg = Arc::new(cli);
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(policy).expect("test policy must parse"),
     });

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -1,0 +1,346 @@
+//! End-to-end tests of API key custody over REAL streamable HTTP.
+//!
+//! Each test builds a [`BugWarden`] with `--transport http`, serves it over
+//! an actual TCP listener through `StreamableHttpService`, and connects an
+//! rmcp client through reqwest — the only harness in which the per-request
+//! key header physically exists. The wiremock upstream plays Bugzilla; the
+//! key reaches it as the `api_key` query parameter, so a `query_param`
+//! matcher proves WHICH key served a request.
+//!
+//! Coverage contract (each of these mutations must fail at least one test):
+//! - server-held mode falling back to the client's header when one is sent;
+//! - `resolve_key_custody` dropping server-held mode on http;
+//! - `api_key()` re-reading the key file per request instead of once at
+//!   startup;
+//! - server-held mode rejecting requests that carry the header;
+//! - dropping the trim of the key file's content.
+
+use std::io::Write as _;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use bugwarden::config::Cli;
+use bugwarden::server::BugWarden;
+use bugwarden_core::client::BugzillaClient;
+use bugwarden_core::guard::Guard;
+use bugwarden_core::policy::Policy;
+use clap::Parser as _;
+use rmcp::model::{CallToolRequestParams, CallToolResult};
+use rmcp::service::{RoleClient, RunningService};
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::streamable_http_server::{
+    session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
+};
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::ServiceExt as _;
+use serde_json::{json, Value};
+use wiremock::matchers::{any, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Build the http-transport `Cli` against `mock`, with `key_file` when the
+/// test runs in server-held mode. Both key fields are then set explicitly,
+/// so the ambient environment (`BUGZILLA_API_KEY`, `BUGZILLA_API_KEY_FILE`)
+/// cannot leak into what a test resolves.
+fn http_cli(mock: &MockServer, key_file: Option<&std::path::Path>) -> Arc<Cli> {
+    let mut cli = Cli::parse_from([
+        "bugwarden",
+        "--bugzilla-server",
+        &mock.uri(),
+        "--transport",
+        "http",
+        "--api-key-header",
+        "ApiKey",
+    ]);
+    cli.api_key = None;
+    cli.api_key_file = key_file.map(std::path::Path::to_path_buf);
+    Arc::new(cli)
+}
+
+/// Serve a [`BugWarden`] built from `cli` and `policy` over a real TCP
+/// listener; returns the bound address.
+async fn serve_http(cli: Arc<Cli>, policy: &str, mock: &MockServer) -> SocketAddr {
+    let guard = Arc::new(Guard {
+        policy: Policy::from_toml_str(policy).expect("test policy must parse"),
+    });
+    let bz = Arc::new(BugzillaClient::new(&mock.uri(), false).expect("client must build"));
+    let server = BugWarden::new(cli, guard, bz).expect("server must build");
+
+    let service = StreamableHttpService::new(
+        move || Ok(server.clone()),
+        LocalSessionManager::default().into(),
+        StreamableHttpServerConfig::default(),
+    );
+    let router = axum::Router::new().nest_service("/mcp", service);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind an ephemeral port");
+    let addr = listener.local_addr().expect("bound address");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    addr
+}
+
+/// Connect an MCP client to `addr` over streamable HTTP. With
+/// `header_value`, every request carries `ApiKey: <value>` (a reqwest
+/// default header); without, no key header exists anywhere in the session.
+async fn connect(addr: SocketAddr, header_value: Option<&str>) -> RunningService<RoleClient, ()> {
+    let mut builder = reqwest::Client::builder();
+    if let Some(value) = header_value {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("ApiKey", value.parse().expect("header value"));
+        builder = builder.default_headers(headers);
+    }
+    let transport = StreamableHttpClientTransport::with_client(
+        builder.build().expect("reqwest client"),
+        StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp")),
+    );
+    ().serve(transport)
+        .await
+        .expect("MCP handshake must succeed")
+}
+
+/// Call `tool` with `args`; the outer `Result` carries protocol errors.
+async fn try_call(
+    client: &RunningService<RoleClient, ()>,
+    tool: &str,
+    args: Value,
+) -> Result<CallToolResult, rmcp::ServiceError> {
+    let Value::Object(args) = args else {
+        panic!("tool arguments must be a JSON object");
+    };
+    client
+        .call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(args))
+        .await
+}
+
+/// All text blocks of a result, concatenated.
+fn text_of(result: &CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .filter_map(|c| c.as_text())
+        .map(|t| t.text.as_str())
+        .collect()
+}
+
+/// A classification response for one world-readable bug.
+fn world_readable_bug(id: u64) -> Value {
+    json!({
+        "id": id,
+        "summary": "a plain bug",
+        "product": "openSUSE",
+        "component": "Kernel",
+        "status": "NEW",
+        "severity": "normal",
+        "priority": "P3",
+        "keywords": [],
+        "groups": [],
+        "whiteboard": "",
+        "creation_time": "2020-01-01T00:00:00Z",
+    })
+}
+
+/// Mount the fetches a served `bug_info` call needs — the bug itself
+/// (classification + body, hence unbounded) and the id=0 link-disclosure
+/// padding — all REQUIRING `api_key=<key>`: a request authenticating with
+/// any other key falls through to the test's catch-all.
+async fn mount_bug_for_key(mock: &MockServer, bug: Value, key: &str) {
+    let id = bug["id"].as_u64().expect("bug fixture has an id");
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", id.to_string()))
+        .and(query_param("api_key", key))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [bug] })))
+        .mount(mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "0"))
+        .and(query_param("api_key", key))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .mount(mock)
+        .await;
+}
+
+/// Mount a catch-all expecting ZERO requests carrying `api_key=<key>`.
+async fn expect_no_requests_with_key(mock: &MockServer, key: &str) {
+    Mock::given(any())
+        .and(query_param("api_key", key))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .named(format!("no request may authenticate with '{key}'"))
+        .mount(mock)
+        .await;
+}
+
+/// A named temp file holding `content` — the operator's key file.
+fn key_file(content: &str) -> tempfile::NamedTempFile {
+    let mut file = tempfile::NamedTempFile::new().expect("temp key file");
+    file.write_all(content.as_bytes()).expect("write key file");
+    file.flush().expect("flush key file");
+    file
+}
+
+/// Assert `bug_info` for bug 7 succeeds and serves the bug's content.
+async fn assert_bug_7_served(client: &RunningService<RoleClient, ()>) {
+    let result = try_call(client, "bug_info", json!({ "bug_ids": [7] }))
+        .await
+        .expect("bug_info must not be a protocol error");
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "bug_info failed: {}",
+        text_of(&result)
+    );
+    let envelope: Value = serde_json::from_str(&text_of(&result)).expect("bug_info returns JSON");
+    assert_eq!(envelope["bugs"][0]["id"], json!(7), "bug 7 must be served");
+}
+
+#[tokio::test]
+async fn server_held_serves_clients_with_no_credential() {
+    // The fleet deployment shape: the key lives in a file only the server
+    // reads, the client presents nothing at all — and is served with the
+    // server's key. The upstream matcher REQUIRES api_key=srv-key, so this
+    // also proves the trailing newline was trimmed end to end.
+    let mock = MockServer::start().await;
+    mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
+
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock).await;
+    let client = connect(addr, None).await;
+
+    assert_bug_7_served(&client).await;
+}
+
+#[tokio::test]
+async fn server_held_never_reads_the_client_header() {
+    // Acceptance criterion 2: in server-held mode a request that DOES carry
+    // the header is served — with the server's key. The header value must
+    // never reach Bugzilla: expect(0) on the attacker key, and the bug-7
+    // mocks only answer api_key=srv-key, so a fallback to the header would
+    // also fail the call itself.
+    let mock = MockServer::start().await;
+    expect_no_requests_with_key(&mock, "attacker-key").await;
+    mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
+
+    let file = key_file("srv-key");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock).await;
+    let client = connect(addr, Some("attacker-key")).await;
+
+    assert_bug_7_served(&client).await;
+}
+
+#[tokio::test]
+async fn per_request_header_still_authenticates_over_http() {
+    // Without --api-key-file nothing changes: the client's key header is
+    // what authenticates to Bugzilla, exactly as before.
+    let mock = MockServer::start().await;
+    mount_bug_for_key(&mock, world_readable_bug(7), "client-key").await;
+
+    let cli = http_cli(&mock, None);
+    let addr = serve_http(cli, "", &mock).await;
+    let client = connect(addr, Some("client-key")).await;
+
+    assert_bug_7_served(&client).await;
+}
+
+#[tokio::test]
+async fn per_request_missing_header_is_a_protocol_error() {
+    // Per-request mode with no header: a protocol-level invalid_request —
+    // not a tool-text denial — and nothing reaches the upstream at all.
+    let mock = MockServer::start().await;
+    Mock::given(any())
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .named("no upstream request without a client key")
+        .mount(&mock)
+        .await;
+
+    let cli = http_cli(&mock, None);
+    let addr = serve_http(cli, "", &mock).await;
+    let client = connect(addr, None).await;
+
+    let err = try_call(&client, "bug_info", json!({ "bug_ids": [7] }))
+        .await
+        .expect_err("a missing key header must be a protocol error");
+    assert!(
+        err.to_string().contains("ApiKey"),
+        "the error must name the header: {err}"
+    );
+}
+
+#[tokio::test]
+async fn server_held_key_is_resolved_once_at_startup() {
+    // The running server holds the String resolved at startup; the file is
+    // never re-read per request. Overwriting it mid-flight changes nothing:
+    // the second call still authenticates with srv-key (and an other-key
+    // request would both trip the expect(0) and fail the call, since the
+    // bug-7 mocks only answer srv-key).
+    let mock = MockServer::start().await;
+    expect_no_requests_with_key(&mock, "other-key").await;
+    mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
+
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock).await;
+    let client = connect(addr, None).await;
+
+    assert_bug_7_served(&client).await;
+
+    // Rotate the file on disk (std::fs::write truncates and rewrites from
+    // offset 0, so the file now really holds "other-key\n"); the running
+    // server must not notice.
+    std::fs::write(file.path(), b"other-key\n").expect("rewrite key file");
+
+    assert_bug_7_served(&client).await;
+}
+
+#[tokio::test]
+async fn guard_denies_uniformly_over_http() {
+    // Transport parity: server-held custody changes who authenticates to
+    // Bugzilla, not what the guard says — a policy-hidden bug takes the
+    // exact uniform denial text stdio clients get (I2), and its comments
+    // are never fetched.
+    let mock = MockServer::start().await;
+    let mut secret = world_readable_bug(7);
+    secret["product"] = json!("SecretSauce");
+    mount_bug_for_key(&mock, secret, "srv-key").await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/7/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "bugs": { "7": { "comments": [] } }
+        })))
+        .expect(0)
+        .mount(&mock)
+        .await;
+
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(
+        cli,
+        concat!(
+            "[[rule]]\nname = \"hide-secret\"\naction = \"deny\"\n",
+            "[rule.match]\nproducts = [\"Secret*\"]\n",
+        ),
+        &mock,
+    )
+    .await;
+    let client = connect(addr, None).await;
+
+    let result = try_call(&client, "bug_comments", json!({ "id": 7 }))
+        .await
+        .expect("a guard refusal is a tool error, not a protocol error");
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "the hidden bug must be refused"
+    );
+    assert_eq!(
+        text_of(&result),
+        "Bug 7 is not accessible through this server",
+        "the denial must be the uniform text (I2)"
+    );
+}

--- a/crates/bugwarden/tests/tools_wiremock.rs
+++ b/crates/bugwarden/tests/tools_wiremock.rs
@@ -39,7 +39,7 @@ const CREATE_DENIAL: &str = "Filing this bug is not permitted through this serve
 /// Serve a [`BugWarden`] built from `policy` against `mock`, and connect an
 /// MCP client to it over an in-memory duplex transport.
 async fn client_for(policy: &str, mock: &MockServer) -> RunningService<RoleClient, ()> {
-    let cfg = Arc::new(Cli::parse_from([
+    let mut cli = Cli::parse_from([
         "bugwarden",
         "--bugzilla-server",
         &mock.uri(),
@@ -47,7 +47,11 @@ async fn client_for(policy: &str, mock: &MockServer) -> RunningService<RoleClien
         "stdio",
         "--api-key",
         "test-key",
-    ]));
+    ]);
+    // The ambient environment (BUGZILLA_API_KEY_FILE) must not leak into
+    // what these tests resolve.
+    cli.api_key_file = None;
+    let cfg = Arc::new(cli);
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(policy).expect("test policy must parse"),
     });
@@ -1146,7 +1150,7 @@ async fn whoami_transport_error_does_not_leak_the_api_key_i12() {
     let addr = listener.local_addr().expect("addr");
     drop(listener); // free the port so every connection is refused
 
-    let cfg = Arc::new(Cli::parse_from([
+    let mut cli = Cli::parse_from([
         "bugwarden",
         "--bugzilla-server",
         &format!("http://{addr}"),
@@ -1154,7 +1158,9 @@ async fn whoami_transport_error_does_not_leak_the_api_key_i12() {
         "stdio",
         "--api-key",
         "SUPERSECRETKEY123",
-    ]));
+    ]);
+    cli.api_key_file = None; // the ambient environment must not leak in
+    let cfg = Arc::new(cli);
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(IDENTITY_POLICY).expect("test policy must parse"),
     });

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -542,7 +542,12 @@ where every other criterion describes bug content. Decisions, all deliberate:
   call (I12). It is compared case-insensitively (`to_lowercase`, the same
   normalization the glob matcher applies) against the bug's `creator`
   field, which joined `CLASSIFY_FIELDS` for this purpose. A non-string
-  `creator` leaves the relationship unknown.
+  `creator` leaves the relationship unknown. "The requesting account" is
+  whatever key custody says authenticates: per-request http custody gives
+  each caller their own identity, while `Server` custody (stdio, or http
+  server-held mode — see "Key custody") resolves EVERY caller to the one
+  account that owns the server's key; under server-held http custody the
+  collapse is warned about at startup.
 - **Laziness.** `Policy::needs_identity()` = some rule whose `operations`
   cover `Operation::Access` carries a `created_by_me` criterion. When it is
   false, `Guard::resolve_caller` returns `None` without any HTTP request —
@@ -595,7 +600,60 @@ Result convention: success => `CallToolResult::success` with ONE text block of
 pretty-printed JSON. The sole exception is `download_attachment`, which
 returns a JSON summary text block PLUS one image or blob-resource block. Guard refusals and input-validation failures =>
 `CallToolResult::error` with a text block (NOT a protocol error). Protocol
-issues (missing API key header) => `McpError::invalid_request`.
+issues (missing API key header in per-request custody) =>
+`McpError::invalid_request`.
+
+### Key custody
+
+Who authenticates to Bugzilla is resolved exactly ONCE, at startup
+(`Cli::resolve_key_custody` => `KeyCustody`, stored on the server; called
+inside `BugWarden::new` so EVERY construction path fails at startup, never
+at first request). The whole table:
+
+| transport | `--api-key` | `--api-key-file` | custody |
+|---|---|---|---|
+| any | set | set | startup error — mutually exclusive, names both flags |
+| stdio | set | — | `Server(key)` |
+| stdio | — | set | `Server(key from file)` |
+| stdio | — | — | startup error |
+| http | — | set | `Server(key from file)` — server-held mode |
+| http | set | — | `tracing::warn` + ignored => `PerRequest` |
+| http | — | — | `PerRequest` |
+
+An empty `--api-key` counts as absent; so does an empty `--api-key-file`
+path (`BUGZILLA_API_KEY_FILE=` is the set-but-empty "unset" idiom of systemd
+units and container specs). Decisions, all deliberate:
+
+- **`Server` custody** (stdio, or http server-held mode): the running
+  server owns the one key `String`; every request is served with it and the
+  per-request key header is NEVER consulted — a request that carries one is
+  SERVED (with the server's key), not rejected, and the header value is
+  never read. The key file is read once at startup; rotation requires a
+  restart (no per-request re-read, no SIGHUP reload).
+- **Identity collapses under server-held http custody.** Every client
+  authenticates — and therefore resolves identity — as the service account
+  that owns the key, so `created_by_me` describes that ONE account's bug
+  reports for all clients, never an individual caller's (see "Identity
+  resolution"). A policy written for per-request custody changes meaning
+  when redeployed with `--api-key-file`, so `BugWarden::new` emits a
+  `tracing::warn` when server-held http custody meets a policy that
+  consults identity (`Policy::needs_identity`).
+- **`PerRequest` custody** (http without a key file): each request must
+  carry the key header; a missing key is `McpError::invalid_request`.
+- **No fallback between custodies, in either direction.** Server-held mode
+  exists so fleet clients can hold NOTHING — a client holding the real key
+  could bypass the guard by talking to Bugzilla directly — so falling back
+  to a client-supplied header would defeat the mode's point. And http with
+  `--api-key` alone stays per-request (warn + ignore, never a silent
+  upgrade): `BUGZILLA_API_KEY` is a generic env name other Bugzilla tooling
+  sets, and flipping it to server-held would change deployed custody
+  semantics.
+- **Key file handling**: `read_to_string` then `trim`; empty after trim or
+  unreadable => startup error naming the PATH only, never file contents
+  (I12). On unix, a file accessible by group or others draws a
+  `tracing::warn` recommending 0600 (the read-bit analogue of the policy
+  file's write-bit warning). The startup log line states mode and source
+  only — never key material (I12).
 
 Tool descriptions: concise and action-oriented; state the defaults and
 constraints the model must know.
@@ -634,15 +692,20 @@ clap derive `Cli`, with env fallbacks:
 | --host | MCP_HOST | 127.0.0.1 | http only |
 | --port | MCP_PORT | 8000 | http only |
 | --api-key-header | MCP_API_KEY_HEADER | ApiKey | http per-request key header |
-| --api-key | BUGZILLA_API_KEY | — | required for stdio; warn-and-ignore for http |
+| --api-key | BUGZILLA_API_KEY | — | required for stdio unless --api-key-file provides it; warn-and-ignore for http (never a silent upgrade to server-held) |
+| --api-key-file | BUGZILLA_API_KEY_FILE | — | file holding the key (container secret / systemd LoadCredential path); mutually exclusive with --api-key; over http selects server-held key mode (see Key custody) |
 | --use-auth-header | — | false | Bearer to Bugzilla instead of api_key query param |
 | --read-only | MCP_READ_ONLY | false | tighten-only (I9) |
 | --policy | BUGWARDEN_POLICY | — | path to guard policy TOML |
 | --audit-config | BUGWARDEN_AUDIT_CONFIG | — | path to audit configuration TOML; without it no audit stream is written |
 
-Startup validation: stdio without api_key => exit with error; http with
-api_key => tracing::warn (ignored); http without audit_config =>
-tracing::warn (remote tool calls leave no audit record).
+Startup validation: key custody is resolved by `Cli::resolve_key_custody`
+inside `BugWarden::new` (see Key custody) — --api-key together with
+--api-key-file, stdio without any key source, and an empty or unreadable
+key file all exit with an error (the key-file errors name the path only,
+I12); http with api_key => tracing::warn (ignored). main.rs adds: http
+without audit_config => tracing::warn (remote tool calls leave no audit
+record).
 
 ## Audit stream (crates/bugwarden/src/audit.rs + the server.rs wrapper)
 
@@ -695,13 +758,13 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
 - `rmcp = { version = "2.2", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }`
 - axum MUST be 0.8 (rmcp's version — extension extraction breaks otherwise);
   schemars 1.x with feature `chrono04`; tokio 1; tokio-util 0.7.
-- Server struct: `#[derive(Clone)] pub struct BugWarden { cfg: Arc<Cli>, guard: Arc<Guard>, bz: Arc<BugzillaClient>, tool_router: ToolRouter<Self> }`
+- Server struct: `#[derive(Clone)] pub struct BugWarden { cfg: Arc<Cli>, guard: Arc<Guard>, bz: Arc<BugzillaClient>, tool_router: ToolRouter<Self>, key_custody: KeyCustody, audit: Option<Arc<AuditState>> }`
 - `BugWarden::new` builds `Self::tool_router()` then `remove_route` for write
   tools when read-only and for every `global.disabled_tools` entry (I13).
   Write tool names: add_comment, update_bug_status, assign_bug,
   update_bug_fields, update_bug_dependencies, add_cc_to_bug, mark_as_duplicate,
   create_bug, add_attachment.
-- API key resolution: stdio => `cfg.api_key`; http => `ctx.extensions.get::<axum::http::request::Parts>()`, then `parts.headers.get(lowercased_header_name)`.
+- API key resolution: a match on `key_custody` (resolved once at startup, see Key custody — never re-read per request): `Server(key)` => the server's key, without touching the request at all; `PerRequest` => `ctx.extensions.get::<axum::http::request::Parts>()`, then `parts.headers.get(lowercased_header_name)`.
 - HTTP serving: `StreamableHttpService::new(move || Ok(server.clone()), LocalSessionManager::default().into(), StreamableHttpServerConfig::default())`, `axum::Router::new().nest_service("/mcp", service)`, `tokio::net::TcpListener::bind`, graceful shutdown on ctrl_c.
 - Tracing to stderr always (stdout belongs to the stdio transport).
 
@@ -770,7 +833,21 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   identical restricted entries; the distinct-id bound; read-only delists
   create_bug and add_attachment (I13); the upload size gate measures decoded
   (never base64-encoded) bytes, is disabled at 0, and its refusal names no
-  number.
+  number; and stdio without any key source fails at `BugWarden::new`
+  construction, never at first request.
+- Unit tests (#[cfg(test)] in crates/bugwarden/src/config.rs): the key
+  custody table — the mutual-exclusion error names both flags (each pinned
+  with its env var, since `--api-key` is a substring of `--api-key-file`);
+  empty, whitespace-only, and unreadable key files error naming the path;
+  the file's content is trimmed (`"the-key\n"` => `Server("the-key")`);
+  stdio resolves the key from the file as well as from --api-key; http with
+  --api-key alone stays `PerRequest` (warn-and-ignore pinned against a
+  silent upgrade to server-held custody); an empty --api-key-file value
+  counts as absent; the startup log line states mode and source, never key
+  material (I12); `Cli`'s Debug redacts the startup key (I12); and
+  server-held http custody under an identity-consulting policy warns at
+  construction (crates/bugwarden/src/server.rs) that created_by_me now
+  describes the service account for every client.
 - Integration tests (crates/bugwarden-core/tests/guard_wiremock.rs, wiremock):
   quicksearch_window — pages stay full while visible bugs remain (no hole),
   consecutive pages tile the visible sequence disjointly (against a stable
@@ -827,6 +904,21 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   own reports POSTs the comment for the caller's bug and refuses a
   foreign one with nothing POSTed), and a whoami transport error leaking
   no API key into any client-visible text (I12).
+- Integration tests (crates/bugwarden/tests/http_transport_wiremock.rs,
+  wiremock + rmcp client over REAL streamable HTTP — the only harness in
+  which the per-request key header physically exists; the wiremock upstream
+  proves WHICH key served a request through an `api_key` query-param
+  matcher): server-held mode serves a client presenting no credential at
+  all, with the key file's trailing newline trimmed end to end; a
+  client-sent key header in server-held mode is SERVED with the server's
+  key — never rejected, never read, and nothing authenticating with the
+  header's value reaches Bugzilla (expect(0) on that key); per-request mode
+  still authenticates with the client's header; a missing header in
+  per-request mode is a protocol-level invalid_request costing zero
+  upstream requests; the key is resolved once at startup (rewriting the key
+  file mid-flight changes nothing — the old key keeps serving); and the
+  guard's uniform denial text is byte-identical over http (I2 transport
+  parity).
 - Audit tests (crates/bugwarden/tests/audit_wiremock.rs + #[cfg(test)] in
   server.rs and audit.rs): one record per call for EVERY routed tool,
   refusal paths and protocol errors included; the refusal map is total


### PR DESCRIPTION
Closes #27.

Over http the Bugzilla key so far came only from a per-request header, so every client holds the real key — and a client holding the key can talk to Bugzilla directly, past the guard. This adds the opposite custody for fleet deployments: the key belongs to the server, clients present nothing.

## What changed

- **`--api-key-file <PATH>` / `BUGZILLA_API_KEY_FILE`** reads the key at startup: content trimmed, empty or unreadable file is a startup error naming the path only (I12), group/other-accessible file draws a chmod-600 warning.
- **Custody is resolved exactly once**, in `Cli::resolve_key_custody()` called from `BugWarden::new`, so every misconfiguration fails at startup, never at first request — and before the audit sink opens, so a bad key config cannot leave a fresh audit file behind. The startup log states the mode and source, never key material.
- **Resolution table** (no fallback between custodies in either direction):
  - stdio: key from `--api-key` or now `--api-key-file`;
  - http + `--api-key-file`: **server-held mode** — every request is served with the server's key; the per-request header is never consulted (a request carrying one is served, its value never read);
  - http + `--api-key` alone: warn-and-ignore stays per-request — no silent upgrade, since `BUGZILLA_API_KEY` is a generic name other Bugzilla tooling sets and flipping it would change deployed custody;
  - both flags: mutually exclusive, startup error. Empty env values count as absent for both.
- **First real-HTTP integration suite** (`http_transport_wiremock.rs`): an rmcp/reqwest streamable-HTTP client drives the server end to end, and `api_key` query-param matchers prove *which* key served each request.
- README documents the mode (incl. a systemd `LoadCredential` deployment sketch); DESIGN.md gains the Key custody section, the resolution table, and the extended testing bar.

## Adversarial review record (pre-PR gate)

Three hostile lenses (security-bypass, correctness/fail-closed, docs-vs-code) plus mutation verification ran against the implementation commit; 10 findings, all addressed, none rebutted:

- **important** — *`created_by_me` identity collapse*: under server-held custody the server whoamis with its own key for every client, so an identity-relative policy silently describes the service account instead of the caller. Now: startup **warning** when server-held http custody meets a policy that consults identity, documented in DESIGN.md (Key custody + Identity resolution) and README, pinned by a test.
- minor ×9, all fixed: ambient `BUGZILLA_API_KEY_FILE` no longer breaks pre-existing test suites (builders null it); set-but-empty `BUGZILLA_API_KEY_FILE=` counts as absent instead of a raw clap usage error; `Cli`'s `Debug` now redacts `api_key` (I12); the mutual-exclusion test pins each flag+env pair unambiguously; the key-rotation test rewrites the file for real (no stale-cursor NUL padding) so its `expect(0)` argument is true; custody resolves before the audit sink opens; the startup log lines are pinned by a tracing capture helper (doubles as an I12 pin — mode and path, never the key); DESIGN.md's `BugWarden` struct listing gained the missing `audit` field.

**Mutation verification: 9/9 killed, no survivors.** Each mutation applied singly in a detached worktree, killed by the named test, reverted:

| mutation | killed by |
|---|---|
| M1 server-held falls back to the client header | `server_held_never_reads_the_client_header` |
| M2 file on http resolves to per-request | `server_held_serves_clients_with_no_credential` |
| M3 both flags accepted | `both_key_sources_are_a_startup_error_naming_both_flags` |
| M4 empty key file accepted | `empty_or_whitespace_key_file_is_an_error_naming_the_path` |
| M5 trim dropped | `key_file_content_is_trimmed` + http suite |
| M6 key re-read per request | `server_held_key_is_resolved_once_at_startup` |
| M7 http + `--api-key` silently upgrades to server-held | `http_with_startup_key_alone_stays_per_request` |
| M8 stdio-without-key fails only at first request | `stdio_without_any_key_source_fails_at_resolution` |
| M9 server-held rejects requests carrying the header | `server_held_never_reads_the_client_header` |

Full AGENTS.md gate re-run independently on the squashed commit: fmt, clippy `-D warnings`, `cargo test --workspace --all-targets --locked` (305 tests), `cargo deny check`, typos — all green. Dev-deps only in the lockfile delta (rmcp http-client features + reqwest 0.13, rustls-only).

As the issue notes, this **blocks #32**: once clients present no credential, per-caller endpoint authentication becomes necessary rather than optional.
