### PR TITLE
feat(audit): account for rows dropped by the search window scan

### DIFF
--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -6,9 +6,10 @@
 //!
 //! - **I2** — uniform denial: [`Guard::denial`] produces the exact same text
 //!   for a policy-denied and a nonexistent bug.
-//! - **I3** — silent filtering: [`Guard::filter_bug_list`] returns the count
-//!   of dropped bugs for server-side logging only; callers must never send
-//!   it to the MCP client.
+//! - **I3** — silent filtering: [`Guard::filter_bug_list`] returns the ids
+//!   of dropped bugs for server-side logging and audit accounting only;
+//!   callers must never send them — or anything derived from them — to the
+//!   MCP client.
 //! - **I4** — fail closed: [`Guard::assess`] maps every id whose
 //!   classification data cannot be fetched to `Denied`.
 //! - **I5** — private comments require BOTH the policy opt-in and the
@@ -64,6 +65,30 @@ pub struct SearchRequest<'a> {
     pub limit: u32,
     /// How many visible bugs to skip.
     pub offset: u32,
+}
+
+/// What one [`Guard::quicksearch_window`] scan produced: the window the
+/// client may see, plus the accounting the audit record needs (issue #29).
+///
+/// The accounting is server-side only (I3): callers may log it or place it
+/// in the audit record, but nothing derived from it — a count, an envelope
+/// field, a timing difference — may reach the MCP client, whose response
+/// is built from `bugs` alone.
+#[derive(Debug, Clone, Default)]
+pub struct SearchWindow {
+    /// The visible window: the bugs the client may see, in upstream order.
+    pub bugs: Vec<Value>,
+    /// Upstream rows the scan examined — duplicate rows and id-less rows
+    /// included, because each one was fetched and looked at.
+    pub scanned: u32,
+    /// Ids of the rows the scan dropped by verdict, in scan order (unique
+    /// by construction: rows are deduped on the server-reported id before
+    /// classification). Pinned semantics: denials in the overshoot region
+    /// past the requested window ARE included — deliberately, they are
+    /// what this scan classified while filling this window — while
+    /// id-less rows and deduped repeats are never classified, so they
+    /// appear neither here nor in any drop count.
+    pub dropped: Vec<u64>,
 }
 
 impl Guard {
@@ -256,13 +281,19 @@ impl Guard {
     /// binary-search `limit` and recover the exact hidden count of every
     /// block, which is why it is there. A long way from reconstructing a
     /// title, which is what this replaces.
+    ///
+    /// Returns a [`SearchWindow`]: the window itself plus the scan's
+    /// accounting (rows examined, ids dropped by verdict) so the caller can
+    /// put the numbers in the audit record (issue #29). The accounting is
+    /// server-side only (I3) — the client response is built from
+    /// [`SearchWindow::bugs`] alone.
     pub async fn quicksearch_window(
         &self,
         bz: &BugzillaClient,
         key: &str,
         req: &SearchRequest<'_>,
         caller: Option<&str>,
-    ) -> anyhow::Result<Vec<Value>> {
+    ) -> anyhow::Result<SearchWindow> {
         let SearchRequest {
             query,
             status,
@@ -272,7 +303,7 @@ impl Guard {
         } = *req;
         let needed = offset.saturating_add(limit).min(Self::MAX_SEARCH_WINDOW);
         if limit == 0 || needed == 0 {
-            return Ok(Vec::new());
+            return Ok(SearchWindow::default());
         }
 
         // Scan for a whole number of chunks' worth of visible bugs rather
@@ -291,7 +322,7 @@ impl Guard {
         let mut visible: Vec<Value> = Vec::new();
         let mut seen: BTreeSet<u64> = BTreeSet::new();
         let mut scanned: u32 = 0;
-        let mut dropped_total = 0usize;
+        let mut dropped: Vec<u64> = Vec::new();
 
         while (visible.len() as u32) < target && scanned < Self::SEARCH_SCAN_MAX {
             let chunk = Self::SEARCH_SCAN_CHUNK.min(Self::SEARCH_SCAN_MAX - scanned);
@@ -316,8 +347,8 @@ impl Guard {
                         .is_some_and(|id| seen.insert(id))
                 })
                 .collect();
-            let (kept, dropped) = self.filter_bug_list(fresh, caller);
-            dropped_total += dropped;
+            let (kept, chunk_dropped) = self.filter_bug_list(fresh, caller);
+            dropped.extend(chunk_dropped);
             visible.extend(kept);
             scanned += returned;
 
@@ -326,10 +357,10 @@ impl Guard {
             }
         }
 
-        if dropped_total > 0 {
+        if !dropped.is_empty() {
             // Server-side only, never a count to the client (I3).
             tracing::debug!(
-                dropped = dropped_total,
+                dropped = dropped.len(),
                 scanned,
                 "quicksearch: withheld policy-denied bugs"
             );
@@ -344,7 +375,11 @@ impl Guard {
         // session down with it).
         let end = (needed as usize).min(visible.len());
         let start = (offset as usize).min(end);
-        Ok(visible[start..end].to_vec())
+        Ok(SearchWindow {
+            bugs: visible[start..end].to_vec(),
+            scanned,
+            dropped,
+        })
     }
 
     /// Bug fields that carry references to OTHER bugs, as id lists.
@@ -835,9 +870,14 @@ impl Guard {
     ///
     /// Per bug: a `read` grant keeps the object as-is, a `summary`-only
     /// grant replaces it with [`Guard::summary_view`], anything else drops
-    /// it. Returns `(kept, dropped_count)`; the count exists for server-side
-    /// logging ONLY and must never be sent to the MCP client (I3) — from the
-    /// client's perspective filtered results simply never existed.
+    /// it. Returns `(kept, dropped_ids)`; the ids — and any count derived
+    /// from them — exist for server-side logging and audit accounting ONLY
+    /// and must never be sent to the MCP client (I3): from the client's
+    /// perspective filtered results simply never existed. A dropped row
+    /// without a readable u64 id contributes no entry, so `dropped.len()`
+    /// equals the drop count for every caller that feeds server-labelled
+    /// rows (which all of them do — [`Guard::quicksearch_window`] excludes
+    /// id-less rows before classification, I4).
     ///
     /// The input objects must include the classification fields (callers
     /// fetch `requested ∪ CLASSIFY_FIELDS`), otherwise bugs may be
@@ -847,10 +887,14 @@ impl Guard {
     /// ([`Guard::resolve_caller`]); under an identity-consulting policy a
     /// caller of `None` denies every bug the identity rules are consulted
     /// for (I4).
-    pub fn filter_bug_list(&self, bugs: Vec<Value>, caller: Option<&str>) -> (Vec<Value>, usize) {
+    pub fn filter_bug_list(
+        &self,
+        bugs: Vec<Value>,
+        caller: Option<&str>,
+    ) -> (Vec<Value>, Vec<u64>) {
         let now = Utc::now();
         let mut kept = Vec::new();
-        let mut dropped = 0usize;
+        let mut dropped = Vec::new();
         for bug in bugs {
             let meta = BugMeta::from_json(&bug, caller);
             let access = self.policy.classify(&meta, now, Operation::Access);
@@ -859,7 +903,7 @@ impl Guard {
             } else if access.allows(Capability::Summary) {
                 kept.push(Self::summary_view(&bug));
             } else {
-                dropped += 1;
+                dropped.extend(bug.get("id").and_then(Value::as_u64));
             }
         }
         (kept, dropped)
@@ -1424,7 +1468,7 @@ products = ["NoView*"]
             json!({"id": 4, "product": "NoViewer", "summary": "also hidden"}),
         ];
         let (kept, dropped) = g.filter_bug_list(bugs, None);
-        assert_eq!(dropped, 2, "denied and view-less bugs are dropped");
+        assert_eq!(dropped, vec![2, 4], "denied and view-less bugs are dropped");
         assert_eq!(kept.len(), 2);
         // Full-read bug passes through unmodified — extra fields intact, no
         // redaction marker.
@@ -1465,7 +1509,11 @@ products = ["NoView*"]
             json!({"id": 6, "groups": []}),
         ];
         let (kept, dropped) = g.filter_bug_list(bugs, None);
-        assert_eq!(dropped, 5, "only the plain, world-readable bug survives");
+        assert_eq!(
+            dropped,
+            vec![2, 3, 4, 5, 6],
+            "only the plain, world-readable bug survives"
+        );
         assert_eq!(kept.len(), 1);
         assert_eq!(kept[0]["id"], json!(1));
     }
@@ -1479,7 +1527,7 @@ products = ["NoView*"]
         };
         let (kept, dropped) =
             g.filter_bug_list(vec![json!({"id": 9, "product": "x", "cc": ["a@b"]})], None);
-        assert_eq!(dropped, 0);
+        assert!(dropped.is_empty());
         assert_eq!(kept.len(), 1);
         assert_eq!(kept[0]["cc"], json!(["a@b"]));
         assert!(kept[0].get("_redacted").is_none());
@@ -1492,7 +1540,7 @@ products = ["NoView*"]
         };
         let (kept, dropped) = g.filter_bug_list(vec![json!({"id": 1}), json!({"id": 2})], None);
         assert_eq!(kept.len(), 2);
-        assert_eq!(dropped, 0);
+        assert!(dropped.is_empty());
     }
 
     #[test]
@@ -1502,7 +1550,7 @@ products = ["NoView*"]
         };
         let (kept, dropped) = g.filter_bug_list(vec![json!({"id": 1}), json!({"id": 2})], None);
         assert!(kept.is_empty());
-        assert_eq!(dropped, 2);
+        assert_eq!(dropped, vec![1, 2]);
     }
 
     #[test]
@@ -1512,7 +1560,7 @@ products = ["NoView*"]
         };
         let (kept, dropped) = g.filter_bug_list(Vec::new(), None);
         assert!(kept.is_empty());
-        assert_eq!(dropped, 0);
+        assert!(dropped.is_empty());
     }
 
     #[test]
