### PR TITLE
feat(audit): populate trace context from params._meta traceparent

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Command-line arguments take precedence over environment variables.
 | `--use-auth-header` | — | `false` | Authenticate to Bugzilla with `Authorization: Bearer <key>` instead of the `api_key` query parameter |
 | `--read-only` | `MCP_READ_ONLY` | `false` | Disable all write tools. Tighten-only: ORed with the policy's `global.read_only`; cannot re-enable writes a policy forbids |
 | `--policy <PATH>` | `BUGWARDEN_POLICY` | — | Path to the guard policy TOML. Without it, an allow-all policy applies (with private comments off) |
-| `--audit-config <PATH>` | `BUGWARDEN_AUDIT_CONFIG` | — | Path to the audit stream configuration TOML (worked example in [`examples/audit.toml`](examples/audit.toml)). Without it, no audit stream is written |
+| `--audit-config <PATH>` | `BUGWARDEN_AUDIT_CONFIG` | — | Path to the audit stream configuration TOML (worked example in [`examples/audit.toml`](examples/audit.toml)). Without it, no audit stream is written. Records carry W3C trace ids when the client sends a `traceparent` in the request's `_meta`, enabling correlation with client-side traces |
 
 ## Policy file reference
 

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -381,6 +381,69 @@ pub struct TraceContext {
     pub span_id: String,
 }
 
+impl TraceContext {
+    /// Parse a W3C `traceparent` header value (version 00 only) into
+    /// trace ids.
+    ///
+    /// Strict by design: anything not exactly
+    /// `00-<32 lowercase hex>-<16 lowercase hex>-<2 lowercase hex>`
+    /// (55 bytes) with non-zero trace and span ids is `None`. In
+    /// particular:
+    ///
+    /// - The length check comes FIRST, on bytes — a cheap rejection of
+    ///   oversized input, and no later step slices a string, so
+    ///   multibyte unicode can never panic the parser.
+    /// - The version must be exactly `00`. That rejects `ff` (forbidden
+    ///   by W3C) AND every future version: W3C allows lenient forward
+    ///   parsing, but this parser refuses to store ids from a format
+    ///   revision it cannot fully validate.
+    /// - Hex means ASCII lowercase `[0-9a-f]` only; uppercase is invalid
+    ///   per W3C.
+    /// - An all-zero trace id or span id is invalid per W3C.
+    /// - The flags byte pair is validated as hex but not stored — the
+    ///   schema has no field for it.
+    ///
+    /// The input is client-controlled bytes headed for operator logs, so
+    /// it is never logged here, valid or not: rejection is silent
+    /// (I12-adjacent hygiene).
+    pub(crate) fn from_traceparent(value: &str) -> Option<TraceContext> {
+        fn lower_hex(bytes: &[u8]) -> bool {
+            bytes
+                .iter()
+                .all(|b| b.is_ascii_digit() || matches!(b, b'a'..=b'f'))
+        }
+        let bytes = value.as_bytes();
+        if bytes.len() != 55 {
+            return None;
+        }
+        // Fixed layout: bytes 0-1 version, byte 2 `-`, bytes 3-34
+        // trace-id, byte 35 `-`, bytes 36-51 span-id, byte 52 `-`,
+        // bytes 53-54 flags.
+        if &bytes[0..2] != b"00" {
+            return None;
+        }
+        if bytes[2] != b'-' || bytes[35] != b'-' || bytes[52] != b'-' {
+            return None;
+        }
+        let trace_id = &bytes[3..35];
+        let span_id = &bytes[36..52];
+        let flags = &bytes[53..55];
+        if !lower_hex(trace_id) || !lower_hex(span_id) || !lower_hex(flags) {
+            return None;
+        }
+        if trace_id.iter().all(|&b| b == b'0') || span_id.iter().all(|&b| b == b'0') {
+            return None;
+        }
+        // Both ranges are validated ASCII hex, so the conversions cannot
+        // fail; going through `from_utf8` keeps the parser panic-free by
+        // construction.
+        Some(TraceContext {
+            trace_id: std::str::from_utf8(trace_id).ok()?.to_owned(),
+            span_id: std::str::from_utf8(span_id).ok()?.to_owned(),
+        })
+    }
+}
+
 /// The request as the client made it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1317,6 +1380,146 @@ mod tests {
             let back: AuditEvent = serde_json::from_str(&s).unwrap();
             assert_eq!(back, event);
         }
