### PR TITLE
feat: generate man page and shell completions from the CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
         run: cargo fmt --check
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Clippy (gen tool)
+        # --all-targets skips bins whose required-features are off, so the
+        # asset generator needs its own leg to stay warning-free.
+        run: cargo clippy -p bugwarden --features gen --all-targets -- -D warnings
       - name: Test
         run: cargo test --workspace --all-targets --locked
 
@@ -138,3 +142,41 @@ jobs:
           workspaces: . -> target
       - name: Build (MSRV)
         run: cargo build --workspace --locked
+
+  rust-assets-drift:
+    # Regenerate the committed man page + shell completions from the clap CLI
+    # and fail if they drift.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
+        with:
+          # Keep in sync with rust-toolchain.toml.
+          toolchain: "1.97.0"
+      - name: Cache cargo
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: . -> target
+      - name: Regenerate man page + completions
+        # Start from empty directories so an asset the generator no longer
+        # emits surfaces as a deletion in the drift diff instead of shipping
+        # stale forever.
+        run: |
+          rm -rf crates/bugwarden/man crates/bugwarden/completions
+          cargo run --locked -p bugwarden --features gen --bin bugwarden-gen
+      - name: Check for drift
+        # Fail on modified tracked assets AND on untracked leftovers (e.g. a
+        # renamed page that regeneration no longer produces/overwrites).
+        run: |
+          git diff --exit-code -- crates/bugwarden/man crates/bugwarden/completions
+          untracked="$(git status --porcelain -- crates/bugwarden/man crates/bugwarden/completions)"
+          if [ -n "$untracked" ]; then
+            echo "::error::untracked generated assets:"
+            echo "$untracked"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,9 @@ jobs:
           cp target/release/bugwarden LICENSE README.md "$dist/"
           mkdir "$dist/examples"
           cp examples/policy.toml "$dist/examples/"
+          # Committed generated assets, kept in sync by the rust-assets-drift
+          # CI job (`cp -R` exists on both the ubuntu and macOS runners).
+          cp -R crates/bugwarden/man crates/bugwarden/completions "$dist/"
           tar czf "${dist}.tar.gz" "$dist"
           # shasum -a 256 exists on both the ubuntu and macOS runners and its
           # output is compatible with `sha256sum -c`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Run commands from the repository root:
 ```bash
 cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy -p bugwarden --features gen --all-targets -- -D warnings
 cargo test --workspace --all-targets --locked
 cargo deny check
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,8 @@ dependencies = [
  "bugwarden-core",
  "chrono",
  "clap",
+ "clap_complete",
+ "clap_mangen",
  "reqwest 0.13.4",
  "rmcp",
  "schemars",
@@ -323,6 +325,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +350,16 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clap_mangen"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "cmake"
@@ -1489,6 +1510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,7 +1598,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2381,7 +2408,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -12,6 +12,24 @@ readme = "README.md"
 keywords = ["bugzilla", "mcp", "llm", "security", "server"]
 categories = ["command-line-utilities", "web-programming::http-server"]
 
+# Two bins live here once the gen feature is on; a bare `cargo run -p
+# bugwarden` must mean the shipped binary.
+default-run = "bugwarden"
+
+[[bin]]
+name = "bugwarden"
+path = "src/main.rs"
+
+# Dev/packaging asset generator; built only with `--features gen` so the
+# shipped `bugwarden` binary never drags in clap_complete/clap_mangen.
+[[bin]]
+name = "bugwarden-gen"
+path = "src/bin/bugwarden-gen.rs"
+required-features = ["gen"]
+
+[features]
+gen = ["dep:clap_complete", "dep:clap_mangen"]
+
 [lints]
 workspace = true
 
@@ -37,6 +55,8 @@ thiserror = "2"
 toml = "1.1"
 
 clap = { version = "4", features = ["derive", "env"] }
