### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "bugwarden"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "bugwarden-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Martin Pluskal <martin@pluskal.org>"]

--- a/crates/bugwarden-core/Cargo.toml
+++ b/crates/bugwarden-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bugwarden-core"
-version = "0.2.0"
+version = "0.3.0"
 description = "Guard policy engine and async Bugzilla REST client for the bugwarden MCP server"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["command-line-utilities", "web-programming::http-server"]
 workspace = true
 
 [dependencies]
-bugwarden-core = { path = "../bugwarden-core", version = "0.2.0" }
+bugwarden-core = { path = "../bugwarden-core", version = "0.3.0" }
 
 rmcp = { version = "2.2", features = [
     "server",


### PR DESCRIPTION
Release bump for 0.3.0, per the release process in AGENTS.md: the tag must equal `[workspace.package]` version, bumped in a normal PR first.

Since 0.2.0 (all on main): server-held Bugzilla API key via `--api-key-file` (#27), `created_by_me` identity-relative matcher (#26), operation-scoped policy rules so create cannot shadow reads (#30), widened `update_bug_fields` audit (#38), audit trace context from `_meta` traceparent (#28), search-window drop accounting (#29), README install instructions (#33).

Mechanical change: workspace version, `bugwarden-core` version + its dependency pin, `Cargo.lock`. Full gate green: fmt, clippy `-D warnings`, 342 tests `--locked`, `cargo deny`, typos.