### PR TITLE
feat(server): widen update_bug_fields per the update-field audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ implied.
 | `attachments` | read | listing attachment metadata and downloading attachment content |
 | `comment` | write | adding a comment |
 | `status` | write | changing status/resolution, marking duplicates |
-| `fields` | write | changing priority, severity, resolution, `cf_*` custom fields |
+| `fields` | write | changing priority, severity, resolution, summary, URL, whiteboard, version, target milestone, keywords, see-also links, `cf_*` custom fields |
 | `assign` | write | changing the assignee |
 | `cc` | write | modifying the CC list |
 | `deps` | write | changing blocks/depends_on |
@@ -397,7 +397,7 @@ action.
 | `add_comment` | Add a comment to a bug | `comment` |
 | `update_bug_status` | Change status/resolution (CLOSED requires a resolution) | `status` |
 | `assign_bug` | Set the assignee | `assign` |
-| `update_bug_fields` | Update priority/severity/resolution and `cf_*` custom fields | `fields` |
+| `update_bug_fields` | Update priority/severity/resolution, summary, URL, whiteboard, version, target milestone, keywords and see-also links (both add/remove, never replace-all), and `cf_*` custom fields | `fields` on the bug **and** at least `summary` on every see-also target on this instance |
 | `update_bug_dependencies` | Add/remove blocks and depends_on entries | `deps` |
 | `add_cc_to_bug` | Add an email to the CC list | `cc` |
 | `mark_as_duplicate` | Close a bug as DUPLICATE of another | `status` on the bug **and** at least `summary` on the duplicate target |