+clap_complete = { version = "4", optional = true }
+clap_mangen = { version = "0.3", optional = true }
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/bugwarden/completions/_bugwarden
+++ b/crates/bugwarden/completions/_bugwarden
@@ -1,0 +1,47 @@
+#compdef bugwarden
+
+autoload -U is-at-least
+
+_bugwarden() {
+    typeset -A opt_args
+    typeset -a _arguments_options
+    local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
+    local context curcontext="$curcontext" state line
+    _arguments "${_arguments_options[@]}" : \
+'--bugzilla-server=[Base URL of the Bugzilla server (e.g., '\''https\://bugzilla.example.com'\''). Environment variable BUGZILLA_SERVER is used if the argument is not provided]:BUGZILLA_SERVER:_default' \
+'--transport=[Transport for the MCP server\: '\''http'\'' (default) or '\''stdio'\''. Environment variable MCP_TRANSPORT can also be used]:TRANSPORT:((http\:"Streamable HTTP transport (default). Clients send the Bugzilla API key per-request via the API key header, unless \`--api-key-file\` selects server-held key mode (then the header is not consulted at all)"
+stdio\:"Stdio transport. The API key comes from \`--api-key\` / \`BUGZILLA_API_KEY\` or \`--api-key-file\` at startup"))' \
+'--host=[Host address for the MCP server to listen on (http transport only). Defaults to 127.0.0.1 or the MCP_HOST environment variable]:HOST:_default' \
+'--port=[Port for the MCP server to listen on (http transport only). Defaults to 8000 or the MCP_PORT environment variable]:PORT:_default' \
+'--api-key-header=[HTTP header for clients to send the Bugzilla API key. Defaults to '\''ApiKey'\'' or the MCP_API_KEY_HEADER environment variable. Not consulted in server-held key mode (--api-key-file over http)]:API_KEY_HEADER:_default' \
+'--api-key=[Bugzilla API key. Required for --transport stdio (no HTTP headers exist there) unless --api-key-file provides it. Environment variable BUGZILLA_API_KEY can also be used. Ignored for --transport http (clients send the key per-request via the API key header; use --api-key-file for a server-held key)]:API_KEY:_default' \
+'--api-key-file=[Path to a file holding the Bugzilla API key (e.g. a container secret or systemd LoadCredential path). Mutually exclusive with --api-key. Over http this selects server-held key mode\: every request is served with this key and the per-request API key header is not consulted. An empty value counts as absent, like --api-key (so \`BUGZILLA_API_KEY_FILE=\` is an unset, not an error)]:API_KEY_FILE:_files' \
+'--policy=[Path to the guard policy TOML file. Environment variable BUGWARDEN_POLICY can also be used. Without it an allow-all default policy is used]:POLICY:_files' \
+'--audit-config=[Path to the audit configuration TOML file (see examples/audit.toml). Environment variable BUGWARDEN_AUDIT_CONFIG can also be used. Without it no audit stream is written]:AUDIT_CONFIG:_files' \
+'--use-auth-header[Use '\''Authorization\: Bearer'\'' header instead of the api_key query parameter (required for some Bugzilla instances)]' \
+'--read-only[Disables all tools which modify the state of a bug. Environment variable MCP_READ_ONLY=true can also be used. Can only tighten the guard policy, never loosen it]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+}
+
+(( $+functions[_bugwarden_commands] )) ||
+_bugwarden_commands() {
+    local commands; commands=()
+    _describe -t commands 'bugwarden commands' commands "$@"
+}
+
+if [ "$funcstack[1]" = "_bugwarden" ]; then
+    _bugwarden "$@"
+else
+    compdef _bugwarden bugwarden
+fi

--- a/crates/bugwarden/completions/bugwarden.bash
+++ b/crates/bugwarden/completions/bugwarden.bash
@@ -1,0 +1,115 @@
+_bugwarden() {
+    local i cur prev opts cmd
+    COMPREPLY=()
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
+    cmd=""
+    opts=""
+
+    for i in "${COMP_WORDS[@]:0:COMP_CWORD}"
+    do
+        case "${cmd},${i}" in
+            ",$1")
+                cmd="bugwarden"
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    case "${cmd}" in
+        bugwarden)
+            opts="-h -V --bugzilla-server --transport --host --port --api-key-header --api-key --api-key-file --use-auth-header --read-only --policy --audit-config --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --bugzilla-server)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --transport)
+                    COMPREPLY=($(compgen -W "http stdio" -- "${cur}"))
+                    return 0
+                    ;;
+                --host)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --port)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --api-key-header)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --api-key)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --api-key-file)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --policy)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --audit-config)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+    esac
+}
+
+if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
+    complete -F _bugwarden -o nosort -o bashdefault -o default bugwarden
+else
+    complete -F _bugwarden -o bashdefault -o default bugwarden
+fi

--- a/crates/bugwarden/completions/bugwarden.fish
+++ b/crates/bugwarden/completions/bugwarden.fish
@@ -1,0 +1,14 @@
+complete -c bugwarden -l bugzilla-server -d 'Base URL of the Bugzilla server (e.g., \'https://bugzilla.example.com\'). Environment variable BUGZILLA_SERVER is used if the argument is not provided' -r
+complete -c bugwarden -l transport -d 'Transport for the MCP server: \'http\' (default) or \'stdio\'. Environment variable MCP_TRANSPORT can also be used' -r -f -a "http\t'Streamable HTTP transport (default). Clients send the Bugzilla API key per-request via the API key header, unless `--api-key-file` selects server-held key mode (then the header is not consulted at all)'
+stdio\t'Stdio transport. The API key comes from `--api-key` / `BUGZILLA_API_KEY` or `--api-key-file` at startup'"
+complete -c bugwarden -l host -d 'Host address for the MCP server to listen on (http transport only). Defaults to 127.0.0.1 or the MCP_HOST environment variable' -r
+complete -c bugwarden -l port -d 'Port for the MCP server to listen on (http transport only). Defaults to 8000 or the MCP_PORT environment variable' -r
+complete -c bugwarden -l api-key-header -d 'HTTP header for clients to send the Bugzilla API key. Defaults to \'ApiKey\' or the MCP_API_KEY_HEADER environment variable. Not consulted in server-held key mode (--api-key-file over http)' -r
+complete -c bugwarden -l api-key -d 'Bugzilla API key. Required for --transport stdio (no HTTP headers exist there) unless --api-key-file provides it. Environment variable BUGZILLA_API_KEY can also be used. Ignored for --transport http (clients send the key per-request via the API key header; use --api-key-file for a server-held key)' -r
+complete -c bugwarden -l api-key-file -d 'Path to a file holding the Bugzilla API key (e.g. a container secret or systemd LoadCredential path). Mutually exclusive with --api-key. Over http this selects server-held key mode: every request is served with this key and the per-request API key header is not consulted. An empty value counts as absent, like --api-key (so `BUGZILLA_API_KEY_FILE=` is an unset, not an error)' -r -F
+complete -c bugwarden -l policy -d 'Path to the guard policy TOML file. Environment variable BUGWARDEN_POLICY can also be used. Without it an allow-all default policy is used' -r -F
+complete -c bugwarden -l audit-config -d 'Path to the audit configuration TOML file (see examples/audit.toml). Environment variable BUGWARDEN_AUDIT_CONFIG can also be used. Without it no audit stream is written' -r -F
+complete -c bugwarden -l use-auth-header -d 'Use \'Authorization: Bearer\' header instead of the api_key query parameter (required for some Bugzilla instances)'
+complete -c bugwarden -l read-only -d 'Disables all tools which modify the state of a bug. Environment variable MCP_READ_ONLY=true can also be used. Can only tighten the guard policy, never loosen it'
+complete -c bugwarden -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c bugwarden -s V -l version -d 'Print version'

--- a/crates/bugwarden/man/bugwarden.1
+++ b/crates/bugwarden/man/bugwarden.1
@@ -1,0 +1,175 @@
+.TH bugwarden 1 "" "bugwarden 0.3.0" "General Commands Manual"
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.SH NAME
+bugwarden \- MCP server for Bugzilla with operator\-controlled security guards
+.SH SYNOPSIS
+\fBbugwarden\fR
+\fB\-\-bugzilla\-server\fR <BUGZILLA_SERVER>
+[\fB\-\-transport\fR <TRANSPORT>]
+[\fB\-\-host\fR <HOST>]
+[\fB\-\-port\fR <PORT>]
+[\fB\-\-api\-key\-header\fR <API_KEY_HEADER>]
+[\fB\-\-api\-key\fR <API_KEY>]
+[\fB\-\-api\-key\-file\fR <API_KEY_FILE>]
+[\fB\-\-use\-auth\-header\fR]
+[\fB\-\-read\-only\fR]
+[\fB\-\-policy\fR <POLICY>]
+[\fB\-\-audit\-config\fR <AUDIT_CONFIG>]
+[\fB\-h\fR|\fB\-\-help\fR]
+[\fB\-V\fR|\fB\-\-version\fR]
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.SH DESCRIPTION
+MCP server for Bugzilla with operator\-controlled security guards
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.SH OPTIONS
+.TP
+\fB\-\-bugzilla\-server\fR \fI<BUGZILLA_SERVER>\fR
+Base URL of the Bugzilla server (e.g., \*(Aqhttps://bugzilla.example.com\*(Aq). Environment variable BUGZILLA_SERVER is used if the argument is not provided
+.TP
+\fB\-\-transport\fR \fI<TRANSPORT>\fR [default: http]
+Transport for the MCP server: \*(Aqhttp\*(Aq (default) or \*(Aqstdio\*(Aq. Environment variable MCP_TRANSPORT can also be used
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+http: Streamable HTTP transport (default). Clients send the Bugzilla API key per\-request via the API key header, unless `\-\-api\-key\-file` selects server\-held key mode (then the header is not consulted at all)
+.IP \(bu 2
+stdio: Stdio transport. The API key comes from `\-\-api\-key` / `BUGZILLA_API_KEY` or `\-\-api\-key\-file` at startup
+.RE
+.TP
+\fB\-\-host\fR \fI<HOST>\fR [default: 127.0.0.1]
+Host address for the MCP server to listen on (http transport only). Defaults to 127.0.0.1 or the MCP_HOST environment variable
+.TP
+\fB\-\-port\fR \fI<PORT>\fR [default: 8000]
+Port for the MCP server to listen on (http transport only). Defaults to 8000 or the MCP_PORT environment variable
+.TP
+\fB\-\-api\-key\-header\fR \fI<API_KEY_HEADER>\fR [default: ApiKey]
+HTTP header for clients to send the Bugzilla API key. Defaults to \*(AqApiKey\*(Aq or the MCP_API_KEY_HEADER environment variable. Not consulted in server\-held key mode (\-\-api\-key\-file over http)
+.TP
+\fB\-\-api\-key\fR \fI<API_KEY>\fR
+Bugzilla API key. Required for \-\-transport stdio (no HTTP headers exist there) unless \-\-api\-key\-file provides it. Environment variable BUGZILLA_API_KEY can also be used. Ignored for \-\-transport http (clients send the key per\-request via the API key header; use \-\-api\-key\-file for a server\-held key)
+.TP
+\fB\-\-api\-key\-file\fR \fI<API_KEY_FILE>\fR
+Path to a file holding the Bugzilla API key (e.g. a container secret or systemd LoadCredential path). Mutually exclusive with \-\-api\-key. Over http this selects server\-held key mode: every request is served with this key and the per\-request API key header is not consulted. An empty value counts as absent, like \-\-api\-key (so `BUGZILLA_API_KEY_FILE=` is an unset, not an error)
+.TP
+\fB\-\-use\-auth\-header\fR
+Use \*(AqAuthorization: Bearer\*(Aq header instead of the api_key query parameter (required for some Bugzilla instances)
+.TP
+\fB\-\-read\-only\fR
+Disables all tools which modify the state of a bug. Environment variable MCP_READ_ONLY=true can also be used. Can only tighten the guard policy, never loosen it
+.TP
+\fB\-\-policy\fR \fI<POLICY>\fR
+Path to the guard policy TOML file. Environment variable BUGWARDEN_POLICY can also be used. Without it an allow\-all default policy is used
+.TP
+\fB\-\-audit\-config\fR \fI<AUDIT_CONFIG>\fR
+Path to the audit configuration TOML file (see examples/audit.toml). Environment variable BUGWARDEN_AUDIT_CONFIG can also be used. Without it no audit stream is written
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version
+.SH EXIT STATUS
+.TP
+.B 0
+Clean shutdown.
+.TP
+.B 1
+Startup or runtime failure: an unreadable policy or audit configuration, a
+key misconfiguration, a Bugzilla client or transport error.
+.TP
+.B 2
+Command\-line usage error.
+.SH ENVIRONMENT
+Each variable is the fallback for one option; a command\-line argument
+always wins over the environment, and the built\-in default applies when
+neither is given.
+.TP
+.B BUGZILLA_SERVER
+Fallback for \fB\-\-bugzilla\-server\fR.
+.TP
+.B MCP_TRANSPORT
+Fallback for \fB\-\-transport\fR.
+.TP
+.B MCP_HOST
+Fallback for \fB\-\-host\fR.
+.TP
+.B MCP_PORT
+Fallback for \fB\-\-port\fR.
+.TP
+.B MCP_API_KEY_HEADER
+Fallback for \fB\-\-api\-key\-header\fR.
+.TP
+.B BUGZILLA_API_KEY
+Fallback for \fB\-\-api\-key\fR.
+.TP
+.B BUGZILLA_API_KEY_FILE
+Fallback for \fB\-\-api\-key\-file\fR.
+.TP
+.B MCP_READ_ONLY
+Fallback for \fB\-\-read\-only\fR.
+.TP
+.B BUGWARDEN_POLICY
+Fallback for \fB\-\-policy\fR.
+.TP
+.B BUGWARDEN_AUDIT_CONFIG
+Fallback for \fB\-\-audit\-config\fR.
+.SH FILES
+.TP
+.I /etc/bugwarden/policy.toml
+Worked example guard policy as installed by distribution packages; the
+source tree and release archives ship it as
+.IR examples/policy.toml .
+The server reads a policy only when one is named with
+.B \-\-policy
+or
+.BR BUGWARDEN_POLICY ;
+without one the built\-in allow\-all default policy applies.
+.TP
+.I /etc/bugwarden/audit.toml
+Worked example audit configuration; the source tree ships it as
+.IR examples/audit.toml .
+Without
+.B \-\-audit\-config
+or
+.B BUGWARDEN_AUDIT_CONFIG
+no audit stream is written.
+.SH EXAMPLES
+Serve a local MCP client over stdio, the server reading the Bugzilla API
+key from a file:
+.PP
+.RS 4
+.nf
+bugwarden \-\-transport stdio \e
+    \-\-bugzilla\-server https://bugzilla.example.com \e
+    \-\-api\-key\-file ~/.config/bugwarden/api\-key \e
+    \-\-policy /etc/bugwarden/policy.toml
+.fi
+.RE
+.PP
+Listen on HTTP (the default transport, 127.0.0.1:8000), each client
+presenting its own key in the API key header:
+.PP
+.RS 4
+.nf
+bugwarden \-\-bugzilla\-server https://bugzilla.example.com \e
+    \-\-policy /etc/bugwarden/policy.toml
+.fi
+.RE
+.PP
+Listen on HTTP with a server\-held key (container secret, systemd
+LoadCredential): every request is served with this key and the per\-request
+key header is not consulted:
+.PP
+.RS 4
+.nf
+bugwarden \-\-bugzilla\-server https://bugzilla.example.com \e
+    \-\-api\-key\-file /run/secrets/bugzilla\-api\-key \e
+    \-\-policy /etc/bugwarden/policy.toml
+.fi
+.RE

--- a/crates/bugwarden/src/bin/bugwarden-gen.rs
+++ b/crates/bugwarden/src/bin/bugwarden-gen.rs
@@ -1,0 +1,205 @@
+//! Dev/packaging tool: regenerate the committed man page and shell
+//! completions from the `bugwarden` CLI definition. CI runs this and diffs
+//! the output so the assets never drift. Built only with `--features gen`.
+
+#![forbid(unsafe_code)]
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+fn main() -> std::process::ExitCode {
+    // args_os: the argument is a path, which need not be UTF-8. The default
+    // is the crate directory baked in at compile time, so the tool writes
+    // the committed asset dirs no matter which cwd it runs from.
+    let out = std::env::args_os()
+        .nth(1)
+        .map_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")), PathBuf::from);
+    match generate(&out) {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::ExitCode::from(2)
+        }
+    }
+}
+
+fn generate(out: &Path) -> std::io::Result<()> {
+    let man_dir = out.join("man");
+    let comp_dir = out.join("completions");
+    std::fs::create_dir_all(&man_dir)?;
+    std::fs::create_dir_all(&comp_dir)?;
+
+    let mut cmd = bugwarden::config::command();
+    cmd.build();
+    std::fs::write(man_dir.join("bugwarden.1"), render_man(&cmd)?)?;
+    for shell in [
+        clap_complete::Shell::Bash,
+        clap_complete::Shell::Zsh,
+        clap_complete::Shell::Fish,
+    ] {
+        clap_complete::generate_to(shell, &mut cmd, "bugwarden", &comp_dir)?;
+    }
+    Ok(())
+}
+
+/// The clap_mangen render of the derive, with the sections the derive cannot
+/// express interleaved at their man-pages(7) positions. SYNOPSIS and
+/// ENVIRONMENT are derived from the same command so they cannot drift from
+/// `config.rs`; the hand-authored sections state only facts the derive has
+/// no field for.
+fn render_man(cmd: &clap::Command) -> std::io::Result<Vec<u8>> {
+    let man = clap_mangen::Man::new(cmd.clone());
+    let mut buf = Vec::new();
+    // Hand-written .TH: clap_mangen leaves an empty date argument unquoted,
+    // shifting source and manual one slot left. The date stays empty on
+    // purpose — a generation date would make every CI regeneration differ
+    // from the committed page and trip the drift gate — and the version
+    // lives in the source field, so no separate VERSION section is rendered.
+    writeln!(
+        buf,
+        ".TH bugwarden 1 \"\" \"bugwarden {}\" \"General Commands Manual\"",
+        cmd.get_version().unwrap_or_default()
+    )?;
+    man.render_name_section(&mut buf)?;
+    render_synopsis(cmd, &mut buf)?;
+    man.render_description_section(&mut buf)?;
+    man.render_options_section(&mut buf)?;
+    buf.write_all(EXIT_STATUS.as_bytes())?;
+    render_environment(cmd, &mut buf)?;
+    buf.write_all(FILES.as_bytes())?;
+    buf.write_all(EXAMPLES.as_bytes())?;
+    Ok(buf)
+}
+
+/// Derived synopsis with the value placeholders clap_mangen's own synopsis
+/// omits (it prints a bare `[--transport]`, hiding which options take a
+/// value, and renders the required option as `<--bugzilla-server>`).
+fn render_synopsis(cmd: &clap::Command, buf: &mut Vec<u8>) -> std::io::Result<()> {
+    writeln!(buf, ".SH SYNOPSIS")?;
+    writeln!(buf, "\\fBbugwarden\\fR")?;
+    for arg in cmd.get_arguments() {
+        if arg.get_id() == "help" || arg.get_id() == "version" {
+            continue;
+        }
+        let long = arg
+            .get_long()
+            .expect("every bugwarden option is a long option")
+            .replace('-', "\\-");
+        let mut piece = format!("\\fB\\-\\-{long}\\fR");
+        if arg.get_num_args().is_some_and(|n| n.takes_values()) {
+            let metavar = arg
+                .get_value_names()
+                .and_then(|names| names.first().map(ToString::to_string))
+                .unwrap_or_else(|| arg.get_id().as_str().to_uppercase());
+            piece.push_str(&format!(" <{metavar}>"));
+        }
+        if arg.is_required_set() {
+            writeln!(buf, "{piece}")?;
+        } else {
+            writeln!(buf, "[{piece}]")?;
+        }
+    }
+    writeln!(buf, "[\\fB\\-h\\fR|\\fB\\-\\-help\\fR]")?;
+    writeln!(buf, "[\\fB\\-V\\fR|\\fB\\-\\-version\\fR]")?;
+    Ok(())
+}
+
+/// One entry per option that has an environment fallback, straight off the
+/// clap command.
+fn render_environment(cmd: &clap::Command, buf: &mut Vec<u8>) -> std::io::Result<()> {
+    writeln!(buf, ".SH ENVIRONMENT")?;
+    writeln!(
+        buf,
+        "Each variable is the fallback for one option; a command\\-line argument"
+    )?;
+    writeln!(
+        buf,
+        "always wins over the environment, and the built\\-in default applies when"
+    )?;
+    writeln!(buf, "neither is given.")?;
+    for arg in cmd.get_arguments() {
+        let Some(env) = arg.get_env() else { continue };
+        let long = arg
+            .get_long()
+            .expect("every bugwarden option is a long option");
+        writeln!(buf, ".TP")?;
+        writeln!(buf, ".B {}", env.to_string_lossy())?;
+        writeln!(
+            buf,
+            "Fallback for \\fB\\-\\-{}\\fR.",
+            long.replace('-', "\\-")
+        )?;
+    }
+    Ok(())
+}
+
+const EXIT_STATUS: &str = r".SH EXIT STATUS
+.TP
+.B 0
+Clean shutdown.
+.TP
+.B 1
+Startup or runtime failure: an unreadable policy or audit configuration, a
+key misconfiguration, a Bugzilla client or transport error.
+.TP
+.B 2
+Command\-line usage error.
+";
+
+const FILES: &str = r".SH FILES
+.TP
+.I /etc/bugwarden/policy.toml
+Worked example guard policy as installed by distribution packages; the
+source tree and release archives ship it as
+.IR examples/policy.toml .
+The server reads a policy only when one is named with
+.B \-\-policy
+or
+.BR BUGWARDEN_POLICY ;
+without one the built\-in allow\-all default policy applies.
+.TP
+.I /etc/bugwarden/audit.toml
+Worked example audit configuration; the source tree ships it as
+.IR examples/audit.toml .
+Without
+.B \-\-audit\-config
+or
+.B BUGWARDEN_AUDIT_CONFIG
+no audit stream is written.
+";
+
+const EXAMPLES: &str = r".SH EXAMPLES
+Serve a local MCP client over stdio, the server reading the Bugzilla API
+key from a file:
+.PP
+.RS 4
+.nf
+bugwarden \-\-transport stdio \e
+    \-\-bugzilla\-server https://bugzilla.example.com \e
+    \-\-api\-key\-file ~/.config/bugwarden/api\-key \e
+    \-\-policy /etc/bugwarden/policy.toml
+.fi
+.RE
+.PP
+Listen on HTTP (the default transport, 127.0.0.1:8000), each client
+presenting its own key in the API key header:
+.PP
+.RS 4
+.nf
+bugwarden \-\-bugzilla\-server https://bugzilla.example.com \e
+    \-\-policy /etc/bugwarden/policy.toml
+.fi
+.RE
+.PP
+Listen on HTTP with a server\-held key (container secret, systemd
+LoadCredential): every request is served with this key and the per\-request
+key header is not consulted:
+.PP
+.RS 4
+.nf
+bugwarden \-\-bugzilla\-server https://bugzilla.example.com \e
+    \-\-api\-key\-file /run/secrets/bugzilla\-api\-key \e
+    \-\-policy /etc/bugwarden/policy.toml
+.fi
+.RE
+";

--- a/crates/bugwarden/src/config.rs
+++ b/crates/bugwarden/src/config.rs
@@ -20,11 +20,13 @@ pub enum Transport {
     Stdio,
 }
 
-/// MCP server for Bugzilla interaction, with operator-controlled security
-/// guards.
-///
-/// `Debug` is implemented by hand to redact `api_key`: the struct holds the
-/// startup key, and key material must never reach logs or error text (I12).
+/// MCP server for Bugzilla with operator-controlled security guards.
+// What `--help` and the man page show is `description` from Cargo.toml (the
+// bare `about` attribute below): with a single-paragraph doc comment clap
+// derives no long_about. Keep this comment to ONE paragraph mirroring that
+// description — a second paragraph resurrects the whole comment as
+// long_about in `--help`, which is how the I12 Debug-redaction note once
+// leaked there (that note lives on the `Debug` impl below).
 #[derive(Parser)]
 #[command(name = "bugwarden", version, about)]
 pub struct Cli {
@@ -72,6 +74,7 @@ pub struct Cli {
     #[arg(
         long,
         env = "BUGZILLA_API_KEY_FILE",
+        value_hint = clap::ValueHint::FilePath,
         value_parser = clap::builder::OsStringValueParser::new().map(PathBuf::from)
     )]
     pub api_key_file: Option<PathBuf>,
@@ -90,13 +93,13 @@ pub struct Cli {
     /// Path to the guard policy TOML file. Environment variable
     /// BUGWARDEN_POLICY can also be used. Without it an allow-all default
     /// policy is used.
-    #[arg(long, env = "BUGWARDEN_POLICY")]
+    #[arg(long, env = "BUGWARDEN_POLICY", value_hint = clap::ValueHint::FilePath)]
     pub policy: Option<PathBuf>,
 
     /// Path to the audit configuration TOML file (see examples/audit.toml).
     /// Environment variable BUGWARDEN_AUDIT_CONFIG can also be used.
     /// Without it no audit stream is written.
-    #[arg(long, env = "BUGWARDEN_AUDIT_CONFIG")]
+    #[arg(long, env = "BUGWARDEN_AUDIT_CONFIG", value_hint = clap::ValueHint::FilePath)]
     pub audit_config: Option<PathBuf>,
 }
 
@@ -118,6 +121,14 @@ impl std::fmt::Debug for Cli {
             .field("audit_config", &self.audit_config)
             .finish()
     }
+}
+
+/// The clap command for the `bugwarden` binary — the single definition the
+/// server parses and `bugwarden-gen` renders into the man page and shell
+/// completions.
+pub fn command() -> clap::Command {
+    use clap::CommandFactory as _;
+    Cli::command()
 }
 
 /// Who holds the Bugzilla API key, resolved exactly once at startup.

--- a/typos.toml
+++ b/typos.toml
@@ -4,7 +4,12 @@
 # once its last real occurrence is gone, and say so.
 
 [files]
-extend-exclude = []
+extend-exclude = [
+  # Generated from the clap CLI (see the rust-assets-drift job); the authored
+  # source that produces them is still spell-checked.
+  "crates/bugwarden/completions/**",
+  "crates/bugwarden/man/**",
+]
 
 [default.extend-words]
 # glob_match backtracking test data in bugwarden-core/src/policy.rs: the


### PR DESCRIPTION
Closes #48.

A feature-gated `bugwarden-gen` binary (`--features gen`) renders the man
page and bash/zsh/fish completions from the one clap `Cli` definition; the
assets are committed under `crates/bugwarden/{man,completions}` and a
`rust-assets-drift` CI job regenerates them into emptied directories and
fails on any difference — a flag added without regeneration, a hand-edited
asset, a stray leftover, or an output the generator stopped emitting. The
shipped server binary is unchanged: `clap_complete`/`clap_mangen` exist
only behind the `gen` feature, so the default dependency graph and the
distributed binary's licence aggregate do not move.

Also in scope:

- The `Cli` struct doc comment leaked the internal I12 Debug-redaction
  note into `--help` (clap derives `long_about` from multi-paragraph doc
  comments); it is trimmed to the public one-liner, and the note stays on
  the `Debug` impl.
- Path-taking options gain `ValueHint::FilePath`, so completions offer
  filenames after `--policy`, `--audit-config`, `--api-key-file`.
- `default-run = "bugwarden"` keeps a bare `cargo run -p bugwarden`
  meaning the server binary.
- The man page derives SYNOPSIS (with the value placeholders clap_mangen's
  own render omits) and ENVIRONMENT from the live command; EXIT STATUS,
  FILES and EXAMPLES are the only hand-authored sections, and their claims
  were verified against the actual exit codes, the release tarball
  contents, and real invocations.
- Release tarballs bundle `man/` and `completions/` next to `examples/`;
  AGENTS.md gains the gen-tool clippy gate.

Adversarial review ran with mutation verification: the drift gate was
proven to catch an unregenerated new flag, a tampered asset, a stray file,
and a dropped output; regeneration is byte-idempotent and deterministic
under a hostile environment (key variables set, non-C locale), and the
default build contains neither generator dependency.