### PR TITLE
refactor(audit): hex-encode the policy digest without LowerHex

### DIFF
--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -1040,7 +1040,21 @@ pub struct AuditState {
 /// carries. The digest is over the raw file bytes, not any parsed form,
 /// so a record ties to the exact document the operator deployed.
 pub fn policy_hash_of(bytes: &[u8]) -> String {
-    format!("sha256:{:x}", Sha256::digest(bytes))
+    use std::fmt::Write as _;
+
+    // Hex-encode the bytes here rather than formatting the digest with
+    // `{:x}`: the `LowerHex` impl belongs to generic-array's
+    // `GenericArray`, which is sha2 0.10's output type, and 0.11's
+    // hybrid-array `Array` has none — so formatting the digest itself
+    // pins the crate to a major version.
+    let digest = Sha256::digest(bytes);
+    let mut hash = String::with_capacity("sha256:".len() + digest.len() * 2);
+    hash.push_str("sha256:");
+    for byte in &digest {
+        // Writing to a String cannot fail.
+        let _ = write!(hash, "{byte:02x}");
+    }
+    hash
 }
 
 impl AuditState {
@@ -2332,5 +2346,26 @@ mod tests {
             policy_hash_of(b"abc"),
             "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
         );
+    }
+
+    #[test]
+    fn policy_hash_of_is_fixed_width_lowercase_hex() {
+        // The vector above pins one exact value; this pins the encoding
+        // for inputs of every length up to a block and a bit. Of these 65
+        // digests 55 carry a byte below 0x10 and all 65 carry one above
+        // 0x9f, so a dropped zero pad shortens the string here and an
+        // uppercase digit surfaces here — whichever input hits it.
+        for len in 0..=64 {
+            let hash = policy_hash_of(&vec![b'x'; len]);
+            let hex = hash
+                .strip_prefix("sha256:")
+                .expect("every hash carries the algorithm prefix");
+            assert_eq!(hex.len(), 64, "input of {len} bytes: {hash}");
+            assert!(
+                hex.bytes()
+                    .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()),
+                "input of {len} bytes: {hash}"
+            );
+        }
     }
 }


### PR DESCRIPTION
`policy_hash_of` formatted the sha2 digest value itself with `{:x}`. That
`LowerHex` impl belongs to generic-array's `GenericArray` — sha2 0.10's output
type — and 0.11 returns a `hybrid-array` value without it, so the formatting
pinned the crate to a major version for no reason of its own. Dependabot's bump
to sha2 0.11 (#46) currently fails on every CI leg with `error[E0277]: the trait
bound Array<u8, ...>: LowerHex is not satisfied`; this is both the necessary and
the sufficient fix for it.

## What changed

- `policy_hash_of` hex-encodes the digest bytes into the string rather than
  formatting the digest value. The output is unchanged, so recorded
  `guard.policy_hash` values keep their meaning across the bump and DESIGN.md's
  "Record provenance" contract (`sha256:<hex>` over the policy file bytes) still
  holds.
- The sha2 requirement stays at `0.10` here — the version bump belongs to #46.
- The existing FIPS 180-2 `abc` vector pins one exact value; a new test pins the
  encoding's shape (fixed width, lowercase) for every input length up to 64
  bytes.

## Merge order

This has to land before #46, and #46 then has to be rebased so its bump commit
sits on top of this one. `main` takes rebase merges, so merging #46 with this
fix underneath it would put a commit on `main` that does not compile on its own,
against the bisectability rule in AGENTS.md. Verified by reconstructing `main`
plus only #46's manifest and lockfile changes: it fails with exactly that one
E0277 and nothing else.

## Verification

- `cargo fmt --check`, both clippy legs, `cargo test --workspace --all-targets
  --locked` (343 tests), `cargo deny check` and `typos` are all clean.
- Forward compatibility: in a worktree holding #46's branch with this commit
  cherry-picked, the workspace builds and the whole suite passes under sha2
  0.11.0, with clippy and `cargo deny` clean too. Both hardcoded digest vectors
  pass there unchanged, which is what shows the hash value itself survives the
  major bump.
- Adversarial review across four independent lenses plus a mutation verifier.
  No blockers. Equivalence was established by running the old and the new
  implementation over 1183 inputs, 1022 of them carrying a digest byte below
  0x10, with identical output on every one. The one major finding was that the
  test as first written added no detection power — its vector, sha256(""), has
  no byte below 0x10, so it could not catch a dropped zero pad — and that the
  commit message overclaimed on the strength of it. The test is now the property
  test described above, re-verified to fail on its own under both the
  dropped-pad and the uppercase mutant, and the commit message is corrected.