--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -453,7 +453,12 @@ impl Guard {
 
     /// The bug id a `see_also` entry points at, when it points at THIS
     /// Bugzilla. Entries for other trackers are somebody else's to disclose.
-    fn see_also_local_id(entry: &str, base_url: &str) -> Option<u64> {
+    ///
+    /// Public because the write side needs the same parse the read side
+    /// uses: `update_bug_fields` must assess the local targets of
+    /// `see_also_add`/`see_also_remove` before writing the link (I8/I14),
+    /// exactly as the read paths scrub such links out of served bugs.
+    pub fn see_also_local_id(entry: &str, base_url: &str) -> Option<u64> {
         // Compare host-and-path only, case-insensitively: Bugzilla stores
         // see_also with the host as the user typed it, so scheme and case
         // vary freely for the same instance. An instance reachable under a

--- a/crates/bugwarden-core/src/policy.rs
+++ b/crates/bugwarden-core/src/policy.rs
@@ -77,7 +77,9 @@ pub enum Capability {
     Comment,
     /// Write: change status/resolution/mark as duplicate.
     Status,
-    /// Write: change priority/severity/resolution/custom `cf_*` fields.
+    /// Write: change priority/severity/resolution, summary, url,
+    /// whiteboard, version, target milestone, keywords, see_also links,
+    /// and custom `cf_*` fields.
     Fields,
     /// Write: change the assignee.
     Assign,

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -143,9 +143,10 @@ fn audit_refusal(tool: &str) -> CallToolResult {
 
 /// Keys of client-authored tool parameters whose VALUES may enter an audit
 /// record. The bar: identifiers, projections and routing/vocabulary fields
-/// yes; free text no. `comment`, `summary`, `description`, `data`
-/// (attachment bytes) and `custom_fields` (operator-defined values) never
-/// appear by value — a non-allowlisted key is recorded as
+/// yes; free text no. `comment`, `summary`, `description`, `url`,
+/// `whiteboard`, `data` (attachment bytes), `custom_fields`
+/// (operator-defined values) and the `see_also_add`/`see_also_remove` URL
+/// lists never appear by value — a non-allowlisted key is recorded as
 /// `{"_len": <serialized byte length>}`, so presence and size are loggable
 /// while content is not. Allowlisted string values are truncated to 1024
 /// characters.
@@ -170,6 +171,8 @@ const PARAM_ALLOWLIST: &[&str] = &[
     "is_patch",
     "is_private",
     "keywords",
+    "keywords_add",
+    "keywords_remove",
     "limit",
     "new_since",
     "offset",
@@ -181,6 +184,7 @@ const PARAM_ALLOWLIST: &[&str] = &[
     "resolution",
     "severity",
     "status",
+    "target_milestone",
     "version",
 ];
 
@@ -444,6 +448,36 @@ fn dep_change(add: Option<&Vec<u64>>, remove: Option<&Vec<u64>>) -> Option<Value
     }
 }
 
+/// [`dep_change`] for string lists (`keywords`, `see_also`): build an
+/// `{"add": [..], "remove": [..]}` change object; `None` when there is no
+/// change. Empty strings are dropped like the scalar params drop them, and
+/// a side that is absent, empty, or becomes empty is omitted. The
+/// replace-all `set` variant is never produced — a stale view of the list
+/// would silently wipe entries added since it was read.
+fn list_change(add: Option<&Vec<String>>, remove: Option<&Vec<String>>) -> Option<Value> {
+    fn clean(list: Option<&Vec<String>>) -> Vec<&str> {
+        list.into_iter()
+            .flatten()
+            .map(String::as_str)
+            .filter(|s| !s.is_empty())
+            .collect()
+    }
+    let mut obj = serde_json::Map::new();
+    let add = clean(add);
+    if !add.is_empty() {
+        obj.insert("add".to_string(), json!(add));
+    }
+    let remove = clean(remove);
+    if !remove.is_empty() {
+        obj.insert("remove".to_string(), json!(remove));
+    }
+    if obj.is_empty() {
+        None
+    } else {
+        Some(Value::Object(obj))
+    }
+}
+
 /// Decoded byte length of a base64 payload, counting the `=` padding out.
 ///
 /// Used to re-check an attachment against the size cap without decoding the
@@ -670,6 +704,34 @@ pub struct UpdateBugFieldsParams {
     /// closed bugs.
     #[serde(default)]
     pub resolution: Option<String>,
+    /// New one-line summary (retitles the bug).
+    #[serde(default)]
+    pub summary: Option<String>,
+    /// URL the bug relates to (the bug's "URL" field).
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Status whiteboard text.
+    #[serde(default)]
+    pub whiteboard: Option<String>,
+    /// Version of the product the bug is against (instance-specific
+    /// vocabulary).
+    #[serde(default)]
+    pub version: Option<String>,
+    /// Target milestone (instance-specific vocabulary).
+    #[serde(default)]
+    pub target_milestone: Option<String>,
+    /// Keywords to add.
+    #[serde(default)]
+    pub keywords_add: Option<Vec<String>>,
+    /// Keywords to remove.
+    #[serde(default)]
+    pub keywords_remove: Option<Vec<String>>,
+    /// See Also entries to add; each value is a bug URL.
+    #[serde(default)]
+    pub see_also_add: Option<Vec<String>>,
+    /// See Also entries to remove; each value is a bug URL.
+    #[serde(default)]
+    pub see_also_remove: Option<Vec<String>>,
     /// Custom fields, e.g. {"cf_fixed_in": "1.2.3"}. Keys must start with
     /// 'cf_'.
     #[serde(default)]
@@ -1598,7 +1660,7 @@ impl BugWarden {
     }
 
     #[tool(
-        description = "Update various bug fields. All fields are optional, but at least one must be specified. Custom field names must start with 'cf_' (e.g. {\"cf_fixed_in\": \"1.2.3\"}).",
+        description = "Update bug fields: priority, severity, resolution, summary, url, whiteboard, version, target_milestone, keywords (add/remove), see_also (add/remove; values are bug URLs), and custom 'cf_*' fields. All fields are optional, but at least one must be specified. Empty strings and empty lists are ignored; clearing a field is not supported. Custom field names must start with 'cf_' (e.g. {\"cf_fixed_in\": \"1.2.3\"}).",
         annotations(
             read_only_hint = false,
             destructive_hint = true,
@@ -1611,24 +1673,49 @@ impl BugWarden {
         Parameters(p): Parameters<UpdateBugFieldsParams>,
         ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
+        // priority/severity/resolution are benign instance vocabulary and
+        // stay value-logged; every other param is logged as presence or
+        // count only — summaries, whiteboards and URLs can carry embargoed
+        // content, and the server log must not become a content sink (the
+        // audit stream's boundary rule, applied to tracing).
         tracing::info!(
             bug_id = p.bug_id,
             priority = ?p.priority,
             severity = ?p.severity,
             resolution = ?p.resolution,
+            summary = p.summary.is_some(),
+            url = p.url.is_some(),
+            whiteboard = p.whiteboard.is_some(),
+            version = p.version.is_some(),
+            target_milestone = p.target_milestone.is_some(),
+            keywords_add = p.keywords_add.as_ref().map_or(0, Vec::len),
+            keywords_remove = p.keywords_remove.as_ref().map_or(0, Vec::len),
+            see_also_add = p.see_also_add.as_ref().map_or(0, Vec::len),
+            see_also_remove = p.see_also_remove.as_ref().map_or(0, Vec::len),
             custom_field_count = p.custom_fields.as_ref().map_or(0, |cf| cf.len()),
             "tool: update_bug_fields"
         );
 
         let mut payload = serde_json::Map::new();
-        if let Some(priority) = p.priority.as_deref().filter(|s| !s.is_empty()) {
-            payload.insert("priority".to_string(), json!(priority));
+        for (field, value) in [
+            ("priority", &p.priority),
+            ("severity", &p.severity),
+            ("resolution", &p.resolution),
+            ("summary", &p.summary),
+            ("url", &p.url),
+            ("whiteboard", &p.whiteboard),
+            ("version", &p.version),
+            ("target_milestone", &p.target_milestone),
+        ] {
+            if let Some(v) = value.as_deref().filter(|s| !s.is_empty()) {
+                payload.insert(field.to_string(), json!(v));
+            }
         }
-        if let Some(severity) = p.severity.as_deref().filter(|s| !s.is_empty()) {
-            payload.insert("severity".to_string(), json!(severity));
+        if let Some(keywords) = list_change(p.keywords_add.as_ref(), p.keywords_remove.as_ref()) {
+            payload.insert("keywords".to_string(), keywords);
         }
-        if let Some(resolution) = p.resolution.as_deref().filter(|s| !s.is_empty()) {
-            payload.insert("resolution".to_string(), json!(resolution));
+        if let Some(see_also) = list_change(p.see_also_add.as_ref(), p.see_also_remove.as_ref()) {
+            payload.insert("see_also".to_string(), see_also);
         }
         if let Some(custom_fields) = &p.custom_fields {
             // I7: only cf_* keys may pass through the generic updater. Error
@@ -1651,14 +1738,63 @@ impl BugWarden {
         }
         attach_comment(&mut payload, &p.comment);
 
+        // I8/I14: a see_also entry that points at THIS Bugzilla is a bug-id
+        // link, so writing one is judged like the other link-writing paths
+        // (update_bug_dependencies, mark_as_duplicate/I11): the bug being
+        // updated needs `fields`, and every LOCAL see_also target must allow
+        // at least `summary` before the PUT. Without this, a see_also change
+        // would write links into policy-denied bugs — Bugzilla records the
+        // reciprocal entry on the target — and leak their existence through
+        // the difference between its success and "does not exist" responses
+        // (I2). Entries for other trackers carry no local bug id and are
+        // somebody else's to disclose; they pass through unassessed.
+        let base_url = self.bz.base_url();
+        let mut ids: Vec<u64> = vec![p.bug_id];
+        for list in [&p.see_also_add, &p.see_also_remove].into_iter().flatten() {
+            ids.extend(
+                list.iter()
+                    .filter_map(|entry| Guard::see_also_local_id(entry, base_url)),
+            );
+        }
+        let mut seen = BTreeSet::new();
+        ids.retain(|id| seen.insert(*id));
+        if let Some(refusal) = too_many_ids(&ids) {
+            note_refused(&ctx);
+            return Ok(refusal);
+        }
+
         let key = self.api_key(&ctx)?;
         let caller = self.guard.resolve_caller(&self.bz, &key).await;
-        if let Some(denied) = self
-            .deny_unless(&key, p.bug_id, Capability::Fields, caller.as_deref(), &ctx)
-            .await
-        {
-            return Ok(denied);
+        let cell = audit_cell(&ctx);
+        let assessments = self.assess(&key, &ids, caller.as_deref()).await;
+        let note = |id: u64, verdict: Verdict| {
+            if let Some(cell) = &cell {
+                match assessments.get(&id) {
+                    Some((access, _)) => cell.note_verdict_rule(verdict, access_rule(access)),
+                    None => cell.note_verdict(verdict),
+                }
+            }
+        };
+        let fields_ok = assessments
+            .get(&p.bug_id)
+            .is_some_and(|(access, _)| access.allows(Capability::Fields));
+        if !fields_ok {
+            tracing::info!(bug_id = p.bug_id, "guard denied operation");
+            note(p.bug_id, Verdict::Denied);
+            return Ok(err_text(Guard::denial(p.bug_id)));
         }
+        for &id in ids.iter().filter(|&&id| id != p.bug_id) {
+            let target_ok = assessments
+                .get(&id)
+                .is_some_and(|(access, _)| access.allows(Capability::Summary));
+            if !target_ok {
+                tracing::info!(bug_id = id, "guard denied see_also target");
+                note(id, Verdict::Denied);
+                return Ok(err_text(Guard::denial(id)));
+            }
+        }
+        note(p.bug_id, Verdict::Served);
+
         match self
             .bz
             .update_bug(&key, p.bug_id, Value::Object(payload))

--- a/crates/bugwarden/tests/tools_wiremock.rs
+++ b/crates/bugwarden/tests/tools_wiremock.rs
@@ -12,6 +12,8 @@
 //!   add_attachment gate;
 //! - deleting the `may_create` call from create_bug;
 //! - deleting the upload size-cap call from add_attachment;
+//! - dropping the local see_also targets from update_bug_fields' assessed
+//!   id set (or lowering their Capability::Summary bar to nothing);
 //! - attaching the quicksearch id-list advisory only when the served `bugs`
 //!   array is non-empty;
 //! - suppressing the quicksearch id-list advisory when I14 link scrubbing
@@ -742,6 +744,296 @@ async fn add_attachment_comment_travels_as_a_plain_string() {
     let result = call(&client, "add_attachment", args).await;
     assert!(!is_error(&result), "result: {}", text_of(&result));
     assert!(text_of(&result).contains("55"));
+}
+
+// ---------- update_bug_fields: the widened field surface (issue #38) ----------
+
+/// Mount a successful `PUT /rest/bug/7` whose body must carry `body`,
+/// expected exactly once.
+async fn mount_update_put(mock: &MockServer, body: Value) {
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/7"))
+        .and(body_partial_json(body))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [{ "id": 7 }] })))
+        .expect(1)
+        .mount(mock)
+        .await;
+}
+
+#[tokio::test]
+async fn update_fields_sends_see_also_add_and_remove() {
+    // see_also travels as the {"add": [..], "remove": [..]} object — the
+    // shape update_bug_dependencies already pinned for blocks/depends_on —
+    // with BOTH sides present when both were given, never a flat array.
+    // The entries name bugs on ANOTHER tracker (bugzilla.example.org, not
+    // this mock), so they are somebody else's to disclose and must NOT be
+    // guard-assessed: the classify mock for bug 7 is the only one mounted,
+    // and its expect(1) fails the test if a foreign URL draws a lookup.
+    let mock = MockServer::start().await;
+    mount_classify(&mock, world_readable_bug(7)).await;
+    mount_update_put(
+        &mock,
+        json!({
+            "see_also": {
+                "add": ["https://bugzilla.example.org/show_bug.cgi?id=101"],
+                "remove": ["https://bugzilla.example.org/show_bug.cgi?id=102"],
+            }
+        }),
+    )
+    .await;
+    let client = client_for("", &mock).await;
+    let result = call(
+        &client,
+        "update_bug_fields",
+        json!({
+            "bug_id": 7,
+            "see_also_add": ["https://bugzilla.example.org/show_bug.cgi?id=101"],
+            "see_also_remove": ["https://bugzilla.example.org/show_bug.cgi?id=102"],
+        }),
+    )
+    .await;
+    assert!(!is_error(&result), "result: {}", text_of(&result));
+}
+
+#[tokio::test]
+async fn update_fields_sends_keywords_as_add_remove_never_set() {
+    // The add/remove-vs-set distinction is the point: `set` replaces the
+    // WHOLE keyword list, so a stale view would silently wipe concurrent
+    // additions. The specific mock accepts only the add shape; the
+    // catch-all behind it answers any other PUT body (a `set`-shaped one
+    // included) and fails the test through its expect(0) when hit.
+    let mock = MockServer::start().await;
+    mount_classify(&mock, world_readable_bug(7)).await;
+    mount_update_put(&mock, json!({ "keywords": { "add": ["regression"] } })).await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/7"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [{ "id": 7 }] })))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    let client = client_for("", &mock).await;
+    let result = call(
+        &client,
+        "update_bug_fields",
+        json!({ "bug_id": 7, "keywords_add": ["regression"] }),
+    )
+    .await;
+    assert!(!is_error(&result), "result: {}", text_of(&result));
+}
+
+#[tokio::test]
+async fn update_fields_sets_scalar_fields() {
+    // All five scalar fields land in one PUT body, and the optional
+    // comment still rides along in the Bug.update shape.
+    let mock = MockServer::start().await;
+    mount_classify(&mock, world_readable_bug(7)).await;
+    mount_update_put(
+        &mock,
+        json!({
+            "summary": "clearer title",
+            "url": "https://example.org/crash-report",
+            "whiteboard": "triaged",
+            "version": "15.6",
+            "target_milestone": "Beta1",
+            "comment": { "body": "retitled after triage" },
+        }),
+    )
+    .await;
+    let client = client_for("", &mock).await;
+    let result = call(
+        &client,
+        "update_bug_fields",
+        json!({
+            "bug_id": 7,
+            "summary": "clearer title",
+            "url": "https://example.org/crash-report",
+            "whiteboard": "triaged",
+            "version": "15.6",
+            "target_milestone": "Beta1",
+            "comment": "retitled after triage",
+        }),
+    )
+    .await;
+    assert!(!is_error(&result), "result: {}", text_of(&result));
+}
+
+#[tokio::test]
+async fn update_fields_ignores_empty_strings_and_empty_lists() {
+    // Empty values mean "not this field", exactly like the pre-existing
+    // params: the body must carry ONLY the real field. The trap mock is
+    // mounted first, so a body still carrying "summary" is routed to it
+    // and fails its expect(0); the emptied keyword list is checked against
+    // the recorded request body directly.
+    let mock = MockServer::start().await;
+    mount_classify(&mock, world_readable_bug(7)).await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/7"))
+        .and(body_partial_json(json!({ "summary": "" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [{ "id": 7 }] })))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    mount_update_put(&mock, json!({ "priority": "P2" })).await;
+    let client = client_for("", &mock).await;
+    let result = call(
+        &client,
+        "update_bug_fields",
+        json!({ "bug_id": 7, "summary": "", "keywords_add": [], "priority": "P2" }),
+    )
+    .await;
+    assert!(!is_error(&result), "result: {}", text_of(&result));
+    let put_body: Value = mock
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .find(|r| r.method == wiremock::http::Method::PUT)
+        .map(|r| serde_json::from_slice(&r.body).expect("PUT body is JSON"))
+        .expect("one PUT reached the mock");
+    assert_eq!(
+        put_body,
+        json!({ "priority": "P2" }),
+        "empty strings and empty lists must not reach the wire"
+    );
+}
+
+#[tokio::test]
+async fn update_fields_new_fields_respect_the_guard() {
+    // A call touching only the newer fields still goes through deny_unless:
+    // a policy-denied bug takes the uniform denial (I2) and nothing is PUT.
+    let mock = MockServer::start().await;
+    let mut secret = world_readable_bug(7);
+    secret["product"] = json!("SecretSauce");
+    mount_classify(&mock, secret).await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/7"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [{ "id": 7 }] })))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    let client = client_for(
+        concat!(
+            "[[rule]]\nname = \"hide-secret\"\naction = \"deny\"\n",
+            "[rule.match]\nproducts = [\"Secret*\"]\n",
+        ),
+        &mock,
+    )
+    .await;
+    let result = call(
+        &client,
+        "update_bug_fields",
+        json!({ "bug_id": 7, "summary": "probe", "keywords_add": ["regression"] }),
+    )
+    .await;
+    assert!(is_error(&result));
+    assert_eq!(
+        text_of(&result),
+        "Bug 7 is not accessible through this server",
+        "a denied bug takes the uniform denial for new fields too (I2)"
+    );
+}
+
+#[tokio::test]
+async fn update_fields_see_also_targets_respect_the_guard() {
+    // A see_also entry naming a bug on THIS instance is a bug-id link, so
+    // its target takes the same Capability::Summary bar as dependency
+    // targets and duplicate_of (I8/I14): a policy-denied target draws the
+    // uniform denial (I2) and nothing is PUT. Otherwise the difference
+    // between Bugzilla's success and "does not exist" answers would
+    // enumerate every hidden id, and a successful PUT would even write the
+    // reciprocal see_also entry onto the denied bug itself.
+    let mock = MockServer::start().await;
+    mount_classify(&mock, world_readable_bug(7)).await;
+    let mut secret = world_readable_bug(999);
+    secret["product"] = json!("SecretSauce");
+    mount_classify(&mock, secret).await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/7"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [{ "id": 7 }] })))
+        .expect(0)
+        .mount(&mock)
+        .await;
+    let client = client_for(
+        concat!(
+            "[[rule]]\nname = \"hide-secret\"\naction = \"deny\"\n",
+            "[rule.match]\nproducts = [\"Secret*\"]\n",
+        ),
+        &mock,
+    )
+    .await;
+    let result = call(
+        &client,
+        "update_bug_fields",
+        json!({
+            "bug_id": 7,
+            "see_also_add": [format!("{}/show_bug.cgi?id=999", mock.uri())],
+        }),
+    )
+    .await;
+    assert!(is_error(&result));
+    assert_eq!(
+        text_of(&result),
+        "Bug 999 is not accessible through this server",
+        "a policy-denied see_also target takes the uniform denial (I2), no PUT"
+    );
+}
+
+#[tokio::test]
+async fn update_fields_still_rejects_non_cf_custom_keys() {
+    // I7 unchanged by the widening: `see_also` has a named param now, and
+    // as a custom_fields key it still errors before Bugzilla is contacted —
+    // the named params did not open a smuggling path through the generic
+    // updater.
+    let mock = MockServer::start().await;
+    let client = client_for("", &mock).await;
+    let result = call(
+        &client,
+        "update_bug_fields",
+        json!({
+            "bug_id": 7,
+            "custom_fields": {
+                "see_also": ["https://bugzilla.example.org/show_bug.cgi?id=101"],
+            },
+        }),
+    )
+    .await;
+    assert!(is_error(&result));
+    assert_eq!(
+        text_of(&result),
+        "Invalid custom field 'see_also': custom field names must start with 'cf_'"
+    );
+    assert!(
+        mock.received_requests().await.unwrap().is_empty(),
+        "the cf_ gate must refuse before any upstream request (I7)"
+    );
+}
+
+#[tokio::test]
+async fn update_fields_all_empty_call_errors_without_calling_bugzilla() {
+    // Nothing but empty strings and empty lists is an empty call: the
+    // at-least-one-field check counts the new params AFTER the emptiness
+    // filtering, and refuses before anything upstream happens.
+    let mock = MockServer::start().await;
+    let client = client_for("", &mock).await;
+    let result = call(
+        &client,
+        "update_bug_fields",
+        json!({
+            "bug_id": 7,
+            "summary": "",
+            "url": "",
+            "whiteboard": "",
+            "keywords_add": [],
+            "see_also_remove": [],
+        }),
+    )
+    .await;
+    assert!(is_error(&result));
+    assert_eq!(text_of(&result), "At least one field must be specified");
+    assert!(
+        mock.received_requests().await.unwrap().is_empty(),
+        "an all-empty call must not contact Bugzilla"
+    );
 }
 
 /// Tool names a client sees when it lists the server's tools — a real

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -53,8 +53,10 @@ Dependency direction: `bugwarden -> bugwarden-core`, never the reverse.
   client IS shown: dependency/duplicate/see_also fields of a served bug,
   history changes naming other bugs, or Bugzilla's auto-generated duplicate
   marker comments. The bar is `Capability::Summary` — the same one the write
-  paths apply before CREATING such a link (I8/I11), since a link read out and
-  a link written in disclose the same fact. Candidate ids come from Bugzilla,
+  paths apply before CREATING such a link (I8/I11: dependency targets,
+  `duplicate_of`, and the local-instance targets of `update_bug_fields`'
+  `see_also_add`/`see_also_remove`), since a link read out and a link
+  written in disclose the same fact. Candidate ids come from Bugzilla,
   not the client, so they are assessed in ONE batched request (Guard::
   disclosable) rather than per id; a failed fetch scrubs everything (I4).
   Applies to bug_info, bugs_quicksearch (the client picks the projection, so
@@ -377,6 +379,7 @@ impl Guard {
     pub async fn disclosable(&self, bz: &BugzillaClient, key: &str,
         ids: &BTreeSet<u64>, caller: Option<&str>) -> BTreeSet<u64>;
     pub fn linked_bug_ids(bug: &Value, base_url: &str) -> BTreeSet<u64>;
+    pub fn see_also_local_id(entry: &str, base_url: &str) -> Option<u64>; // write side reuses the read side's parse
     pub fn scrub_bug_links(bug: &mut Value, base_url: &str, ok: &BTreeSet<u64>);
     pub fn history_bug_ids(history: &Value, base_url: &str) -> BTreeSet<u64>;
     pub fn scrub_history(history: Value, base_url: &str, ok: &BTreeSet<u64>) -> Value;
@@ -611,7 +614,7 @@ constraints the model must know.
 | add_comment | bug_id, comment, is_private: bool = false | comment (write) | |
 | update_bug_status | bug_id, status, resolution?, comment: String = "" | status (write) | CLOSED requires resolution (error otherwise); when reopening (status not CLOSED/VERIFIED and no resolution given) set `"resolution": ""` |
 | assign_bug | bug_id, assignee (email), comment = "" | assign (write) | payload `{"assigned_to": ..}` |
-| update_bug_fields | bug_id, priority?, severity?, resolution?, custom_fields?: JsonObject, comment = "" | fields (write) | at least one field required; custom_fields keys must start with `cf_` (I7) |
+| update_bug_fields | bug_id, priority?, severity?, resolution?, summary?, url?, whiteboard?, version?, target_milestone?, keywords_add?/keywords_remove?: Vec<String>, see_also_add?/see_also_remove?: Vec<String> (bug URLs), custom_fields?: JsonObject, comment = "" | fields (write) on bug_id + summary on every LOCAL see_also target (I8/I14) | at least one field required — the named params all count, so a call touching only the newer fields is valid, and a call carrying nothing but empty strings/lists still errors without contacting Bugzilla; empty strings and empty lists are ignored (clearing a field is unsupported); keywords and see_also travel as `{"add": [..], "remove": [..]}`, NEVER the replace-all `set` variant; a see_also entry that points at THIS instance is a bug-id link, so its target is assessed like a dependency target — at least `summary`, uniform denial (I2), no PUT on refusal — while entries for other trackers carry no local id and pass through unassessed; custom_fields keys must start with `cf_` (I7) — `see_also` and `keywords` are named params now, and as custom_fields keys they still error before Bugzilla is contacted; free-text values (summary/whiteboard/url) never enter the server log — only which fields a call touched (see "Update-field surface") |
 | update_bug_dependencies | bug_id, blocks_add?/blocks_remove?/depends_on_add?/depends_on_remove?: Vec<u64>, comment = "" | deps (write) | at least one change required; payload uses `{"blocks": {"add": [..], "remove": [..]}}` shape |
 | add_cc_to_bug | bug_id, cc_email | cc (write) | payload `{"cc": {"add": [email]}}` |
 | mark_as_duplicate | bug_id, duplicate_of, comment = "" | status on bug_id + summary on duplicate_of (I11) | default comment "Marking as duplicate of bug {duplicate_of}"; payload status CLOSED, resolution DUPLICATE, dupe_of |
@@ -622,6 +625,87 @@ constraints the model must know.
 | quicksearch_syntax | — | none | HTML doc page |
 | mcp_server_info | — | none | version (CARGO_PKG_VERSION), bugzilla server url, transport, and policy summary per I1 |
 | summarize_bug | id | comments | fetches comments (private filtered with include_private=false), returns the summarization prompt text (fixed prompt template) |
+
+### Update-field surface (issue #38)
+
+The full audit of Bugzilla's `PUT /rest/bug/<id>` parameter surface against
+the guard model. The split is deliberate and permanent record: every REST
+update parameter is either exposed through a named tool/param below or
+withheld for the stated reason — nothing is exposed by accident, and
+nothing may be smuggled through `custom_fields` (I7).
+
+Exposed:
+
+| REST param | tool / param | capability |
+|---|---|---|
+| `priority`, `severity`, `resolution`, `cf_*` | `update_bug_fields` | `fields` |
+| `summary` | `update_bug_fields.summary` | `fields` |
+| `url` | `update_bug_fields.url` | `fields` |
+| `whiteboard` | `update_bug_fields.whiteboard` | `fields` |
+| `version` | `update_bug_fields.version` (product-scoped vocabulary; Bugzilla validates the value) | `fields` |
+| `target_milestone` | `update_bug_fields.target_milestone` (product-scoped vocabulary; Bugzilla validates the value) | `fields` |
+| `keywords` (add/remove) | `update_bug_fields.keywords_add` / `keywords_remove` — parity with `create_bug`, which can already set them; the replace-all `set` variant stays withheld as a footgun | `fields` |
+| `see_also` (add/remove) | `update_bug_fields.see_also_add` / `see_also_remove` (bug URLs) | `fields`, plus at least `summary` on every target the URL resolves to on THIS instance (I8/I14 — the same bar as dependency targets; foreign-tracker entries are unassessed) |
+| `status` + `resolution` | `update_bug_status` | `status` |
+| `dupe_of` | `mark_as_duplicate` | `status` |
+| `assigned_to` | `assign_bug` | `assign` |
+| `cc.add` | `add_cc_to_bug` | `cc` |
+| `blocks` / `depends_on` (add/remove) | `update_bug_dependencies` | `deps` |
+| `comment` | `add_comment`, plus the optional comment on the write tools that take one (update_bug_status, assign_bug, update_bug_fields, update_bug_dependencies, mark_as_duplicate, add_attachment — add_cc_to_bug does not) | `comment` (write tools: their own capability) |
+
+Withheld, deliberately:
+
+| REST param | why |
+|---|---|
+| `product`, `component` | the reclassification levers: they change which guard rules match *and* which Bugzilla groups apply server-side. If ever exposed, that wants its own design (and probably its own capability) — a follow-up issue, not this surface. |
+| `groups` (add/remove) | directly edits the confidentiality boundary the guard exists to respect. |
+| `is_cc_accessible`, `is_creator_accessible`, `comment_is_private` | confidentiality toggles, same reasoning. |
+| `flags` | instance-specific approval workflows with high blast radius; own design if ever needed. |
+| `alias` | global namespace, niche. |
+| `deadline`, `estimated_time`, `remaining_time`, `work_time` | time tracking; no agent use case. |
+| `qa_contact`, `reset_qa_contact`, `reset_assigned_to` | not requested; assignee handling stays with `assign_bug`. |
+| `cc.remove` | not requested; CC handling stays additive via `add_cc_to_bug`. |
+| `op_sys`, `platform` | not requested; trivially addable under `fields` later. |
+| new-comment privacy (`comment.is_private` inside the `comment` object) | already handled (and pinned by tests) by `add_comment`'s `is_private` param; the privacy of EXISTING comments is the `comment_is_private` confidentiality toggle withheld above. |
+| `ids` (batch update) | one bug per call, so the guard verdict stays exactly per-bug. |
+| `keywords`/`see_also` `set` variant | replace-all from a possibly stale view silently wipes concurrent additions. |
+
+On policy relevance: `keywords`, `summary` and `whiteboard` are
+matcher-visible (rules can match on them), so writing them lets a caller
+move a bug along matcher axes. That is not a new property — `severity`,
+`priority` and `status` are matcher-visible and writable today. The bound,
+stated precisely: it takes a `fields` grant on the bug's *current*
+classification to touch it, so a write can never lift a bug out of a
+`deny` — a deny grants nothing, and a denied bug cannot be written at
+all. A `restrict` rule that grants `fields` is NOT bounded this way: if
+its match criteria include a field `fields` can write
+(`summary_contains`, `whiteboard_contains`, `keywords`, `severities`,
+`priorities` — or `statuses` under a `status` grant), the rule is
+self-defeating — one write rewrites the very field the rule matches on,
+classification is never cached, and on the next call the bug falls
+through to a later, more permissive rule or to `default_action`, opening
+the capabilities the rule withheld. Operators must not grant `fields` in
+a restrict rule whose match criteria are fields `fields` can write (the
+warning is restated at the restrict examples in `examples/policy.toml`).
+The opposite direction is reachable too, and one-way: a write CAN move a
+bug INTO a rule that denies it (adding an embargo keyword under the
+example policy, say), and because a denied bug is unwritable, that change
+cannot be reverted through this server — only an operator with direct
+Bugzilla access can undo it. Both directions are the price of `fields`
+under a policy whose rules key on writable fields; grant it accordingly.
+
+Semantics kept deliberately narrow: add/remove only, never replace-all;
+empty strings are ignored, as for the pre-existing params — clearing a
+field (e.g. blanking the whiteboard) stays unsupported until someone needs
+it; one bug per call. The free-text values (`summary`, `whiteboard`,
+`url`) never appear in the server log — only which fields a call touched
+(presence/counts in the tool-entry trace; the audit stream's params
+allowlist records them, and the see_also URL lists, as `_len`).
+`keywords_add`/`keywords_remove` and `target_milestone` are closed
+instance vocabulary — the same class as the already-allowlisted
+`keywords` and `version` — and are audit-recorded by value, so the
+keyword that hid a bug is recoverable from the audit stream no matter
+which tool wrote it.
 
 ## CLI (crates/bugwarden/src/config.rs)
 
@@ -809,7 +893,22 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   grant carrying `attachments` (read) without `attach` (write) and uploads
   on `attach`; the upload size cap refuses before anything is POSTed; the
   attachment `comment` travels as a plain string (Bug.add_attachment
-  API shape), pinned by a wiremock body matcher; and identity end to end —
+  API shape), pinned by a wiremock body matcher; the update-field surface
+  (issue #38) — see_also travels as the `{"add": [..], "remove": [..]}`
+  object with both sides present, keywords travel as add/remove and NEVER
+  as the replace-all `set` (a catch-all PUT mock fails the test if any
+  other body shape reaches Bugzilla), the five scalar fields
+  (summary/url/whiteboard/version/target_milestone) land in one PUT body
+  together with the attached comment, empty strings and empty lists are
+  ignored (an expect(0) trap mock proves the ignored field never reaches
+  the wire), a new-fields-only call against a policy-denied bug takes the
+  uniform denial with zero PUTs, a see_also entry naming a policy-denied
+  bug on THIS instance draws that bug's uniform denial with zero PUTs
+  (I8/I14) while foreign-tracker entries are never assessed (the bug-7-only
+  classify mock's expect(1) proves it), `see_also` inside `custom_fields` still
+  errors on the `cf_` gate (I7) with zero upstream requests, and an
+  all-empty call errors "At least one field must be specified" without
+  contacting Bugzilla; and identity end to end —
   issue #33's exact scenario (a my-own-reports restrict rule above a
   group_restricted deny: with whoami answering the caller, a
   group-restricted bug the caller authored is readable through bug_info

--- a/examples/policy.toml
+++ b/examples/policy.toml
@@ -349,6 +349,22 @@ younger_than_days = 5
 #capabilities = ["summary", "comment"]
 #[rule.match]
 #products = ["Security*"]
+#
+# CAUTION — self-defeating grants: do not grant `fields` (or `status`) in a
+# restrict rule whose match criteria are fields those capabilities can
+# write. `fields` writes summary, whiteboard, keywords, severity and
+# priority; `status` writes the status. A rule matching on
+# summary_contains / whiteboard_contains / keywords / severities /
+# priorities (or statuses, for a `status` grant) while granting the
+# matching capability lets one write rewrite the very field the rule
+# matches on — nothing is cached, so the next call reclassifies the bug
+# past this rule to a later rule or default_action, opening everything the
+# rule withheld. Matching on product/component/groups/created_by_me/age is
+# safe: no capability this server grants can write those. (Deny rules are
+# not affected — a denied bug cannot be written at all. The flip side is
+# permanent: a write CAN add e.g. an embargo keyword and push a bug INTO a
+# deny rule, after which no client of this server — the writer included —
+# can see or revert it; only direct Bugzilla access can.)
 
 # Filing new bugs ("create") and uploading attachments ("attach") are
 # capabilities like any other. A create request has no bug id yet, so the


### PR DESCRIPTION
Closes #38.

Implements the audit posted on the issue: every `PUT /rest/bug` parameter is now either exposed through a named tool param or withheld with its reason recorded in DESIGN.md — the split is a decision, not an accident of tool growth.

## What changed

- **`update_bug_fields` gains** `summary`, `url`, `whiteboard`, `version`, `target_milestone`, `keywords_add`/`keywords_remove`, and `see_also_add`/`see_also_remove` (bug URLs), all under the existing `fields` capability. Add/remove objects are built the way `update_bug_dependencies` builds them; the replace-all `set` variant is unreachable by construction.
- **`see_also` targets are guard-assessed before the PUT**: local-instance URLs are resolved to bug ids (`Guard::see_also_local_id`, the same parser the read paths use for scrubbing) and each target must pass `Capability::Summary` — the I14/I8/I11 bar `update_bug_dependencies` and `mark_as_duplicate` already apply — so a see_also write can neither link into a policy-denied bug (Bugzilla records a reciprocal entry on the target) nor be used as an existence oracle over denied ids (I2). Non-local URLs pass through untouched.
- Empty strings/lists count as absent; the at-least-one-field check counts the new params; the `cf_` gate (I7) is untouched and now pinned by a test proving `see_also` cannot be smuggled through `custom_fields`; one bug per call stays.
- Server log records only presence/counts for the new params (summaries/whiteboards can carry embargoed content); the audit `PARAM_ALLOWLIST` records `keywords_add`/`keywords_remove`/`target_milestone` by value (closed instance vocabulary) while the free-text params stay length-only.
- **DESIGN.md** carries the full exposed/withheld audit table, including the corrected matcher-visibility bound (see below); README, `Capability::Fields` rustdoc, and `examples/policy.toml` updated in step.

## Adversarial review record (pre-PR gate)

Three hostile lenses plus mutation verification against the implementation commit; 8 findings, all addressed, none rebutted:

- **blocking (security)** — *see_also existence oracle*: as implemented first, see_also targets were never assessed, so writing a link probed denied ids through Bugzilla's distinguishable success/no-such-bug/not-authorized responses and wrote reciprocal entries onto denied bugs. Fixed as described above; pinned by `update_fields_see_also_targets_respect_the_guard` (uniform denial, zero PUTs). Since this fix landed after the workflow's mutation pass, I re-verified it by hand: neutering the target extraction makes the pin test fail.
- **blocking (docs)** — the DESIGN.md `comment_is_private` row had been reworded into claiming existing-comment privacy is handled elsewhere (it is not — it is withheld); restored to the plan's new-comment-privacy meaning.
- **important** — the matcher-visibility paragraph claimed "a bug a rule denies cannot be written at all" as the bound, which holds for `deny` (grants nothing) but not for a `restrict` grant that includes `fields` while withholding `read`: such a grant can be escaped in one write along a matched axis. The DESIGN.md record now states the bound precisely, including that a `restrict` rule granting `fields` on a matcher-visible axis is an escape hatch the operator must not build.
- minor ×5, all fixed: `keywords_*`/`target_milestone` added to the audit param allowlist; the irreversibility direction (a write can push a bug *into* a denial that then makes the change unrevertable through this server) recorded in DESIGN.md and the shipped policy's comments; `cc.remove` given its withheld row (completeness claim now true); "comment on every write tool" corrected (add_cc_to_bug takes none); the stale `comment_is_private` rationale resolved with the blocking docs finding.

**Mutation verification: 8/8 killed, no survivors** (each applied singly in a detached worktree, killed by the named test, reverted): keywords-as-`set`, flat see_also array, empty-string passthrough, guard-skip for new-fields-only payloads, remove-side dropped, `cf_` gate weakened, at-least-one-field miscount, comment dropped — plus the manual post-fix mutation above.

Full AGENTS.md gate re-run independently in the isolated worktree: fmt, clippy `-D warnings`, `cargo test --workspace --all-targets --locked` (294 tests), `cargo deny check`, typos — all green. No dependency changes.