@@ -1527,7 +1575,7 @@ products = ["NoView*"]
             json!({"id": 2, "product": "P", "groups": []}),
         ];
         let (kept, dropped) = g.filter_bug_list(bugs, None);
-        assert_eq!(dropped, 1);
+        assert_eq!(dropped, vec![1]);
         assert_eq!(kept.len(), 1);
         assert_eq!(kept[0]["id"], json!(2));
     }

--- a/crates/bugwarden-core/tests/guard_wiremock.rs
+++ b/crates/bugwarden-core/tests/guard_wiremock.rs
@@ -622,7 +622,8 @@ async fn quicksearch_window_pages_have_no_holes_when_bugs_are_hidden() {
         let got = g
             .quicksearch_window(&bz, KEY, &search("q", 5, page * 5), None)
             .await
-            .expect("search succeeds");
+            .expect("search succeeds")
+            .bugs;
         assert_eq!(
             got.len(),
             5,
@@ -658,13 +659,15 @@ async fn quicksearch_window_pages_are_disjoint_and_gapless() {
         let got = g
             .quicksearch_window(&bz, KEY, &search("q", 4, page * 4), None)
             .await
-            .expect("search succeeds");
+            .expect("search succeeds")
+            .bugs;
         paged.extend(ids_of(&got));
     }
     let whole = g
         .quicksearch_window(&bz, KEY, &search("q", 32, 0), None)
         .await
-        .expect("search succeeds");
+        .expect("search succeeds")
+        .bugs;
     assert_eq!(
         paged,
         ids_of(&whole),
@@ -690,11 +693,13 @@ async fn quicksearch_window_page_is_identical_whether_or_not_bugs_are_hidden() {
     let clean = g
         .quicksearch_window(&client(&server_clean), KEY, &search("q", 4, 2), None)
         .await
-        .expect("search succeeds");
+        .expect("search succeeds")
+        .bugs;
     let mixed = g
         .quicksearch_window(&client(&server_mixed), KEY, &search("q", 4, 2), None)
         .await
-        .expect("search succeeds");
+        .expect("search succeeds")
+        .bugs;
     // Clean: visible are 1..12, so offset 2 limit 4 => 3,4,5,6.
     assert_eq!(ids_of(&clean), vec![3, 4, 5, 6]);
     // Mixed: visible are 1,3,5,6,8,9,10,11,12 => offset 2 limit 4 => 5,6,8,9.
@@ -721,12 +726,14 @@ async fn quicksearch_window_runs_out_like_a_normal_end_of_results() {
     let tail = g
         .quicksearch_window(&bz, KEY, &search("q", 10, 4), None)
         .await
-        .expect("search succeeds");
+        .expect("search succeeds")
+        .bugs;
     assert_eq!(ids_of(&tail), vec![6, 7]);
     let past = g
         .quicksearch_window(&bz, KEY, &search("q", 10, 50), None)
         .await
-        .expect("search succeeds");
+        .expect("search succeeds")
+        .bugs;
     assert!(past.is_empty());
 }
 
@@ -743,7 +750,8 @@ async fn quicksearch_window_scan_is_bounded() {
     let got = g
         .quicksearch_window(&client(&server), KEY, &search("q", 50, 0), None)
         .await
-        .expect("search succeeds");
+        .expect("search succeeds")
+        .bugs;
     assert!(got.is_empty(), "everything was hidden");
     assert_eq!(
         requests_to(&server).await,
@@ -767,7 +775,8 @@ async fn quicksearch_window_deep_offset_is_empty_whether_or_not_bugs_are_hidden(
             let got = g
                 .quicksearch_window(&client(&server), KEY, &search("q", 1, offset), None)
                 .await
-                .expect("a deep offset is not an error");
+                .expect("a deep offset is not an error")
+                .bugs;
             assert!(
                 got.is_empty(),
                 "offset {offset} with hidden={hidden:?} must be an empty page"
@@ -793,7 +802,8 @@ async fn quicksearch_window_scan_target_does_not_track_the_requested_limit() {
         let _ = g
             .quicksearch_window(&client(&server), KEY, &search("q", limit, 0), None)
             .await
-            .expect("search succeeds");
+            .expect("search succeeds")
+            .bugs;
         counts.push(requests_to(&server).await);
     }
     assert!(
@@ -823,7 +833,8 @@ async fn quicksearch_window_drops_rows_without_a_readable_id() {
     let got = g
         .quicksearch_window(&client(&server), KEY, &search("q", 10, 0), None)
         .await
-        .expect("search succeeds");
+        .expect("search succeeds")
+        .bugs;
     assert_eq!(ids_of(&got), vec![1, 2]);
 }
 
@@ -844,7 +855,8 @@ async fn quicksearch_window_dedupes_rows_repeated_across_chunks() {
     let got = g
         .quicksearch_window(&client(&server), KEY, &search("q", 400, 0), None)
         .await
-        .expect("search succeeds");
+        .expect("search succeeds")
+        .bugs;
     let ids = ids_of(&got);
     let unique: std::collections::BTreeSet<_> = ids.iter().collect();
     assert_eq!(unique.len(), ids.len(), "a bug was served twice: {ids:?}");
@@ -856,11 +868,14 @@ async fn quicksearch_window_zero_limit_touches_nothing() {
     let server = MockServer::start().await;
     // No mock is mounted: any upstream request would fail the call.
     let g = guard(EMBARGO_POLICY);
-    let got = g
+    let window = g
         .quicksearch_window(&client(&server), KEY, &search("q", 0, 0), None)
         .await
         .expect("zero limit is not an error");
-    assert!(got.is_empty());
+    assert!(window.bugs.is_empty());
+    // Nothing was fetched, so there is nothing to account for either.
+    assert_eq!(window.scanned, 0);
+    assert!(window.dropped.is_empty());
 }
 
 #[tokio::test]
@@ -873,9 +888,103 @@ async fn quicksearch_window_returns_the_classified_objects() {
     let got = g
         .quicksearch_window(&client(&server), KEY, &search("q", 10, 0), None)
         .await
-        .expect("search succeeds");
+        .expect("search succeeds")
+        .bugs;
     assert_eq!(ids_of(&got), vec![1, 3]);
     assert_eq!(got[0]["summary"], json!("test bug"), "full object returned");
+}
+
+#[tokio::test]
+async fn quicksearch_window_accounts_for_scanned_rows_and_dropped_ids() {
+    // The accounting exists for the audit record (issue #29): `scanned` is
+    // every upstream row the scan examined, `dropped` is exactly the ids
+    // the verdict withheld — in scan order, nothing more.
+    let server = MockServer::start().await;
+    corpus(&server, 30, &[2, 3, 11]).await;
+    let g = guard(EMBARGO_POLICY);
+    let window = g
+        .quicksearch_window(&client(&server), KEY, &search("q", 5, 0), None)
+        .await
+        .expect("search succeeds");
+    assert_eq!(ids_of(&window.bugs), vec![1, 4, 5, 6, 7]);
+    assert_eq!(window.scanned, 30, "every upstream row was examined");
+    assert_eq!(window.dropped, vec![2, 3, 11]);
+}
+
+#[tokio::test]
+async fn quicksearch_window_accounts_for_overshoot_denials() {
+    // The scan is quantised to whole chunks, so it classifies rows far
+    // past the requested window. A denial out there IS part of what this
+    // scan withheld while filling this window, and the accounting says so:
+    // hidden bug 120 sits well past the 5-bug window but inside the first
+    // 200-row chunk.
+    let server = MockServer::start().await;
+    corpus(&server, 150, &[120]).await;
+    let g = guard(EMBARGO_POLICY);
+    let window = g
+        .quicksearch_window(&client(&server), KEY, &search("q", 5, 0), None)
+        .await
+        .expect("search succeeds");
+    assert_eq!(ids_of(&window.bugs), vec![1, 2, 3, 4, 5]);
+    assert_eq!(window.dropped, vec![120], "overshoot denials are counted");
+    assert_eq!(window.scanned, 150);
+}
+
+#[tokio::test]
+async fn quicksearch_window_accounting_skips_idless_rows_and_repeats() {
+    // Neither an id-less row nor a deduped repeat reaches the verdict, so
+    // neither may appear in the drop accounting (they were never
+    // classified, and a non-verdict is not a drop) — but both were fetched
+    // and examined, so both count as scanned rows.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "bugs": [
+                bug(1, &[], OLD),
+                bug(2, &["embargo-security"], OLD),
+                json!({ "summary": "no id here", "groups": [] }),
+                bug(1, &[], OLD), // repeated inside the chunk
+                bug(3, &[], OLD),
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let g = guard(EMBARGO_POLICY);
+    let window = g
+        .quicksearch_window(&client(&server), KEY, &search("q", 10, 0), None)
+        .await
+        .expect("search succeeds");
+    assert_eq!(ids_of(&window.bugs), vec![1, 3]);
+    assert_eq!(window.dropped, vec![2], "only the classified denial");
+    assert_eq!(window.scanned, 5, "every row upstream served was examined");
+}
+
+#[tokio::test]
+async fn quicksearch_window_accounting_accumulates_across_chunks() {
+    // The accounting is accumulated per chunk (`dropped.extend`,
+    // `scanned +=`); a regression that reset either counter each
+    // iteration would pass every single-chunk fixture. 250 rows force a
+    // second chunk (target 400 for limit 201), with one hidden id in each
+    // chunk: 10 in the first (rows 1..=200), 230 in the second
+    // (rows 201..=250).
+    let server = MockServer::start().await;
+    corpus(&server, 250, &[10, 230]).await;
+    let g = guard(EMBARGO_POLICY);
+    let window = g
+        .quicksearch_window(&client(&server), KEY, &search("q", 201, 0), None)
+        .await
+        .expect("search succeeds");
+    assert_eq!(window.scanned, 250, "both chunks' rows are counted");
+    assert_eq!(
+        window.dropped,
+        vec![10, 230],
+        "drops from every chunk survive, in scan order"
+    );
+    let ids = ids_of(&window.bugs);
+    assert_eq!(ids.len(), 201, "the window itself is unaffected");
+    assert!(!ids.contains(&10) && !ids.contains(&230));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -490,6 +490,30 @@ pub struct GuardInfo {
     /// Names of fields the guard redacted from served bugs (field names
     /// only, never their values).
     pub redacted_fields: Vec<String>,
+    /// Search-window scan accounting, present only on calls that ran a
+    /// window scan (`bugs_quicksearch`). Recorded regardless of
+    /// [`AuditConfig::suppressed_ids`] — that switch elides ids, never
+    /// counts. Records written before this field existed deserialize to
+    /// `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scan: Option<ScanInfo>,
+}
+
+/// What the search-window scan behind one call examined and withheld
+/// (issue #29). These numbers are exactly what I3 keeps out of the
+/// response: without them a search that silently dropped many denied rows
+/// is indistinguishable in the stream from one that dropped none.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScanInfo {
+    /// Upstream rows the scan examined — duplicate and id-less rows
+    /// included, because each one was fetched and looked at.
+    pub scanned: u64,
+    /// Rows the scan dropped by verdict. Authoritative on its own, like
+    /// [`GuardInfo::suppressed_count`]: the dropped ids ride
+    /// [`GuardInfo::suppressed_ids`] and may be elided by configuration,
+    /// so consumers must never infer this count from that list.
+    pub dropped: u64,
 }
 
 /// The guard's overall verdict for one tool call.
@@ -1055,6 +1079,8 @@ struct CellState {
     /// metadata filtered out): counted, never named.
     suppressed_extra: u64,
     redacted_fields: std::collections::BTreeSet<String>,
+    /// Search-window scan accounting ([`AuditCell::note_scan`]).
+    scan: Option<ScanInfo>,
     upstream: Option<UpstreamInfo>,
 }
 
@@ -1140,6 +1166,22 @@ impl AuditCell {
         state.suppressed_extra = state.suppressed_extra.saturating_add(n);
     }
 
+    /// Note the search-window scan's accounting (issue #29): how many
+    /// upstream rows it examined and how many it dropped by verdict. One
+    /// scan per call by construction; if noted twice, the last note wins.
+    /// A scan that dropped rows IS a filtered serve, so `dropped > 0`
+    /// upgrades the verdict exactly as [`AuditCell::note_suppressed`]
+    /// does; a clean scan records its numbers without touching the
+    /// verdict at all. The dropped IDS are not this method's business —
+    /// the call site feeds them to [`AuditCell::note_suppressed`], where
+    /// the existing `suppressed_ids` config switch governs them.
+    pub fn note_scan(&self, scanned: u64, dropped: u64) {
+        if dropped > 0 {
+            self.merge(Verdict::ServedFiltered, None);
+        }
+        self.lock().scan = Some(ScanInfo { scanned, dropped });
+    }
+
     /// Note a field (or view marker) the guard redacted from served
     /// bugs. Upgrades the verdict to `ServedFiltered`.
     pub fn note_redacted(&self, field: &str) {
@@ -1182,6 +1224,8 @@ impl AuditCell {
                 Vec::new()
             },
             redacted_fields: state.redacted_fields.into_iter().collect(),
+            // Counts, not ids: the suppressed_ids switch never touches it.
+            scan: state.scan,
         })
     }
 }
@@ -1238,6 +1282,10 @@ mod tests {
                 suppressed_count: 2,
                 suppressed_ids: vec![1290040, 1290041],
                 redacted_fields: vec!["cc".into(), "flags".into()],
+                scan: Some(ScanInfo {
+                    scanned: 200,
+                    dropped: 2,
+                }),
             }),
             upstream: Some(UpstreamInfo {
                 requests: 1,
@@ -1324,10 +1372,32 @@ mod tests {
     // ---------- schema goldens (v1 stability gate) ----------
     //
     // These strings ARE the wire format. A failure here means the schema
-    // changed; that requires a version bump and a deliberate decision,
-    // not an updated constant.
+    // changed; that requires a deliberate decision, not an updated
+    // constant. One shape of change stays within v1: adding a field that
+    // is optional and absent when unset (as `guard.scan` was, issue #29).
+    // Such a change updates the golden AND must pin the prior byte
+    // sequence as a GOLDEN_*_PRE_* constant with a test proving old lines
+    // still deserialize. Any other byte change — removing, renaming,
+    // reordering, or retyping a field — requires a version bump.
 
     const GOLDEN_TOOL_CALL: &str = concat!(
+        r#"{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":7,"#,
+        r#""session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"#,
+        r#""event":"tool_call","#,
+        r#""client":{"name":"example-agent","version":"1.4.2","principal":"alice@example.org"},"#,
+        r#""trace":{"trace_id":"0af7651916cd43dd8448eb211c80319c","span_id":"b7ad6b7169203331"},"#,
+        r#""request":{"tool":"bug_info","id":"3","params":{"id":1290042,"include_private":false}},"#,
+        r#""guard":{"verdict":"served_filtered","rule":"group-restricted","policy_hash":"2b6e8f5d1c9a4e70","#,
+        r#""suppressed_count":2,"suppressed_ids":[1290040,1290041],"redacted_fields":["cc","flags"],"#,
+        r#""scan":{"scanned":200,"dropped":2}},"#,
+        r#""upstream":{"requests":1,"status":200,"latency_ms":48},"#,
+        r#""outcome":{"class":"ok","duration_ms":52}}"#,
+    );
+
+    /// [`GOLDEN_TOOL_CALL`] as records looked before `guard.scan` existed
+    /// (issue #29). The field was added optional-and-absent-when-unset, so
+    /// lines from older files must keep deserializing — to a `None` scan.
+    const GOLDEN_TOOL_CALL_PRE_SCAN: &str = concat!(
         r#"{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":7,"#,
         r#""session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"#,
         r#""event":"tool_call","#,
@@ -1367,6 +1437,20 @@ mod tests {
     fn golden_audit_gap_json() {
         let event = envelope(9, session_stdio(), sample_gap());
         assert_eq!(serde_json::to_string(&event).unwrap(), GOLDEN_AUDIT_GAP);
+    }
+
+    #[test]
+    fn tool_call_line_without_scan_still_deserializes() {
+        // A pre-#29 record has no `guard.scan` bytes at all; it must parse
+        // into today's types with the scan simply absent.
+        let event: AuditEvent =
+            serde_json::from_str(GOLDEN_TOOL_CALL_PRE_SCAN).expect("an old line must parse");
+        let AuditEventKind::ToolCall(tc) = &event.kind else {
+            panic!("expected a tool_call event");
+        };
+        let guard = tc.guard.as_ref().expect("the old line carries a guard");
+        assert_eq!(guard.scan, None, "absent field means None, not an error");
+        assert_eq!(guard.suppressed_count, 2, "the rest is read unchanged");
     }
 
     #[test]
@@ -2160,6 +2244,83 @@ mod tests {
         let info = cell.into_guard_info(None, true).unwrap();
         assert_eq!(info.verdict, Verdict::ServedFiltered);
         assert_eq!(info.redacted_fields, vec!["summary_view".to_string()]);
+    }
+
+    #[test]
+    fn cell_scan_with_drops_is_a_filtered_serve() {
+        let cell = AuditCell::default();
+        cell.note_verdict(Verdict::Served);
+        cell.note_scan(200, 3);
+        let info = cell.into_guard_info(None, true).unwrap();
+        assert_eq!(
+            info.verdict,
+            Verdict::ServedFiltered,
+            "a search that withheld rows is a filtered serve"
+        );
+        assert_eq!(
+            info.scan,
+            Some(ScanInfo {
+                scanned: 200,
+                dropped: 3
+            })
+        );
+    }
+
+    #[test]
+    fn cell_clean_scan_records_numbers_without_touching_the_verdict() {
+        let cell = AuditCell::default();
+        cell.note_verdict(Verdict::Served);
+        cell.note_scan(30, 0);
+        let info = cell.into_guard_info(None, true).unwrap();
+        assert_eq!(info.verdict, Verdict::Served, "a clean scan stays served");
+        assert_eq!(
+            info.scan,
+            Some(ScanInfo {
+                scanned: 30,
+                dropped: 0
+            })
+        );
+    }
+
+    #[test]
+    fn cell_scan_noted_twice_keeps_the_last_note() {
+        // One search per call by construction; should a second note ever
+        // happen, last write wins — documented, not merged.
+        let cell = AuditCell::default();
+        cell.note_scan(200, 3);
+        cell.note_scan(400, 0);
+        let info = cell.into_guard_info(None, true).unwrap();
+        assert_eq!(
+            info.scan,
+            Some(ScanInfo {
+                scanned: 400,
+                dropped: 0
+            })
+        );
+        // The earlier note's verdict upgrade is NOT rolled back: rows
+        // were withheld at some point of this call, so the record says
+        // filtered (worst-wins, like every other verdict source).
+        assert_eq!(info.verdict, Verdict::ServedFiltered);
+    }
+
+    #[test]
+    fn cell_scan_counts_survive_the_suppressed_ids_config() {
+        // `suppressed_ids = false` elides ids; the scan carries counts
+        // only, so it ships untouched (acceptance (c) of issue #29).
+        let cell = AuditCell::default();
+        cell.note_scan(30, 2);
+        cell.note_suppressed([12, 19]);
+        let info = cell.into_guard_info(None, false).unwrap();
+        assert!(info.suppressed_ids.is_empty(), "ids elided by config");
+        assert_eq!(info.suppressed_count, 2, "the count still ships");
+        assert_eq!(
+            info.scan,
+            Some(ScanInfo {
+                scanned: 30,
+                dropped: 2
+            }),
+            "the scan accounting is counts, never ids"
+        );
     }
 
     #[test]

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use bugwarden_core::client::{BugzillaClient, CLASSIFY_FIELDS};
-use bugwarden_core::guard::{Guard, SearchRequest};
+use bugwarden_core::guard::{Guard, SearchRequest, SearchWindow};
 use bugwarden_core::policy::{Access, Action, Capability};
 use chrono::{DateTime, Utc};
 use rmcp::{
@@ -302,7 +302,7 @@ fn assemble_bug_info(
                 // Absent from the body response => fail closed (I4).
                 .and_then(|body| {
                     let (kept, dropped) = guard.filter_bug_list(vec![body.clone()], caller);
-                    if dropped > 0 {
+                    if !dropped.is_empty() {
                         // The verdict flipped between the two fetches — the
                         // anomaly this re-check exists for. Server-side only
                         // (I3): the client just sees the uniform denial.
@@ -1321,7 +1321,14 @@ impl BugWarden {
         // limit/offset address the bugs the client may see; the guard scans
         // and filters upstream rows to fill that window (I2/I3).
         let caller = self.guard.resolve_caller(&self.bz, &key).await;
-        let kept = match self
+        // `scanned`/`dropped` are the scan's accounting for the audit
+        // record only (issue #29); the response is built from `kept`
+        // alone, so it stays byte-identical whatever they hold (I3).
+        let SearchWindow {
+            bugs: kept,
+            scanned,
+            dropped,
+        } = match self
             .guard
             .quicksearch_window(
                 &self.bz,
@@ -1337,7 +1344,7 @@ impl BugWarden {
             )
             .await
         {
-            Ok(kept) => kept,
+            Ok(window) => window,
             // Uniform: a failing search never says which bug or why (I2).
             Err(e) => {
                 tracing::warn!(error = %e, "bugs_quicksearch: upstream search failed");
@@ -1369,11 +1376,19 @@ impl BugWarden {
             Guard::scrub_bug_links(bug, base_url, &allowed);
         }
         if let Some(cell) = audit_cell(&ctx) {
-            // The window's own drops happen inside the guard scan and are
-            // not surfaced here; what this site sees is the served
-            // projection — redacted rows and the linked ids I14 scrubbed
-            // out of them.
             cell.note_verdict(Verdict::Served);
+            // The window scan's own accounting (issue #29): rows examined
+            // and rows dropped by verdict. A dropping scan upgrades the
+            // verdict to served_filtered inside note_scan; the dropped
+            // ids ride the existing suppressed-ids machinery below —
+            // config gate, suppressed_count, and the BTreeSet union with
+            // the I14-scrubbed link ids (overlap dedupes, a feature).
+            cell.note_scan(u64::from(scanned), dropped.len() as u64);
+            if !dropped.is_empty() {
+                cell.note_suppressed(dropped.iter().copied());
+            }
+            // What this site itself sees is the served projection —
+            // redacted rows and the linked ids I14 scrubbed out of them.
             for bug in &projected {
                 if bug.get("_redacted").is_some() {
                     cell.note_redacted("summary_view");
@@ -2518,6 +2533,8 @@ impl ServerHandler for BugWarden {
                     suppressed_count: 0,
                     suppressed_ids: Vec::new(),
                     redacted_fields: Vec::new(),
+                    // The guard never ran, so no window scan did either.
+                    scan: None,
                 }),
                 upstream: None,
                 outcome: audit::OutcomeInfo {

--- a/crates/bugwarden/tests/audit_wiremock.rs
+++ b/crates/bugwarden/tests/audit_wiremock.rs
@@ -610,6 +610,178 @@ async fn suppressed_ids_off_records_the_count_never_the_ids() {
     );
 }
 
+/// Serve a quicksearch corpus (issue #29 tests): search requests are paged
+/// by limit/offset the way Bugzilla pages them, and the I14 link-disclosure
+/// classify fetch — which addresses bugs by id, not by query — gets an
+/// empty answer (the corpus rows carry no link fields to disclose).
+async fn mount_search_corpus(mock: &MockServer, rows: Vec<Value>) {
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(move |req: &wiremock::Request| {
+            let q: std::collections::HashMap<_, _> = req.url.query_pairs().collect();
+            if !q.contains_key("quicksearch") {
+                return ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] }));
+            }
+            let get = |k: &str| q.get(k).and_then(|v| v.parse::<usize>().ok());
+            let offset = get("offset").unwrap_or(0);
+            let limit = get("limit").unwrap_or(rows.len());
+            let page: Vec<_> = rows.iter().skip(offset).take(limit).cloned().collect();
+            ResponseTemplate::new(200).set_body_json(json!({ "bugs": page }))
+        })
+        .mount(mock)
+        .await;
+}
+
+/// A [`world_bug`] in the `Secret*` product the [`HIDE_SECRET_POLICY`]
+/// denies.
+fn secret_bug(id: u64) -> Value {
+    let mut bug = world_bug(id);
+    bug["product"] = json!("SecretSauce");
+    bug
+}
+
+#[tokio::test]
+async fn quicksearch_scan_accounting_reaches_the_record_never_the_envelope() {
+    // Five upstream rows, two of them hidden: the record must say the scan
+    // examined 5 and dropped 2 — and which two, through the existing
+    // suppressed-ids machinery — while the envelope shows three bugs and
+    // not a hint of accounting (I3).
+    let mock = MockServer::start().await;
+    mount_search_corpus(
+        &mock,
+        vec![
+            world_bug(1),
+            secret_bug(2),
+            world_bug(3),
+            secret_bug(4),
+            world_bug(5),
+        ],
+    )
+    .await;
+    let audited = audited_client_for(HIDE_SECRET_POLICY, &mock, "test-key").await;
+
+    let result = call(&audited.client, "bugs_quicksearch", json!({ "query": "q" })).await;
+    assert_ne!(result.is_error, Some(true), "the search is served");
+    let envelope = serde_json::to_string(&result).unwrap();
+    for leak in ["scanned", "dropped", "\"scan\""] {
+        assert!(
+            !envelope.contains(leak),
+            "scan accounting leaked into the envelope: {envelope}"
+        );
+    }
+
+    let events = read_events(&audited.audit_path);
+    let tc = last_tool_call(&events);
+    let guard = tc.guard.as_ref().expect("guard info recorded");
+    let scan = guard.scan.expect("a search records its scan");
+    assert_eq!(scan.scanned, 5, "every upstream row was examined");
+    assert_eq!(scan.dropped, 2, "the two hidden rows were dropped");
+    assert_eq!(guard.verdict, Verdict::ServedFiltered);
+    assert_eq!(
+        guard.suppressed_ids,
+        vec![2, 4],
+        "the dropped ids ride the suppressed-ids machinery"
+    );
+    assert_eq!(guard.suppressed_count, 2);
+}
+
+#[tokio::test]
+async fn quicksearch_response_is_byte_identical_whether_or_not_rows_were_dropped() {
+    // Acceptance (b) of issue #29, at the tool level with auditing ON: a
+    // window that dropped hidden rows serializes byte-identically to the
+    // same window over an upstream where those rows simply do not exist.
+    let visible: Vec<u64> = vec![1, 3, 5, 6, 8, 9, 10, 11, 12];
+    let mock_mixed = MockServer::start().await;
+    mount_search_corpus(
+        &mock_mixed,
+        (1..=12)
+            .map(|id| {
+                if [2, 4, 7].contains(&id) {
+                    secret_bug(id)
+                } else {
+                    world_bug(id)
+                }
+            })
+            .collect(),
+    )
+    .await;
+    let mock_clean = MockServer::start().await;
+    mount_search_corpus(
+        &mock_clean,
+        visible.iter().map(|&id| world_bug(id)).collect(),
+    )
+    .await;
+
+    let mixed = audited_client_for(HIDE_SECRET_POLICY, &mock_mixed, "test-key").await;
+    let clean = audited_client_for(HIDE_SECRET_POLICY, &mock_clean, "test-key").await;
+    let args = json!({ "query": "q", "limit": 4, "offset": 2 });
+    let from_mixed = call(&mixed.client, "bugs_quicksearch", args.clone()).await;
+    let from_clean = call(&clean.client, "bugs_quicksearch", args).await;
+    assert_eq!(
+        serde_json::to_string(&from_mixed).unwrap(),
+        serde_json::to_string(&from_clean).unwrap(),
+        "dropped rows must not change a single response byte (I3)"
+    );
+
+    // The difference lives in the records alone: the mixed scan dropped,
+    // the clean scan did not.
+    let mixed_events = read_events(&mixed.audit_path);
+    let mixed_guard = last_tool_call(&mixed_events).guard.as_ref().unwrap();
+    assert!(mixed_guard.scan.expect("scan recorded").dropped > 0);
+    let clean_events = read_events(&clean.audit_path);
+    let clean_guard = last_tool_call(&clean_events).guard.as_ref().unwrap();
+    assert_eq!(clean_guard.scan.expect("scan recorded").dropped, 0);
+}
+
+#[tokio::test]
+async fn quicksearch_drop_count_survives_the_suppressed_ids_knob() {
+    // Acceptance (c) of issue #29: with `suppressed_ids = false` the
+    // record still counts what the scan dropped — it just names no id.
+    let mock = MockServer::start().await;
+    mount_search_corpus(&mock, vec![world_bug(1), secret_bug(2), world_bug(3)]).await;
+    let audited = audited_client_with(HIDE_SECRET_POLICY, &mock, "test-key", false).await;
+
+    let result = call(&audited.client, "bugs_quicksearch", json!({ "query": "q" })).await;
+    assert_ne!(result.is_error, Some(true), "the search is served");
+
+    let events = read_events(&audited.audit_path);
+    let guard = last_tool_call(&events).guard.as_ref().unwrap();
+    let scan = guard.scan.expect("a search records its scan");
+    assert_eq!(scan.dropped, 1, "the count survives the elision");
+    assert_eq!(scan.scanned, 3);
+    assert!(guard.suppressed_count >= 1, "so does suppressed_count");
+    assert!(
+        guard.suppressed_ids.is_empty(),
+        "ids are elided when the knob is off: {:?}",
+        guard.suppressed_ids
+    );
+}
+
+#[tokio::test]
+async fn quicksearch_clean_scan_records_zero_drops_and_stays_served() {
+    // A search that hid nothing still accounts for its scan — dropped = 0
+    // is a statement, not an omission — and keeps the clean verdict.
+    let mock = MockServer::start().await;
+    mount_search_corpus(&mock, vec![world_bug(1), world_bug(2), world_bug(3)]).await;
+    let audited = audited_client_for(HIDE_SECRET_POLICY, &mock, "test-key").await;
+
+    let result = call(&audited.client, "bugs_quicksearch", json!({ "query": "q" })).await;
+    assert_ne!(result.is_error, Some(true), "the search is served");
+
+    let events = read_events(&audited.audit_path);
+    let guard = last_tool_call(&events).guard.as_ref().unwrap();
+    assert_eq!(
+        guard.scan,
+        Some(bugwarden::audit::ScanInfo {
+            scanned: 3,
+            dropped: 0
+        })
+    );
+    assert_eq!(guard.verdict, Verdict::Served, "a clean scan stays served");
+    assert!(guard.suppressed_ids.is_empty());
+    assert_eq!(guard.suppressed_count, 0);
+}
+
 #[tokio::test]
 async fn canary_content_never_reaches_the_audit_file() {
     const KEY_CANARY: &str = "canary-api-key-5c9e02";

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -367,8 +367,12 @@ impl Guard {
     // limit/offset address VISIBLE bugs: scan upstream from row 0 in chunks,
     // classify, fill the window from survivors. Bounded by MAX_SEARCH_WINDOW
     // (1000 addressable) and 2000 scanned rows; truncation looks like the end
-    // of results. Returns the classified objects themselves.
+    // of results. Returns the classified objects themselves, wrapped in a
+    // SearchWindow together with the scan's accounting (issue #29) —
+    // server-side only (I3), for the audit record; the client response is
+    // built from `bugs` alone.
     pub struct SearchRequest<'a> { query, status, include_fields: &'a str, limit, offset: u32 }
+    pub struct SearchWindow { bugs: Vec<serde_json::Value>, scanned: u32, dropped: Vec<u64> }
     pub const MAX_SEARCH_WINDOW: u32;
 
     // I14 link scrubbing. Candidate ids come from Bugzilla, not the client,
@@ -387,7 +391,7 @@ impl Guard {
     pub fn duplicate_marker_ids(comments: &[Value]) -> BTreeSet<u64>;
     pub fn scrub_duplicate_markers(comments: Vec<Value>, ok: &BTreeSet<u64>) -> Vec<Value>;
     pub async fn quicksearch_window(&self, bz: &BugzillaClient, key: &str,
-        req: &SearchRequest<'_>, caller: Option<&str>) -> anyhow::Result<Vec<serde_json::Value>>;
+        req: &SearchRequest<'_>, caller: Option<&str>) -> anyhow::Result<SearchWindow>;
 
     // The `caller` parameter on assess/quicksearch_window/disclosable/
     // filter_bug_list is the identity resolved ONCE per tool call by
@@ -408,9 +412,10 @@ impl Guard {
     pub fn summary_view(bug: &serde_json::Value) -> serde_json::Value;
 
     /// Classify each bug: full read kept as-is, summary-only replaced by
-    /// summary_view, denied dropped. Returns (kept, dropped_count) — the count
-    /// is for server-side logging ONLY, never sent to the client (I3).
-    pub fn filter_bug_list(&self, bugs: Vec<serde_json::Value>, caller: Option<&str>) -> (Vec<serde_json::Value>, usize);
+    /// summary_view, denied dropped. Returns (kept, dropped_ids) — the ids
+    /// are for server-side logging and audit accounting ONLY, never sent to
+    /// the client (I3).
+    pub fn filter_bug_list(&self, bugs: Vec<serde_json::Value>, caller: Option<&str>) -> (Vec<serde_json::Value>, Vec<u64>);
 
     /// Drops is_private comments unless include_private && policy allows (I5).
     pub fn filter_comments(&self, comments: Vec<serde_json::Value>, include_private: bool) -> Vec<serde_json::Value>;
@@ -666,7 +671,7 @@ constraints the model must know.
 | bug_info | bug_ids: Vec<u64> | per-id: Read => full, else Summary => redacted, else restricted entry | envelope `{"bugs":[..], "restricted":[{"id":N,"note":denial(N)}]}`; full fetch only for Read-granted ids. Every fetched body is RE-CLASSIFIED before it is served (assemble_bug_info): the verdict came from the classification fetch and the body from a later request, so a bug embargoed in between must not be served on the stale verdict (TOCTOU; same reason download_attachment re-checks). Costs no request — the body is a superset of CLASSIFY_FIELDS — and a body that now earns only summary is served as the summary view, one that earns nothing becomes the uniform restricted entry. A failed body fetch is logged server-side ONLY and leaves those ids restricted: Bugzilla's message names the bug and says whether it exists, so forwarding it would undo I2 |
 | bug_history | id, new_since?: DateTime<Utc> | history | |
 | bug_comments | id, include_private: bool = false, new_since? | comments | filter_comments applied (I5) |
-| bugs_quicksearch | query, status: String = "ALL", include_fields: String = "id,product,component,assigned_to,status,resolution,summary,last_change_time", limit: u32 = 50, offset: u32 = 0 | post-filter | fetch include_fields = requested ∪ CLASSIFY_FIELDS; after filter, project kept bugs to requested fields (keep `_redacted` marker); envelope `{"bugs":[..]}` only (I3), except an advisory `note` when the query is nothing but bug ids (comma/whitespace-separated, optional `#` per id) steering exact id sets to bug_info — the note is a pure function of the CLIENT'S REQUEST (the query and status strings), never of results, verdicts, or anything upstream said (no new oracle), and the `bugs` array is byte-identical with or without it (the query is still searched, never rerouted); its wording tracks the request: a non-empty status is prefixed to the query so upstream content-matches the whole expression, while an empty status sends the query bare and Bugzilla routes a bare all-number query to an exact id lookup (bug_id + anyexact) — on that path the note drops the content-matching claim — and a query naming more distinct ids than MAX_ASSESS_IDS steers to batched bug_info calls (the cap is already public in the too_many_ids refusal text) instead of straight into that refusal | **limit/offset address the bugs the client may SEE, not upstream rows** (Guard::quicksearch_window): filtering an already-paginated page left a hole exactly where a hidden bug sat — a short page the next offset contradicted — and since quicksearch matches summary text that hole was a probe for the hidden title, one word at a time. The guard now scans upstream from row 0 in 200-row chunks, classifies each, and fills the window from the survivors; rows are deduped on the server-reported id (relevance order is not stable between calls) and an id-less row is dropped (I4). Bounds: MAX_SEARCH_WINDOW=1000 addressable, 2000 rows scanned (<=10 sequential requests); hitting either truncates, which looks exactly like the end of results. The objects returned are the ones classified. The scan target is quantised to whole chunks so the stopping point does not track the client's `limit`; without that, `limit` could be binary-searched against the clock to recover each block's exact hidden count. Residual, accepted: filling a window of VISIBLE bugs needs more rows when bugs are hidden, so a stopwatch still learns one bit per scanned block ("not entirely visible"). Removing that would mean scanning the worst case on every search, or letting pages go short again. Search failure returns a bare "Search failed"; the upstream text is logged server-side only (it can name a bug and say whether it exists) |
+| bugs_quicksearch | query, status: String = "ALL", include_fields: String = "id,product,component,assigned_to,status,resolution,summary,last_change_time", limit: u32 = 50, offset: u32 = 0 | post-filter | fetch include_fields = requested ∪ CLASSIFY_FIELDS; after filter, project kept bugs to requested fields (keep `_redacted` marker); envelope `{"bugs":[..]}` only (I3), except an advisory `note` when the query is nothing but bug ids (comma/whitespace-separated, optional `#` per id) steering exact id sets to bug_info — the note is a pure function of the CLIENT'S REQUEST (the query and status strings), never of results, verdicts, or anything upstream said (no new oracle), and the `bugs` array is byte-identical with or without it (the query is still searched, never rerouted); its wording tracks the request: a non-empty status is prefixed to the query so upstream content-matches the whole expression, while an empty status sends the query bare and Bugzilla routes a bare all-number query to an exact id lookup (bug_id + anyexact) — on that path the note drops the content-matching claim — and a query naming more distinct ids than MAX_ASSESS_IDS steers to batched bug_info calls (the cap is already public in the too_many_ids refusal text) instead of straight into that refusal | **limit/offset address the bugs the client may SEE, not upstream rows** (Guard::quicksearch_window): filtering an already-paginated page left a hole exactly where a hidden bug sat — a short page the next offset contradicted — and since quicksearch matches summary text that hole was a probe for the hidden title, one word at a time. The guard now scans upstream from row 0 in 200-row chunks, classifies each, and fills the window from the survivors; rows are deduped on the server-reported id (relevance order is not stable between calls) and an id-less row is dropped (I4). Bounds: MAX_SEARCH_WINDOW=1000 addressable, 2000 rows scanned (<=10 sequential requests); hitting either truncates, which looks exactly like the end of results. The objects returned are the ones classified. The scan target is quantised to whole chunks so the stopping point does not track the client's `limit`; without that, `limit` could be binary-searched against the clock to recover each block's exact hidden count. Residual, accepted: filling a window of VISIBLE bugs needs more rows when bugs are hidden, so a stopwatch still learns one bit per scanned block ("not entirely visible"). Removing that would mean scanning the worst case on every search, or letting pages go short again. Search failure returns a bare "Search failed"; the upstream text is logged server-side only (it can name a bug and say whether it exists). The scan's accounting — rows examined, verdict-dropped ids — goes to the audit record only (`guard.scan` plus the suppressed-ids machinery, issue #29); the response is byte-identical with or without drops |
 | create_bug | product, component, summary, version, description = "", severity?, priority?, op_sys?, platform?, keywords?: Vec<String>, groups?: Vec<String> | create (write), judged on the bug AS REQUESTED (Guard::may_create) | there is no bug id to assess, so the request itself is classified BEFORE any upstream call (I8): the rules that hide a product by name refuse filing into it, a field the request omits fails closed (I4), and a client-claimed `groups` list is never trusted — Bugzilla unions the product's mandatory groups in server-side, so may_create forces groups to unknown, which means a group-consulting rule refuses every create request that REACHES it — creation is possible only where an earlier rule covering the create operation grants it (a rule carrying `operations = ["create"]`, placed ahead of the group-consulting rules, is how an operator permits filing without that grant shadowing reads of existing bugs — issue #26), and a policy with no such grant refuses all creation. **Both refusals are one refusal**: a policy refusal and an upstream failure return the same fixed create_denial text after the same single upstream request — the refused path burns one classify call against bug id 0 (never a valid id, creates nothing; download_attachment's padding precedent) instead of the POST. Two texts, or 0 vs 1 requests, would be a free policy-enumeration oracle: send a guaranteed-invalid `version` plus a probe product and read the policy off which refusal (or which latency) comes back, with nothing created. Residual, accepted: a SUCCESSFUL create still confirms the product is allowed — that is the tool doing its job, and it costs a real, attributable bug; and the padding equalizes request count, not the upstream handler's exact latency (GET classify vs rejected POST). Bugzilla's failure message is logged server-side only (it can say whether a product/component exists) |
 | add_attachment | bug_id, data (base64), file_name, summary, content_type, comment = "", is_private = false, is_patch = false | attach (write) on bug_id | guard assessment before the upload (I8), uniform denial (I2); then global.max_attachment_bytes caps the DECODED size of `data` (0 = no cap) — the ceiling the operator set on downloads binds uploads through the same server too, measured after base64 expansion is stripped so encoding overhead cannot shrink it. The refusal names neither the payload's size nor the cap value (max_attachment_bytes is not I1-disclosable, exactly as on the download path). `comment` travels as a PLAIN string — Bug.add_attachment documents it so; the `{"comment": {"body": ..}}` shape belongs to Bug.update only |
 | add_comment | bug_id, comment, is_private: bool = false | comment (write) | |
@@ -852,6 +857,29 @@ Decisions, all deliberate:
   are deliberately not stored: the schema has no field for either,
   `tracestate` is client free text, and `baggage` is unbounded client
   key/values — revisit under #34.
+- **Search-window drop accounting (issue #29).** A `bugs_quicksearch`
+  record carries `guard.scan = {scanned, dropped}`: how many upstream rows
+  the window scan examined and how many it dropped by verdict — without
+  it, a search that silently withheld many denied rows is
+  indistinguishable in the stream from one that withheld none. Pinned
+  semantics follow what the scan actually classified: overshoot-region
+  denials (past the requested window but inside the quantised chunk) are
+  counted, deduped repeats and id-less rows are not (they never reach a
+  verdict). The field is present on every served `bugs_quicksearch`
+  call — a zero-limit call touches no upstream rows and records
+  `{scanned: 0, dropped: 0}`, and a failed search records no scan (the
+  error discards its partial accounting along with the window) — so on
+  a served search, `dropped: 0` is a statement, not an omission;
+  records from before the field existed deserialize with no scan
+  (optional field, schema still v1). The dropped IDS ride the existing suppressed-ids machinery —
+  unioned into `guard.suppressed_ids` under the same `suppressed_ids`
+  config switch, no second knob — while the counts in `scan` are recorded
+  regardless of that switch. DELIBERATE verdict change: a search whose
+  scan dropped rows now records `served_filtered` (through the worst-wins
+  merge; previously such a call recorded `served`), because a search that
+  withheld rows IS a filtered serve; a clean scan leaves the verdict
+  untouched. Client-invisible by construction (I3): the response is built
+  from the window's bugs alone, byte-identical with or without drops.
 
 ## rmcp 2.2 usage notes
 
@@ -977,7 +1005,12 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   an empty page whether or not bugs were hidden, the scan bound is counted in
   requests, the scan target does not track `limit`, id-less rows are dropped,
   rows repeated across chunks are served once, exhaustion and scan truncation look alike, zero limit
-  touches nothing, and the returned objects are the classified ones;
+  touches nothing (and accounts for nothing), the returned objects are the
+  classified ones, and the scan accounting (issue #29) — `scanned` counts
+  every upstream row examined and `dropped` is exactly the verdict-dropped
+  ids, overshoot-region denials included, id-less rows and deduped repeats
+  excluded, and both accumulate across chunks (a multi-chunk corpus with a
+  drop in each chunk pins the per-chunk `extend`/`+=`);
   assess() deny for embargoed group; min-age deny; one request per distinct
   id whatever the answer (nonexistent vs withheld cost the same), repeated
   ids fetched once, no batch to poison; per-id
@@ -1085,6 +1118,16 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   direct in-process `ServerHandler::call_tool` invocation with the
   traceparent in the params-struct meta and an empty `context.meta`
   pins the `CallToolRequestParams.meta` arm that no serialized
-  transport can exercise.
+  transport can exercise; and search-window drop accounting (issue #29)
+  — a search over hidden rows records `guard.scan` with the exact
+  scanned/dropped counts, the dropped ids in `suppressed_ids`, and
+  verdict `served_filtered`, while the served envelope carries not a
+  byte of accounting and is byte-identical to the same window over an
+  upstream where the hidden rows do not exist; with `suppressed_ids =
+  false` the scan counts and `suppressed_count` survive while the ids
+  are elided; a clean search records `scan.dropped == 0` under verdict
+  `served`; and a pre-#29 record line without `guard.scan`
+  deserializes with the scan absent (plus the cell-level note_scan
+  merge tests and the updated schema golden in audit.rs).
 - CI: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
   `cargo test --workspace --locked`, `cargo deny check`.

--- a/examples/audit.toml
+++ b/examples/audit.toml
@@ -101,5 +101,8 @@ rotate_keep = 8
 # Keep `true` (the default) when the file stays operator-only and you
 # want to answer "which bugs did that agent almost see?"; set `false`
 # when the stream is shipped into a broader log platform where readers
-# are less trusted than the operator. Default: true.
+# are less trusted than the operator. The ids the bugs_quicksearch
+# window scan dropped follow this same switch — there is no second knob
+# — while the scan's counts (`guard.scan.scanned` / `guard.scan.dropped`)
+# are always recorded: counts are not ids. Default: true.
 suppressed_ids = true


### PR DESCRIPTION
Closes #29.

## What

`bugs_quicksearch` audit records now account for what the window scan withheld. `Guard::quicksearch_window` returns a `SearchWindow { bugs, scanned, dropped }` — the served window plus the scan's accounting — and `Guard::filter_bug_list` reports the verdict-dropped **ids** instead of a bare count. The server records the numbers as `guard.scan = {scanned, dropped}` on the tool-call record and feeds the dropped ids through the existing suppressed-ids machinery, so they obey the existing `suppressed_ids` config switch with no second knob, while the counts are recorded regardless of it.

Pinned semantics (documented on `SearchWindow` and in DESIGN.md):

- `scanned` counts every upstream row examined — duplicate and id-less rows included, because each was fetched and looked at.
- `dropped` is exactly the ids the verdict withheld, in scan order: overshoot-region denials (past the requested window but inside the quantised chunk) included; id-less rows and deduped repeats excluded (they never reach a verdict).
- `scan` is present on every served `bugs_quicksearch` call — zero-limit records `{scanned: 0, dropped: 0}`, a failed search records no scan — so on a served search, `dropped: 0` is a statement, not an omission.
- **Deliberate verdict change**: a search whose scan dropped rows now records `served_filtered` (previously `served`) — a search that withheld rows is a filtered serve. A clean scan leaves the verdict untouched.
- Client-invisible by construction (I3): the response is built from the window's bugs alone; a byte-identity test (and a dedicated mutation, below) enforces it.
- Records written before the field existed still deserialize (`scan` optional-and-absent-when-unset, schema stays v1; the pre-#29 golden bytes are pinned as `GOLDEN_TOOL_CALL_PRE_SCAN` with an old-line deserialization test, and the schema-goldens discipline comment now states this additive exception explicitly).

Acceptance criteria from the issue, each pinned by a test:

- a search whose window drops denied rows records a non-zero drop count → `quicksearch_scan_accounting_reaches_the_record_never_the_envelope`;
- the client-visible response is byte-identical → `quicksearch_response_is_byte_identical_whether_or_not_rows_were_dropped` (mixed-vs-clean upstream, auditing on);
- with suppressed-id recording off, the count is still recorded but the ids are not → `quicksearch_drop_count_survives_the_suppressed_ids_knob`.

`examples/audit.toml` documents that the scan-dropped ids follow the `suppressed_ids` switch (counts always recorded); DESIGN.md gains the audit-stream bullet and extended testing bars.

## Adversarial review record

Implemented via fan-out (implementer → security-bypass / correctness-fail-closed / docs-vs-code lenses + mutation verifier → fixer), findings addressed before this PR was opened. 4 findings, all minor, all fixed:

1. **Schema-goldens comment contradicted the in-place golden update** (security + docs lenses, independently). The stability-gate comment forbade updating `GOLDEN_TOOL_CALL` without a version bump, while the change did exactly that (legitimately — additive optional field, blessed by DESIGN.md). Fixed: the comment now states the practiced rule — an optional, absent-when-unset field stays within v1, updates the golden, and must pin the prior bytes as a `GOLDEN_*_PRE_*` constant with an old-line deserialization test; any other byte change still requires a version bump.
2. **DESIGN.md overclaimed "present exactly when a window scan ran"** (docs lens) — false in both directions: a failed search discards its partial accounting with the error, and a zero-limit call records `{0, 0}` without touching upstream. Fixed: DESIGN.md now states the exact presence rule.
3. **No test covered accounting accumulation across scan chunks** (correctness lens) — all initial fixtures fit in one 200-row chunk, so a per-chunk reset of either counter would have survived the suite. Fixed: `quicksearch_window_accounting_accumulates_across_chunks` (250-row corpus, one hidden id in each chunk) pins the per-chunk `extend`/`+=`; both reset-mutants re-proved killed in a throwaway worktree.

## Mutation verification

16 mutants, 16 killed, 0 survivors: ids never collected; `scanned` counting kept instead of examined rows; `scanned` counting post-dedupe rows; `note_scan` never called; `note_suppressed(dropped)` removed; verdict upgraded on a clean scan; verdict not upgraded on a dropping scan; suppressed-ids config gate inverted; `scan` never serialized; **accounting leaked into the envelope under a fresh key — killed solely by the byte-identity test, proving it load-bearing for I3**; drop count zeroed at the call site; first-write-wins in `note_scan`; cell state never drained into the record; dropped ids replaced with zeros (killed by the exact-id-list assertions); plus the two per-chunk reset mutants from finding 3.

## Gate

`cargo fmt --all --check` · `cargo clippy --workspace --all-targets -- -D warnings` · `cargo test --workspace --all-targets --locked` (342 passed, 0 failed) · `cargo deny check` (advisories/bans/licenses/sources ok) · `typos` — all green, re-run independently after the review fixes.