+    }
+
+    // ---------- traceparent parsing ----------
+
+    /// The canonical W3C example, 55 bytes; the ids are the same as the
+    /// golden serialization fixture's.
+    const CANONICAL_TRACEPARENT: &str = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+    #[test]
+    fn traceparent_canonical_value_parses_into_its_ids() {
+        let trace = TraceContext::from_traceparent(CANONICAL_TRACEPARENT)
+            .expect("the canonical W3C example must parse");
+        assert_eq!(trace.trace_id, "0af7651916cd43dd8448eb211c80319c");
+        assert_eq!(trace.span_id, "b7ad6b7169203331");
+    }
+
+    #[test]
+    fn traceparent_flags_00_parses_and_flags_are_not_stored() {
+        // The flags value is irrelevant (validated as hex, never stored):
+        // an unsampled request correlates the same as a sampled one.
+        let unsampled = CANONICAL_TRACEPARENT.replace("-01", "-00");
+        let trace = TraceContext::from_traceparent(&unsampled).expect("flags 00 must parse");
+        assert_eq!(trace.trace_id, "0af7651916cd43dd8448eb211c80319c");
+        assert_eq!(trace.span_id, "b7ad6b7169203331");
+    }
+
+    #[test]
+    fn traceparent_rejects_wrong_lengths() {
+        assert_eq!(TraceContext::from_traceparent(""), None);
+        // 54 bytes: the canonical value minus its last byte.
+        let short = &CANONICAL_TRACEPARENT[..54];
+        assert_eq!(TraceContext::from_traceparent(short), None);
+        // 56 bytes: the canonical value plus one hex byte. A truncating
+        // `>= 55` length check would parse this — the exact-length check
+        // must not.
+        let long = format!("{CANONICAL_TRACEPARENT}0");
+        assert_eq!(TraceContext::from_traceparent(&long), None);
+        // Oversized input is rejected on length alone (~1 MiB).
+        let huge = "a".repeat(1 << 20);
+        assert_eq!(TraceContext::from_traceparent(&huge), None);
+    }
+
+    #[test]
+    fn traceparent_rejects_uppercase_hex() {
+        // Uppercase in the trace-id: invalid per W3C.
+        let upper_trace = "00-0AF7651916CD43DD8448EB211C80319C-b7ad6b7169203331-01";
+        assert_eq!(TraceContext::from_traceparent(upper_trace), None);
+        // Uppercase in the span-id.
+        let upper_span = "00-0af7651916cd43dd8448eb211c80319c-B7AD6B7169203331-01";
+        assert_eq!(TraceContext::from_traceparent(upper_span), None);
+        // Uppercase hex in the version position.
+        let upper_version = "0A-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        assert_eq!(TraceContext::from_traceparent(upper_version), None);
+    }
+
+    #[test]
+    fn traceparent_rejects_versions_other_than_00() {
+        // `ff` is forbidden by W3C.
+        let ff = "ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        assert_eq!(TraceContext::from_traceparent(ff), None);
+        // A future version is rejected even when it happens to be 55
+        // bytes of version-00 shape: strict, no forward parsing.
+        let v01 = "01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        assert_eq!(TraceContext::from_traceparent(v01), None);
+        // The forward-format case W3C would allow lenient parsers to
+        // accept: a future version with trailing data. Deliberately None.
+        let forward = "01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-extra";
+        assert_eq!(TraceContext::from_traceparent(forward), None);
+    }
+
+    #[test]
+    fn traceparent_rejects_all_zero_ids() {
+        let zero_trace = "00-00000000000000000000000000000000-b7ad6b7169203331-01";
+        assert_eq!(TraceContext::from_traceparent(zero_trace), None);
+        let zero_span = "00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01";
+        assert_eq!(TraceContext::from_traceparent(zero_span), None);
+    }
+
+    #[test]
+    fn traceparent_rejects_non_hex_in_every_field() {
+        for bad in [
+            // `g` in the version, trace-id, span-id, and flags.
+            "g0-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            "00-gaf7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            "00-0af7651916cd43dd8448eb211c80319c-g7ad6b7169203331-01",
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-g1",
+            // A space in each field.
+            " 0-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            "00- af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            "00-0af7651916cd43dd8448eb211c80319c- 7ad6b7169203331-01",
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331- 1",
+        ] {
+            assert_eq!(
+                TraceContext::from_traceparent(bad),
+                None,
+                "must reject {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn traceparent_rejects_misplaced_separators() {
+        // Still 55 bytes each, but a `-` is off its fixed position.
+        for bad in [
+            // The trace-id/span-id separator shifted right by one.
+            "00-0af7651916cd43dd8448eb211c80319cb-7ad6b7169203331-01",
+            // The version separator replaced (two ids run together).
+            "0000af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            // The flags separator replaced by a hex byte.
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331001",
+        ] {
+            assert_eq!(bad.len(), 55, "fixture must stay 55 bytes");
+            assert_eq!(
+                TraceContext::from_traceparent(bad),
+                None,
+                "must reject {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn traceparent_rejects_surrounding_whitespace() {
+        // No trimming anywhere: whitespace is rejected, either by the
+        // hex/layout checks (55 bytes) or by the length check (56).
+        let lead_55 = format!(" {}", &CANONICAL_TRACEPARENT[..54]);
+        assert_eq!(TraceContext::from_traceparent(&lead_55), None);
+        let lead_56 = format!(" {CANONICAL_TRACEPARENT}");
+        assert_eq!(TraceContext::from_traceparent(&lead_56), None);
+        let trail_56 = format!("{CANONICAL_TRACEPARENT}\n");
+        assert_eq!(TraceContext::from_traceparent(&trail_56), None);
+    }
+
+    #[test]
+    fn traceparent_multibyte_unicode_returns_none_without_panicking() {
+        // 53 ASCII bytes of the canonical value plus one 2-byte char:
+        // exactly 55 bytes, so it passes the length check and must fall
+        // out of the layout checks — never panic.
+        let multibyte = format!("{}\u{e9}", &CANONICAL_TRACEPARENT[..53]);
+        assert_eq!(multibyte.len(), 55, "fixture must be 55 bytes");
+        assert_eq!(TraceContext::from_traceparent(&multibyte), None);
     }
 
     #[test]

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -2476,6 +2476,25 @@ impl ServerHandler for BugWarden {
         // avoids cloning free-text and blob values that would be reduced
         // to a byte length anyway.
         let params = allowlisted(request.arguments.as_ref());
+        // Trace enrichment (issue #28), extracted BEFORE the router
+        // consumes `request`. The rmcp 2.2 trap: over every serialized
+        // transport the wire `params._meta` (SEP-414) does NOT arrive in
+        // `CallToolRequestParams.meta` — the SDK's custom `Request`
+        // deserializer strips `_meta` out of the params before the
+        // params struct sees it, parks it in the request extensions, and
+        // the serve loop hands it to the handler as `context.meta`. The
+        // params-struct field is populated only by in-process callers
+        // that never serialize. Read both, params struct first, so the
+        // value is found wherever the SDK put it. Strictly validated,
+        // fail-to-absent, never logged; the value enriches the record
+        // only — it must never influence the guard, the refusal
+        // decision, or the response (I15).
+        let trace = request
+            .meta
+            .as_ref()
+            .and_then(|m| m.get_traceparent())
+            .or_else(|| context.meta.get_traceparent())
+            .and_then(audit::TraceContext::from_traceparent);
 
         // Pre-dispatch gate: a sink already in failure holds back further
         // unaudited work, scoped by the fail mode. The refusal is
@@ -2486,7 +2505,7 @@ impl ServerHandler for BugWarden {
         if audit.sink.failing() && gate_applies(audit.fail_mode, &tool) {
             let event = audit::AuditEventKind::ToolCall(Box::new(audit::ToolCallEvent {
                 client,
-                trace: None,
+                trace: trace.clone(),
                 request: audit::RequestInfo {
                     tool: tool.clone(),
                     id: request_id,
@@ -2535,7 +2554,7 @@ impl ServerHandler for BugWarden {
         };
         let event = audit::AuditEventKind::ToolCall(Box::new(audit::ToolCallEvent {
             client,
-            trace: None,
+            trace,
             request: audit::RequestInfo {
                 tool: tool.clone(),
                 id: request_id,
@@ -3503,5 +3522,262 @@ mod tests {
                 .any(|e| matches!(e.kind, AuditEventKind::AuditGap(_))),
             "a gap marker must follow recovery"
         );
+    }
+
+    // ---------- trace enrichment (issue #28) ----------
+
+    /// The canonical W3C `traceparent` example; its ids.
+    const TRACEPARENT: &str = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+    const TRACE_ID: &str = "0af7651916cd43dd8448eb211c80319c";
+    const SPAN_ID: &str = "b7ad6b7169203331";
+
+    /// Like [`call`], but with `traceparent` in the request's `_meta`.
+    /// The duplex transport serde-roundtrips the bytes, so this exercises
+    /// the wire `params._meta` shape, not an in-process shortcut.
+    async fn call_with_traceparent(
+        client: &RunningService<RoleClient, ()>,
+        tool: &str,
+        args: Value,
+        traceparent: &str,
+    ) -> CallToolResult {
+        let Value::Object(args) = args else {
+            panic!("tool arguments must be a JSON object");
+        };
+        let mut params = CallToolRequestParams::new(tool.to_string()).with_arguments(args);
+        let mut meta = rmcp::model::Meta::new();
+        meta.set_traceparent(traceparent);
+        params.meta = Some(meta);
+        client
+            .call_tool(params)
+            .await
+            .expect("tool call must not be a protocol error")
+    }
+
+    /// The `tool_call` payloads of `events`, in file order.
+    fn tool_calls(events: &[AuditEvent]) -> Vec<&audit::ToolCallEvent> {
+        events
+            .iter()
+            .filter_map(|e| match &e.kind {
+                AuditEventKind::ToolCall(ev) => Some(ev.as_ref()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn assert_trace_is_canonical(trace: Option<&audit::TraceContext>) {
+        let trace = trace.expect("the record must carry the sent trace ids");
+        assert_eq!(trace.trace_id, TRACE_ID);
+        assert_eq!(trace.span_id, SPAN_ID);
+    }
+
+    #[tokio::test]
+    async fn traceparent_in_meta_lands_in_the_tool_record() {
+        let mock = MockServer::start().await;
+        mount_bug7(&mock).await;
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
+        let client = mcp_client("", &mock.uri(), Some(audit)).await;
+
+        let plain = call(&client, "bug_history", json!({ "id": 7 })).await;
+        let traced =
+            call_with_traceparent(&client, "bug_history", json!({ "id": 7 }), TRACEPARENT).await;
+        // Record enrichment only (I15): the response must not change.
+        assert_eq!(
+            serde_json::to_string(&plain).unwrap(),
+            serde_json::to_string(&traced).unwrap(),
+            "a traceparent must not change the response"
+        );
+
+        let events = read_audit_events(&audit_path);
+        let calls = tool_calls(&events);
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].trace, None, "no meta means no trace field");
+        assert_trace_is_canonical(calls[1].trace.as_ref());
+    }
+
+    #[tokio::test]
+    async fn malformed_traceparent_leaves_the_record_without_trace() {
+        let mock = MockServer::start().await;
+        mount_bug7(&mock).await;
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
+        let client = mcp_client("", &mock.uri(), Some(audit)).await;
+
+        let plain = call(&client, "bug_history", json!({ "id": 7 })).await;
+        // Uppercase hex is invalid per W3C; the strict parser records
+        // nothing rather than a value it could not fully validate.
+        let upper = "00-0AF7651916CD43DD8448EB211C80319C-B7AD6B7169203331-01";
+        let traced = call_with_traceparent(&client, "bug_history", json!({ "id": 7 }), upper).await;
+        assert_eq!(
+            serde_json::to_string(&plain).unwrap(),
+            serde_json::to_string(&traced).unwrap(),
+            "a malformed traceparent must not change the response"
+        );
+
+        // Absent means absent bytes: no serialized line carries a trace
+        // key at all — and none echoes the rejected value anywhere.
+        let raw = std::fs::read_to_string(&audit_path).expect("audit file must be readable");
+        assert!(
+            !raw.contains("\"trace\""),
+            "a malformed traceparent must leave no trace field: {raw}"
+        );
+        assert!(
+            !raw.contains("0AF76519"),
+            "the rejected value must never reach the file: {raw}"
+        );
+        assert_eq!(tool_calls(&read_audit_events(&audit_path)).len(), 2);
+    }
+
+    #[tokio::test]
+    async fn traceparent_on_a_denied_call_enriches_but_never_influences() {
+        // Correlation matters most on denials — and the trace ids must
+        // never leak into the denial itself.
+        let policy = concat!(
+            "[[rule]]\nname = \"hide-secret\"\naction = \"deny\"\n",
+            "[rule.match]\nproducts = [\"Secret*\"]\n",
+        );
+        let mock = MockServer::start().await;
+        mount_bug7(&mock).await;
+        let mut secret = world_bug(99);
+        secret["product"] = json!("SecretSauce");
+        Mock::given(method("GET"))
+            .and(path("/rest/bug"))
+            .and(query_param("id", "99"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [secret] })))
+            .mount(&mock)
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
+        let client = mcp_client(policy, &mock.uri(), Some(audit)).await;
+
+        let denied =
+            call_with_traceparent(&client, "bug_comments", json!({ "id": 99 }), TRACEPARENT).await;
+        assert!(is_error(&denied), "the hidden bug must be denied");
+        assert_eq!(
+            text_of(&denied),
+            "Bug 99 is not accessible through this server",
+            "the denial must be the uniform text (I2), traceparent or not"
+        );
+
+        let calls_events = read_audit_events(&audit_path);
+        let calls = tool_calls(&calls_events);
+        assert_eq!(calls.len(), 1);
+        let guard = calls[0].guard.as_ref().expect("a denial has a guard");
+        assert_eq!(guard.verdict, Verdict::Denied);
+        assert_trace_is_canonical(calls[0].trace.as_ref());
+    }
+
+    #[tokio::test]
+    async fn failing_sink_gate_record_carries_the_trace() {
+        // The pre-dispatch fail-closed gate builds its own record; it
+        // must carry the trace too, not only the post-dispatch site.
+        let mock = MockServer::start().await;
+        mount_bug7(&mock).await;
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::ClosedAll);
+        let client = mcp_client("", &mock.uri(), Some(Arc::clone(&audit))).await;
+
+        // Discover the outage on the response path, then lift the
+        // injected fault: the sink still counts as failing (records were
+        // dropped), so the next call takes the pre-dispatch gate — and
+        // its best-effort record now persists.
+        audit.sink.set_fail_writes(true);
+        let discovered = call(&client, "bug_history", json!({ "id": 7 })).await;
+        assert!(is_error(&discovered));
+        audit.sink.set_fail_writes(false);
+        let before_gated = mock.received_requests().await.unwrap().len();
+
+        let gated =
+            call_with_traceparent(&client, "bug_history", json!({ "id": 7 }), TRACEPARENT).await;
+        assert!(is_error(&gated));
+        assert_eq!(text_of(&gated), "Failed to fetch bug history");
+        assert_eq!(
+            mock.received_requests().await.unwrap().len(),
+            before_gated,
+            "the gated call must not contact upstream"
+        );
+
+        let events = read_audit_events(&audit_path);
+        let calls = tool_calls(&events);
+        assert_eq!(calls.len(), 1, "only the gate record reached the file");
+        let guard = calls[0].guard.as_ref().expect("the gate records a guard");
+        assert_eq!(guard.verdict, Verdict::Refused);
+        assert_trace_is_canonical(calls[0].trace.as_ref());
+    }
+
+    #[tokio::test]
+    async fn in_process_params_meta_traceparent_enriches_the_record() {
+        // The params-struct arm of the trace extraction (`request.meta`,
+        // consulted before the `context.meta` fallback) is reachable ONLY
+        // by an in-process caller: over every serialized transport rmcp
+        // strips the wire `_meta` into the request extensions before the
+        // params struct is built, so `CallToolRequestParams.meta` is
+        // always `None` there and the duplex and streamable-http tests
+        // all pin the `context.meta` fallback instead. This test invokes
+        // `ServerHandler::call_tool` directly, with the traceparent in
+        // the params-struct meta and a hand-built `RequestContext` whose
+        // meta is empty — killing a mutant that reads only `context.meta`
+        // (behavior-preserving over every serialized transport, so no
+        // other test can).
+        use clap::Parser as _;
+        let mock = MockServer::start().await;
+        mount_bug7(&mock).await;
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
+
+        let mut cli = Cli::parse_from([
+            "bugwarden",
+            "--bugzilla-server",
+            &mock.uri(),
+            "--transport",
+            "stdio",
+            "--api-key",
+            "test-key",
+        ]);
+        cli.api_key_file = None;
+        let guard = Arc::new(Guard {
+            policy: Policy::from_toml_str("").expect("test policy must parse"),
+        });
+        let bz = Arc::new(BugzillaClient::new(&mock.uri(), false).expect("client must build"));
+        let server = BugWarden::new(Arc::new(cli), guard, bz)
+            .expect("server must build")
+            .with_audit(Arc::clone(&audit));
+
+        // A genuine `Peer<RoleServer>` for the hand-built context, minted
+        // by serving a clone over a duplex (the SDK exposes no other
+        // constructor); no tool call flows through that session, so the
+        // direct call below writes the only tool_call record.
+        let (client_io, server_io) = tokio::io::duplex(1 << 16);
+        let serving = server.clone();
+        let server_task = tokio::spawn(async move { serving.serve(server_io).await });
+        let _client = ().serve(client_io).await.expect("MCP handshake must succeed");
+        let running = server_task
+            .await
+            .expect("serve task must not panic")
+            .expect("server must serve");
+        let peer = running.peer().clone();
+
+        let Value::Object(args) = json!({ "id": 7 }) else {
+            panic!("tool arguments must be a JSON object");
+        };
+        let mut params = CallToolRequestParams::new("bug_history".to_string()).with_arguments(args);
+        let mut meta = rmcp::model::Meta::new();
+        meta.set_traceparent(TRACEPARENT);
+        params.meta = Some(meta);
+        let context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer);
+        assert!(
+            context.meta.get_traceparent().is_none(),
+            "the hand-built context must carry no meta — the params struct is the only source"
+        );
+
+        let result = ServerHandler::call_tool(&server, params, context)
+            .await
+            .expect("the in-process call must not be a protocol error");
+        assert!(!is_error(&result), "bug_history must succeed");
+
+        let events = read_audit_events(&audit_path);
+        let calls = tool_calls(&events);
+        assert_eq!(calls.len(), 1, "exactly the direct call is recorded");
+        assert_trace_is_canonical(calls[0].trace.as_ref());
     }
 }

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -13,12 +13,21 @@
 //! - `api_key()` re-reading the key file per request instead of once at
 //!   startup;
 //! - server-held mode rejecting requests that carry the header;
-//! - dropping the trim of the key file's content.
+//! - dropping the trim of the key file's content;
+//! - audit trace enrichment reading only the params-struct
+//!   `CallToolRequestParams.meta` — always `None` over a serialized
+//!   transport, because rmcp strips the wire `_meta` into the request
+//!   extensions and hands it to the handler as `RequestContext.meta` —
+//!   instead of falling back to `context.meta` (the inverse mutant,
+//!   reading only `context.meta`, is behavior-preserving over every
+//!   serialized transport and is killed by the direct in-process call
+//!   test in server.rs instead).
 
 use std::io::Write as _;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use bugwarden::audit::{AuditConfig, AuditEvent, AuditEventKind, AuditSink, AuditState, FailMode};
 use bugwarden::config::Cli;
 use bugwarden::server::BugWarden;
 use bugwarden_core::client::BugzillaClient;
@@ -57,13 +66,22 @@ fn http_cli(mock: &MockServer, key_file: Option<&std::path::Path>) -> Arc<Cli> {
 }
 
 /// Serve a [`BugWarden`] built from `cli` and `policy` over a real TCP
-/// listener; returns the bound address.
-async fn serve_http(cli: Arc<Cli>, policy: &str, mock: &MockServer) -> SocketAddr {
+/// listener, with the audit sink wired in when a test needs the record
+/// stream; returns the bound address.
+async fn serve_http(
+    cli: Arc<Cli>,
+    policy: &str,
+    mock: &MockServer,
+    audit: Option<Arc<AuditState>>,
+) -> SocketAddr {
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(policy).expect("test policy must parse"),
     });
     let bz = Arc::new(BugzillaClient::new(&mock.uri(), false).expect("client must build"));
-    let server = BugWarden::new(cli, guard, bz).expect("server must build");
+    let mut server = BugWarden::new(cli, guard, bz).expect("server must build");
+    if let Some(audit) = audit {
+        server = server.with_audit(audit);
+    }
 
     let service = StreamableHttpService::new(
         move || Ok(server.clone()),
@@ -208,7 +226,7 @@ async fn server_held_serves_clients_with_no_credential() {
 
     let file = key_file("srv-key\n");
     let cli = http_cli(&mock, Some(file.path()));
-    let addr = serve_http(cli, "", &mock).await;
+    let addr = serve_http(cli, "", &mock, None).await;
     let client = connect(addr, None).await;
 
     assert_bug_7_served(&client).await;
@@ -227,7 +245,7 @@ async fn server_held_never_reads_the_client_header() {
 
     let file = key_file("srv-key");
     let cli = http_cli(&mock, Some(file.path()));
-    let addr = serve_http(cli, "", &mock).await;
+    let addr = serve_http(cli, "", &mock, None).await;
     let client = connect(addr, Some("attacker-key")).await;
 
     assert_bug_7_served(&client).await;
@@ -241,7 +259,7 @@ async fn per_request_header_still_authenticates_over_http() {
     mount_bug_for_key(&mock, world_readable_bug(7), "client-key").await;
 
     let cli = http_cli(&mock, None);
-    let addr = serve_http(cli, "", &mock).await;
+    let addr = serve_http(cli, "", &mock, None).await;
     let client = connect(addr, Some("client-key")).await;
 
     assert_bug_7_served(&client).await;
@@ -260,7 +278,7 @@ async fn per_request_missing_header_is_a_protocol_error() {
         .await;
 
     let cli = http_cli(&mock, None);
-    let addr = serve_http(cli, "", &mock).await;
+    let addr = serve_http(cli, "", &mock, None).await;
     let client = connect(addr, None).await;
 
     let err = try_call(&client, "bug_info", json!({ "bug_ids": [7] }))
@@ -285,7 +303,7 @@ async fn server_held_key_is_resolved_once_at_startup() {
 
     let file = key_file("srv-key\n");
     let cli = http_cli(&mock, Some(file.path()));
-    let addr = serve_http(cli, "", &mock).await;
+    let addr = serve_http(cli, "", &mock, None).await;
     let client = connect(addr, None).await;
 
     assert_bug_7_served(&client).await;
@@ -326,6 +344,7 @@ async fn guard_denies_uniformly_over_http() {
             "[rule.match]\nproducts = [\"Secret*\"]\n",
         ),
         &mock,
+        None,
     )
     .await;
     let client = connect(addr, None).await;
@@ -343,4 +362,81 @@ async fn guard_denies_uniformly_over_http() {
         "Bug 7 is not accessible through this server",
         "the denial must be the uniform text (I2)"
     );
+}
+
+#[tokio::test]
+async fn traceparent_over_http_lands_in_the_audit_record() {
+    // End-to-end over REAL streamable http: the client's `params._meta`
+    // traceparent survives serialization, transport, and deserialization
+    // into the audit record. Over every real transport the SDK strips the
+    // wire `_meta` out of the params before the params struct is built —
+    // `CallToolRequestParams.meta` arrives `None` here — and delivers it
+    // to the handler as the extensions-backed `RequestContext.meta`, so
+    // this test pins the `context.meta` fallback that every serialized
+    // transport depends on (see the rmcp 2.2 usage notes in DESIGN.md).
+    let mock = MockServer::start().await;
+    mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
+
+    let dir = tempfile::tempdir().expect("audit temp dir");
+    let audit_path = dir.path().join("audit.jsonl");
+    let sink = AuditSink::open(AuditConfig {
+        path: audit_path.clone(),
+        fsync: false,
+        fail_mode: None,
+        rotate_max_bytes: 0,
+        rotate_keep: 8,
+        suppressed_ids: true,
+    })
+    .expect("audit sink must open");
+    let audit = Arc::new(AuditState::new(sink, FailMode::Open, None));
+
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock, Some(audit)).await;
+    let client = connect(addr, None).await;
+
+    let plain = try_call(&client, "bug_info", json!({ "bug_ids": [7] }))
+        .await
+        .expect("bug_info must not be a protocol error");
+    let traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+    let Value::Object(args) = json!({ "bug_ids": [7] }) else {
+        panic!("tool arguments must be a JSON object");
+    };
+    let mut params = CallToolRequestParams::new("bug_info".to_string()).with_arguments(args);
+    let mut meta = rmcp::model::Meta::new();
+    meta.set_traceparent(traceparent);
+    params.meta = Some(meta);
+    let traced = client
+        .call_tool(params)
+        .await
+        .expect("a traced bug_info must not be a protocol error");
+
+    // Record enrichment only: the served response is unaffected.
+    assert_eq!(
+        serde_json::to_string(&plain).expect("serialize"),
+        serde_json::to_string(&traced).expect("serialize"),
+        "a traceparent must not change the response over http"
+    );
+
+    let raw = std::fs::read_to_string(&audit_path).expect("audit file must be readable");
+    let events: Vec<AuditEvent> = raw
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str(l).expect("every audit line must parse"))
+        .collect();
+    let calls: Vec<_> = events
+        .iter()
+        .filter_map(|e| match &e.kind {
+            AuditEventKind::ToolCall(ev) => Some(ev.as_ref()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(calls.len(), 2, "both calls must be recorded");
+    assert_eq!(calls[0].trace, None, "no meta means no trace field");
+    let trace = calls[1]
+        .trace
+        .as_ref()
+        .expect("the traced call's record must carry the sent ids");
+    assert_eq!(trace.trace_id, "0af7651916cd43dd8448eb211c80319c");
+    assert_eq!(trace.span_id, "b7ad6b7169203331");
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -831,6 +831,27 @@ Decisions, all deliberate:
   anchored by `<pid>-<startup epoch>`; http sessions by the
   `mcp-session-id` header, with the remote address when the listener
   provides connect-info.
+- **Trace enrichment (issue #28).** When a tool call's `params._meta`
+  carries a `traceparent` (SEP-414), its trace and span ids are copied
+  into the record's `trace` field — the pre-dispatch fail-closed gate
+  record included. Validation is strict: exactly the W3C version-00
+  layout (55 bytes, `00-<32 lowercase hex>-<16 lowercase hex>-<2
+  lowercase hex>`) with non-zero trace and span ids; `ff` and every
+  future version are rejected (no lenient forward parsing — ids from a
+  format revision the parser cannot fully validate are not stored), and
+  anything malformed records nothing rather than something wrong. The
+  value is client-controlled bytes headed for operator logs, so it is
+  never logged anywhere, valid or not, and it never influences a guard
+  decision or a response (I15) — enrichment is unconditional when
+  auditing is on, with no configuration knob. The stored ids are
+  unauthenticated client claims: any client can stamp any call with any
+  well-formed ids — its own probes with an innocent service's ids, or
+  unrelated calls with an id an operator is pivoting on — so they are
+  correlation hints, never evidence; attribution rests on the record's
+  session and client anchoring, not on `trace`. `tracestate` and `baggage`
+  are deliberately not stored: the schema has no field for either,
+  `tracestate` is client free text, and `baggage` is unbounded client
+  key/values — revisit under #34.
 
 ## rmcp 2.2 usage notes
 
@@ -850,6 +871,22 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   create_bug, add_attachment.
 - API key resolution: a match on `key_custody` (resolved once at startup, see Key custody — never re-read per request): `Server(key)` => the server's key, without touching the request at all; `PerRequest` => `ctx.extensions.get::<axum::http::request::Parts>()`, then `parts.headers.get(lowercased_header_name)`.
 - HTTP serving: `StreamableHttpService::new(move || Ok(server.clone()), LocalSessionManager::default().into(), StreamableHttpServerConfig::default())`, `axum::Router::new().nest_service("/mcp", service)`, `tokio::net::TcpListener::bind`, graceful shutdown on ctrl_c.
+- Request `_meta` (SEP-414, e.g. `traceparent`): over every serialized
+  transport the wire `params._meta` does NOT arrive in the params struct
+  (`CallToolRequestParams.meta` stays `None`) — the SDK's custom
+  `Deserialize for Request` (model/serde_impl.rs) strips `_meta` out of
+  the params into the request's extensions typemap, and the serve loop
+  (service.rs) moves that into `RequestContext.meta`. So read
+  `context.meta`; the params-struct `meta` field is populated only by
+  in-process callers that never serialize (`call_tool` consults it
+  first, then falls back to `context.meta`). Reading only the params
+  field compiles fine and is silently empty over every real transport —
+  pinned by the streamable-http traceparent test. The inverse mutant
+  (reading only `context.meta`) is behavior-preserving over every
+  serialized transport, so no transport-level test can kill it; the
+  params-struct arm is pinned by a direct in-process
+  `ServerHandler::call_tool` test with a hand-built `RequestContext`
+  (the only caller shape that populates the field).
 - Tracing to stderr always (stdout belongs to the stdio transport).
 
 ## Testing
@@ -1015,9 +1052,13 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   still authenticates with the client's header; a missing header in
   per-request mode is a protocol-level invalid_request costing zero
   upstream requests; the key is resolved once at startup (rewriting the key
-  file mid-flight changes nothing — the old key keeps serving); and the
+  file mid-flight changes nothing — the old key keeps serving); the
   guard's uniform denial text is byte-identical over http (I2 transport
-  parity).
+  parity); and a `params._meta` traceparent sent over real streamable
+  http lands its ids in the audit record with the response unchanged —
+  the end-to-end proof that the wire `_meta` is read from where the SDK
+  delivers it (`RequestContext.meta`), not from the params-struct field
+  that stays empty over serialized transports.
 - Audit tests (crates/bugwarden/tests/audit_wiremock.rs + #[cfg(test)] in
   server.rs and audit.rs): one record per call for EVERY routed tool,
   refusal paths and protocol errors included; the refusal map is total
@@ -1027,6 +1068,23 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   fail-closed scopes (pre-dispatch gate proven by upstream request
   counts) via the sink's cfg(test) fault injection; the transport-derived
   fail-mode defaults bound to their documented wording; the params
-  allowlist (free text to `_len`, 1024-char truncation).
+  allowlist (free text to `_len`, 1024-char truncation); and trace
+  enrichment (issue #28) — the strict traceparent parser (the canonical
+  W3C value and its flags-00 variant parse into their ids; empty,
+  54-byte, 56-byte, and ~1 MiB values, uppercase hex, versions other
+  than `00` including `ff` and the W3C forward-format, all-zero trace
+  or span ids, non-hex bytes and spaces in every field, misplaced
+  separators, surrounding whitespace, and a 55-byte multibyte-unicode
+  value are all `None`, without panicking), a well-formed traceparent
+  in `_meta` lands its ids in the tool record over the duplex transport
+  with the response byte-identical to the meta-less call, a malformed
+  one leaves the record without any `trace` bytes (and the rejected
+  value never reaches the file), a guard-denied call keeps the uniform
+  denial text while its record carries verdict and ids, the
+  failing-sink pre-dispatch gate record carries the ids too, and a
+  direct in-process `ServerHandler::call_tool` invocation with the
+  traceparent in the params-struct meta and an empty `context.meta`
+  pins the `CallToolRequestParams.meta` arm that no serialized
+  transport can exercise.
 - CI: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
   `cargo test --workspace --locked`, `cargo deny check`.


### PR DESCRIPTION
Closes #28.

The audit schema's `trace` field (`trace_id` + `span_id`) existed since 0.2.0 with nothing populating it. This wires it up: a `traceparent` sent in a tool call's `params._meta` (SEP-414) is validated and its ids copied into the call's record — at both record sites, the pre-dispatch fail-closed gate included. Record enrichment only (I15): the value never influences the guard, the refusal decision, or the response, and responses are asserted byte-identical with and without it, over the duplex transport and over real streamable http.

## What ships

- **`TraceContext::from_traceparent`** (`audit.rs`) — strict by design: exactly the W3C version-00 layout, 55 bytes checked first on bytes (oversized or multibyte-unicode input is rejected before anything slices), lowercase hex only, non-zero trace and span ids, flags validated but not stored. `ff` and every future version are refused — no lenient forward parsing; ids from a format revision the parser cannot fully validate are not stored. Malformed records nothing rather than something wrong, and the client-controlled value is never logged, valid or not.
- **`call_tool` wiring** (`server.rs`) — one extraction before dispatch, used by both `ToolCallEvent` sites.
- **Docs** — DESIGN.md audit-stream bullet (including that stored ids are *unauthenticated client claims* — correlation hints, never evidence; attribution rests on session/client anchoring), an rmcp usage note on the `_meta` delivery path (below), extended testing bars; a README sentence on the `--audit-config` row.
- **Deliberate skips**, documented: `tracestate` (schema has no field; client free text) and `baggage` (unbounded client key/values) — revisit under #34. No schema change, no new dependencies, no config knob: enrichment is unconditional while auditing is on.

## The rmcp 2.2 `_meta` delivery path (the round's load-bearing fact)

Over every serialized transport the wire `params._meta` does **not** arrive in `CallToolRequestParams.meta` — rmcp's custom `Deserialize for Request` strips `_meta` out of the params into the request's extensions typemap, and the serve loop hands it to the handler as `RequestContext.meta`. The pre-implementation spec asserted the opposite direction; the implementation agent refuted it empirically (the spec's wiring failed every trace test) and shipped the correct read: params-struct meta first (in-process callers that never serialize), falling back to `context.meta`, where every real transport delivers the value. Both arms are pinned by tests that fail if either read is dropped.

## Adversarial review record

Three review lenses (security-bypass, correctness/fail-closed, docs-vs-code) plus an independent mutation-verification pass ran against the implementation commit; every finding is addressed in the final commit, none rebutted:

1. **security/minor** — DESIGN.md framed client control of `traceparent` purely as log hygiene, not stating the stored ids are forgeable. *Fixed*: the doc now says any client can stamp any call with any well-formed ids (its own probes with an innocent service's ids, or unrelated calls with an id under investigation); correlation hints, never evidence.
2. **correctness/important + docs/important (×2, independent)** — the http test file's module-doc coverage contract and inline comment documented the `_meta` trap *backwards* (claiming the test proves a `request.meta` read and naming an unkillable mutant), contradicting DESIGN.md and the commit body in the same commit. *Fixed*: both comments now state the true direction and name the mutant the file actually kills.
3. **correctness/minor** — the params-struct arm was dead in every test and every serialized transport, so no coverage claim about it could hold. *Fixed by pinning it*: a new in-process test invokes `ServerHandler::call_tool` directly with the traceparent in `CallToolRequestParams.meta` and a hand-built `RequestContext` asserted to carry no meta — the only caller shape that populates that field.
4. **mutation/blocking — M4 survived** — a `context.meta`-only read was behavior-preserving over every transport the suite exercised. *Fixed* by the same in-process test; the kill was re-proven by re-applying the M4 mutant in a throwaway detached worktree (the new test fails on it, passes on the unmutated tree).

**Mutation verification: 8/8 killed** (in a detached worktree at the implementation commit; M4's kill added by the fix and re-proven):

| Mutation | Killed by |
|---|---|
| M1 swap trace-id/span-id ranges | 5 tests (parser + 3 integration) |
| M2 drop all-zero trace-id rejection | `traceparent_rejects_all_zero_ids` |
| M3 accept uppercase hex | parser + `malformed_traceparent_leaves_the_record_without_trace` |
| M4 read only `context.meta` | `in_process_params_meta_traceparent_enriches_the_record` (added post-review) |
| M4-inverse read only params-struct meta | 3 transport tests incl. the streamable-http end-to-end |
| M5 gate-site event gets `trace: None` | `failing_sink_gate_record_carries_the_trace` |
| M6 length `== 55` → truncating `>= 55` | `traceparent_rejects_wrong_lengths` + whitespace test |
| M7 version check accepts any hex | `traceparent_rejects_versions_other_than_00` |
| M8 drop all-zero span-id rejection | `traceparent_rejects_all_zero_ids` |

Gate re-run independently on the final commit: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --all-targets --locked` (329 tests), `cargo deny check`, `typos` — all green.
