### PR TITLE
feat(server): move to rmcp 3.1 and pin what the transport may serve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
           # Keep in sync with rust-version in Cargo.toml.
-          toolchain: "1.85"
+          toolchain: "1.88"
       - name: Cache cargo
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ cargo deny check
 
 Use the toolchain pinned in `rust-toolchain.toml` (repo root, currently
 `1.97.0`). The workspace MSRV is declared once in `Cargo.toml`
-(`rust-version = "1.85"`); do not introduce APIs or dependencies which
+(`rust-version = "1.88"`); do not introduce APIs or dependencies which
 require a newer compiler without deliberately updating both the pin and the
 MSRV policy. CI and reproducible local checks use the committed
 `Cargo.lock`, so use `--locked` for verification.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,7 +817,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1374,7 +1380,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -1412,7 +1418,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1462,12 +1468,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "futures",
@@ -1494,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2555,7 +2561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 authors = ["Martin Pluskal <martin@pluskal.org>"]
 repository = "https://github.com/plusky/bugwarden"
 homepage = "https://github.com/plusky/bugwarden"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -36,7 +36,7 @@ workspace = true
 [dependencies]
 bugwarden-core = { path = "../bugwarden-core", version = "0.3.0" }
 
-rmcp = { version = "2.2", features = [
+rmcp = { version = "3.1", features = [
     "server",
     "macros",
     "transport-io",
@@ -66,7 +66,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # in-memory duplex transport (tools_wiremock) and over real streamable HTTP
 # (http_transport_wiremock) — so the client half of rmcp is needed here. The
 # rmcp `reqwest` feature selects rustls, matching the rustls-only workspace.
-rmcp = { version = "2.2", features = [
+rmcp = { version = "3.1", features = [
     "client",
     "transport-streamable-http-client-reqwest",
     "reqwest",

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -298,7 +298,10 @@ pub struct ToolCallEvent {
 pub struct InitializeEvent {
     /// The client as it introduced itself in the handshake.
     pub client: ClientInfo,
-    /// The MCP protocol version the client requested, when it sent one.
+    /// The MCP protocol version the session negotiated — the revision
+    /// actually spoken, which is not always the one the client asked for:
+    /// a client requesting a revision this build does not serve is handed
+    /// the server default, and this field records what it got.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub protocol_version: Option<String>,
 }

--- a/crates/bugwarden/src/main.rs
+++ b/crates/bugwarden/src/main.rs
@@ -17,9 +17,7 @@ use clap::Parser;
 use rmcp::{
     transport::{
         stdio,
-        streamable_http_server::{
-            session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
-        },
+        streamable_http_server::{session::local::LocalSessionManager, StreamableHttpService},
     },
     ServiceExt,
 };
@@ -123,9 +121,8 @@ async fn main() -> anyhow::Result<()> {
             let service = StreamableHttpService::new(
                 move || Ok(server.clone()),
                 LocalSessionManager::default().into(),
-                StreamableHttpServerConfig::default().with_cancellation_token(ct.child_token()),
+                bugwarden::server::http_server_config().with_cancellation_token(ct.child_token()),
             );
-
             let router = axum::Router::new().nest_service("/mcp", service);
             let addr = format!("{}:{}", cfg.host, cfg.port);
             tracing::info!("Starting Bugzilla MCP server on {addr}");

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -6,6 +6,7 @@
 //! nothing). Denials use the uniform text from `Guard::denial` only, so a
 //! policy-denied bug and a nonexistent bug are indistinguishable (I2).
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::Instant;
@@ -19,12 +20,38 @@ use rmcp::{
     model::*,
     schemars,
     service::RequestContext,
-    tool, tool_router, ErrorData as McpError, RoleServer, ServerHandler,
+    tool, tool_router,
+    transport::streamable_http_server::StreamableHttpServerConfig,
+    ErrorData as McpError, RoleServer, ServerHandler,
 };
 use serde_json::{json, Value};
 
 use crate::audit::{self, AuditCell, AuditState, FailMode, TransportKind, Verdict};
 use crate::config::{Cli, KeyCustody, Transport};
+
+/// The MCP revisions this build actually implements, newest last.
+///
+/// Deliberately not `ProtocolVersion::KNOWN_VERSIONS`: the SDK knows more
+/// revisions than it can serve through this handler, and both the rmcp
+/// default for `supported_protocol_versions` and the handshake below
+/// would otherwise accept `2026-07-28` — a revision whose stateless
+/// requests carry no handshake, so audit records would name a client the
+/// server never spoke to (issue #34). A client asking for it gets the
+/// server default instead, and every rmcp bump has to widen this list
+/// deliberately, never by inheriting a longer one.
+const SUPPORTED_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
+    ProtocolVersion::V_2024_11_05,
+    ProtocolVersion::V_2025_03_26,
+    ProtocolVersion::V_2025_06_18,
+    ProtocolVersion::V_2025_11_25,
+];
+
+/// The revision offered when a client asks for one this build cannot
+/// serve, and the one `get_info` advertises. Pinned rather than left to
+/// `ProtocolVersion::default()`, whose value moves with the SDK: an
+/// rmcp release that advances `LATEST` past what [`SUPPORTED_PROTOCOL_VERSIONS`]
+/// lists would otherwise make the fallback a revision this build rejects.
+const DEFAULT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V_2025_11_25;
 
 /// Names of the tools that modify bug state. These routes are removed from
 /// the router in read-only mode (I13).
@@ -237,6 +264,60 @@ fn client_of(ctx: &RequestContext<RoleServer>) -> audit::ClientInfo {
         version: peer.as_ref().map(|p| p.client_info.version.clone()),
         principal: None,
     }
+}
+
+/// The streamable-HTTP transport configuration this build serves with.
+///
+/// Lives here rather than in `main` so the integration tests serve the
+/// configuration a deployment actually gets. Two rmcp 3.1 defaults are set
+/// by name rather than inherited, because inheriting them changes how a
+/// deployment behaves without anyone choosing it:
+///
+/// * `allowed_hosts` defaults to loopback only — a DNS-rebinding defence
+///   for MCP servers a browser can reach on `localhost`. bugwarden is
+///   reached by MCP clients at whatever address the operator bound and
+///   named, so that default would refuse every deployment not addressed as
+///   `localhost`, containers included. Disabled deliberately: the access
+///   control here is the network boundary, and per-caller authentication
+///   when it lands (issue #32).
+/// * `max_request_body_bytes` is a 4 MiB POST cap with no rmcp 2.2
+///   equivalent. Worth keeping as a memory bound, but it also ceilings
+///   `add_attachment` independently of the operator's
+///   `global.max_attachment_bytes`, so it is pinned to the SDK's current
+///   value: an SDK bump must not move an operator-visible limit. Issue #52
+///   reconciles the two ceilings.
+pub fn http_server_config() -> StreamableHttpServerConfig {
+    StreamableHttpServerConfig::default()
+        .disable_allowed_hosts()
+        .with_max_request_body_bytes(4 * 1024 * 1024)
+}
+
+/// Whether this request took rmcp's handshake-free lifecycle.
+///
+/// The transport routes on the PRESENCE of
+/// `_meta.io.modelcontextprotocol/protocolVersion`, whatever revision that
+/// key names — not on the negotiated revision, and not on
+/// [`SUPPORTED_PROTOCOL_VERSIONS`]. So excluding `2026-07-28` does not keep
+/// a request off that path: a client naming a revision this build does
+/// serve reaches the handler with no `initialize` behind it, and rmcp
+/// synthesises its peer with the SDK's own build identity as `client_info`.
+/// Served, such a call would put a client the server never spoke to into
+/// the audit stream, with no session record anchoring it — a plausible
+/// wrong attribution, which is the one an audit trail can least afford.
+///
+/// No revision this build serves defines that lifecycle, so a request
+/// carrying it is out of contract and is refused.
+fn skips_the_handshake(ctx: &RequestContext<RoleServer>) -> bool {
+    ctx.meta.protocol_version().is_some()
+}
+
+/// The uniform refusal for a request that skipped the handshake. Names no
+/// tool, bug or policy — it is a statement about the request's shape.
+fn handshake_required() -> McpError {
+    McpError::invalid_request(
+        "this server requires the initialize handshake; per-request protocol negotiation is not served",
+        None,
+    )
 }
 
 /// Total elapsed milliseconds since `started`, saturating.
@@ -2430,6 +2511,22 @@ impl ServerHandler for BugWarden {
         // handshake info is stored so later calls (and their audit
         // records) can read it back through `peer_info`.
         context.peer.set_peer_info(request.clone());
+        // Negotiate before recording: the record names the revision the
+        // session actually speaks, not the one the client asked for.
+        // Echo a requested revision this build serves, keep the server
+        // default otherwise — the same shape the SDK's own negotiation
+        // has, tested against `SUPPORTED_PROTOCOL_VERSIONS` rather than
+        // the wider set of revisions the SDK merely knows about.
+        let mut info = self.get_info();
+        if SUPPORTED_PROTOCOL_VERSIONS.contains(&request.protocol_version) {
+            info.protocol_version = request.protocol_version.clone();
+        } else {
+            tracing::warn!(
+                client_requested = %request.protocol_version,
+                server_fallback = %info.protocol_version,
+                "client requested unsupported protocol version; falling back to server default"
+            );
+        }
         if let Some(audit) = &self.audit {
             // Every session start is recorded, unconditionally — no
             // configuration knob: a stream that could omit session
@@ -2440,7 +2537,7 @@ impl ServerHandler for BugWarden {
                     version: Some(request.client_info.version.clone()),
                     principal: None,
                 },
-                protocol_version: Some(request.protocol_version.as_str().to_string()),
+                protocol_version: Some(info.protocol_version.as_str().to_string()),
             });
             let session = self.session_info(&context, audit);
             if record_event(audit, event, session).await.is_err()
@@ -2453,27 +2550,55 @@ impl ServerHandler for BugWarden {
                 return Err(McpError::internal_error("audit unavailable", None));
             }
         }
-        // The default handler's version negotiation, replicated: echo a
-        // client-requested version this SDK knows, keep the server
-        // default otherwise.
-        let mut info = self.get_info();
-        if ProtocolVersion::KNOWN_VERSIONS.contains(&request.protocol_version) {
-            info.protocol_version = request.protocol_version;
-        } else {
-            tracing::warn!(
-                client_requested = %request.protocol_version,
-                server_fallback = %info.protocol_version,
-                "client requested unsupported protocol version; falling back to server default"
-            );
-        }
         Ok(info)
+    }
+
+    /// The revisions this handler serves, narrowing the SDK's default of
+    /// every revision it knows (see [`SUPPORTED_PROTOCOL_VERSIONS`]). The
+    /// SDK consults this on the handshake, on the stateless request path
+    /// and in `server/discover`, so the whole surface narrows with it.
+    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+        Cow::Borrowed(SUPPORTED_PROTOCOL_VERSIONS)
     }
 
     async fn call_tool(
         &self,
         request: CallToolRequestParams,
         mut context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
+        let started = Instant::now();
+        if skips_the_handshake(&context) {
+            // Recorded before it is refused, like every other turned-away
+            // call: a stream that went quiet for a whole request class
+            // could not be read as a complete account. `client` is left
+            // absent rather than carrying the placeholder identity the
+            // handshake-free path synthesises — the record says the caller
+            // is unknown, because it is.
+            if let Some(audit) = self.audit.clone() {
+                let event = audit::AuditEventKind::ToolCall(Box::new(audit::ToolCallEvent {
+                    client: audit::ClientInfo {
+                        name: None,
+                        version: None,
+                        principal: None,
+                    },
+                    trace: None,
+                    request: audit::RequestInfo {
+                        tool: request.name.to_string(),
+                        id: Some(context.id.to_string()),
+                        params: allowlisted(request.arguments.as_ref()),
+                    },
+                    guard: None,
+                    upstream: None,
+                    outcome: audit::OutcomeInfo {
+                        class: audit::OutcomeClass::Error,
+                        duration_ms: elapsed_ms(started),
+                    },
+                }));
+                let session = self.session_info(&context, &audit);
+                let _ = record_event(&audit, event, session).await;
+            }
+            return Err(handshake_required());
+        }
         // Auditing off: byte-identical to the macro-generated dispatch.
         let Some(audit) = self.audit.clone() else {
             return self
@@ -2481,7 +2606,6 @@ impl ServerHandler for BugWarden {
                 .call(ToolCallContext::new(self, request, context))
                 .await;
         };
-        let started = Instant::now();
         let tool = request.name.to_string();
         let session = self.session_info(&context, &audit);
         let client = client_of(&context);
@@ -2492,7 +2616,7 @@ impl ServerHandler for BugWarden {
         // to a byte length anyway.
         let params = allowlisted(request.arguments.as_ref());
         // Trace enrichment (issue #28), extracted BEFORE the router
-        // consumes `request`. The rmcp 2.2 trap: over every serialized
+        // consumes `request`. The rmcp trap: over every serialized
         // transport the wire `params._meta` (SEP-414) does NOT arrive in
         // `CallToolRequestParams.meta` — the SDK's custom `Request`
         // deserializer strips `_meta` out of the params before the
@@ -2543,7 +2667,7 @@ impl ServerHandler for BugWarden {
                 },
             }));
             let _ = record_event(&audit, event, session).await;
-            return Ok(audit_refusal(&tool));
+            return Ok(audit_refusal(&tool).into());
         }
 
         let cell = Arc::new(AuditCell::default());
@@ -2562,8 +2686,12 @@ impl ServerHandler for BugWarden {
             // A guard denial is a well-formed response (the uniform
             // denial text): its `is_error` marker classifies the
             // content, not the call, so the outcome stays `ok` and the
-            // denial lives in guard.verdict.
-            Ok(r) if r.is_error == Some(true) && guard_verdict != Some(Verdict::Denied) => {
+            // denial lives in guard.verdict. Only a completed call
+            // carries that marker; the other `CallToolResponse` variants
+            // belong to revisions this build does not serve.
+            Ok(CallToolResponse::Complete(r))
+                if r.is_error == Some(true) && guard_verdict != Some(Verdict::Denied) =>
+            {
                 audit::OutcomeClass::Refused
             }
             Ok(_) => audit::OutcomeClass::Ok,
@@ -2604,11 +2732,11 @@ impl ServerHandler for BugWarden {
                             Some(Verdict::Denied | Verdict::Refused | Verdict::ServedFiltered)
                         ) =>
                 {
-                    Ok(audit_refusal(&tool))
+                    Ok(audit_refusal(&tool).into())
                 }
                 // A read the guard fully allowed serves unaudited.
                 (FailMode::ClosedWritesDenials, _) => result,
-                (FailMode::ClosedAll, _) => Ok(audit_refusal(&tool)),
+                (FailMode::ClosedAll, _) => Ok(audit_refusal(&tool).into()),
             },
         }
     }
@@ -2616,12 +2744,31 @@ impl ServerHandler for BugWarden {
     async fn list_tools(
         &self,
         _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
+        // Refused on the same terms as a tool call: the listing is pruned
+        // per deployment (I13), so serving it to a handshake-free caller
+        // would disclose which tools this policy removed. Unrecorded, as
+        // every listing is — schema v1 has no event kind for one.
+        if skips_the_handshake(&context) {
+            return Err(handshake_required());
+        }
         Ok(ListToolsResult {
             tools: self.tool_router.list_all(),
+            result_type: Some(ResultType::COMPLETE),
             meta: None,
             next_cursor: None,
+            // The 2026-07-28 cache hints stay absent, exactly as they
+            // were before this SDK had the fields: no revision this
+            // build serves defines them, and emitting them anyway would
+            // add fields to responses no peer asked for. When the
+            // revision is adopted, `cache_scope` is `Private` — the
+            // listing is pruned per deployment by policy and by
+            // read-only mode (I13), so a shared cache must never serve
+            // one deployment's list to another. `CacheScope::default()`
+            // is `Public`; this field is always written by name.
+            ttl_ms: None,
+            cache_scope: None,
         })
     }
 
@@ -2631,6 +2778,7 @@ impl ServerHandler for BugWarden {
 
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_protocol_version(DEFAULT_PROTOCOL_VERSION)
             .with_server_info(Implementation::from_build_env())
             .with_instructions(
                 "MCP server for Bugzilla. Provides tools to search bugs \
@@ -3041,6 +3189,37 @@ mod tests {
                 logs.contains("created_by_me describes that one account"),
                 expect_warn,
                 "startup logs: {logs}"
+            );
+        }
+    }
+
+    #[test]
+    fn advertised_protocol_versions_are_the_ones_this_build_serves() {
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz).expect("server must build");
+        assert_eq!(
+            server.supported_protocol_versions().as_ref(),
+            SUPPORTED_PROTOCOL_VERSIONS,
+            "the handler must advertise this build's list, never inherit the SDK's"
+        );
+        assert!(
+            !SUPPORTED_PROTOCOL_VERSIONS.contains(&ProtocolVersion::V_2026_07_28),
+            "2026-07-28 requests carry no handshake, so their records could not \
+             name the calling client (issue #34)"
+        );
+        assert!(
+            SUPPORTED_PROTOCOL_VERSIONS.contains(&DEFAULT_PROTOCOL_VERSION),
+            "the negotiation fallback must itself be a revision this build serves"
+        );
+        assert_eq!(
+            server.get_info().protocol_version,
+            DEFAULT_PROTOCOL_VERSION,
+            "the advertised default is pinned here, not taken from the SDK's LATEST"
+        );
+        for version in SUPPORTED_PROTOCOL_VERSIONS {
+            assert!(
+                ProtocolVersion::KNOWN_VERSIONS.contains(version),
+                "the SDK cannot serve {version}, which this build advertises"
             );
         }
     }
@@ -3561,7 +3740,7 @@ mod tests {
             panic!("tool arguments must be a JSON object");
         };
         let mut params = CallToolRequestParams::new(tool.to_string()).with_arguments(args);
-        let mut meta = rmcp::model::Meta::new();
+        let mut meta = rmcp::model::RequestMetaObject::new();
         meta.set_traceparent(traceparent);
         params.meta = Some(meta);
         client
@@ -3778,7 +3957,7 @@ mod tests {
             panic!("tool arguments must be a JSON object");
         };
         let mut params = CallToolRequestParams::new("bug_history".to_string()).with_arguments(args);
-        let mut meta = rmcp::model::Meta::new();
+        let mut meta = rmcp::model::RequestMetaObject::new();
         meta.set_traceparent(TRACEPARENT);
         params.meta = Some(meta);
         let context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer);
@@ -3790,11 +3969,83 @@ mod tests {
         let result = ServerHandler::call_tool(&server, params, context)
             .await
             .expect("the in-process call must not be a protocol error");
+        let CallToolResponse::Complete(result) = result else {
+            panic!("a served tool call completes; this build serves no other response kind")
+        };
         assert!(!is_error(&result), "bug_history must succeed");
 
         let events = read_audit_events(&audit_path);
         let calls = tool_calls(&events);
         assert_eq!(calls.len(), 1, "exactly the direct call is recorded");
         assert_trace_is_canonical(calls[0].trace.as_ref());
+    }
+
+    #[tokio::test]
+    async fn initialize_never_echoes_a_revision_this_build_cannot_serve() {
+        // A dual-revision client probing for 2026-07-28 must be handed
+        // the server default instead. Both halves of the negotiation are
+        // exercised here: this handler's own test against
+        // `SUPPORTED_PROTOCOL_VERSIONS`, and the SDK's, which runs after
+        // the handler returns and takes the handler's value as its
+        // fallback — so a handler that echoed the request would make the
+        // SDK echo it too.
+        use clap::Parser as _;
+        let mock = MockServer::start().await;
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
+        let mut cli = Cli::parse_from([
+            "bugwarden",
+            "--bugzilla-server",
+            &mock.uri(),
+            "--transport",
+            "stdio",
+            "--api-key",
+            "test-key",
+        ]);
+        cli.api_key_file = None;
+        let guard = Arc::new(Guard {
+            policy: Policy::from_toml_str("").expect("test policy must parse"),
+        });
+        let bz = Arc::new(BugzillaClient::new(&mock.uri(), false).expect("client must build"));
+        let server = BugWarden::new(Arc::new(cli), guard, bz)
+            .expect("server must build")
+            .with_audit(Arc::clone(&audit));
+
+        let (client_io, server_io) = tokio::io::duplex(1 << 16);
+        tokio::spawn(async move {
+            if let Ok(running) = server.serve(server_io).await {
+                let _ = running.waiting().await;
+            }
+        });
+        // rmcp serves a `ClientInfo` as its own handler, so this value is
+        // what the client asks for on the wire.
+        let probe = ClientInfo::default().with_protocol_version(ProtocolVersion::V_2026_07_28);
+        let client = probe
+            .serve(client_io)
+            .await
+            .expect("the handshake must succeed");
+
+        assert_eq!(
+            client
+                .peer_info()
+                .expect("the server answers initialize")
+                .protocol_version,
+            DEFAULT_PROTOCOL_VERSION,
+            "a revision this build cannot serve must not be echoed back"
+        );
+
+        let events = read_audit_events(&audit_path);
+        let recorded = events
+            .iter()
+            .find_map(|e| match &e.kind {
+                AuditEventKind::Initialize(ev) => ev.protocol_version.clone(),
+                AuditEventKind::ToolCall(_) | AuditEventKind::AuditGap(_) => None,
+            })
+            .expect("the handshake is recorded");
+        assert_eq!(
+            recorded,
+            DEFAULT_PROTOCOL_VERSION.as_str(),
+            "the record names the revision the session speaks, not the one requested"
+        );
     }
 }

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -38,7 +38,7 @@ use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::service::{RoleClient, RunningService};
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 use rmcp::transport::streamable_http_server::{
-    session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
+    session::local::LocalSessionManager, StreamableHttpService,
 };
 use rmcp::transport::StreamableHttpClientTransport;
 use rmcp::ServiceExt as _;
@@ -86,7 +86,10 @@ async fn serve_http(
     let service = StreamableHttpService::new(
         move || Ok(server.clone()),
         LocalSessionManager::default().into(),
-        StreamableHttpServerConfig::default(),
+        // The deployed configuration, not a default one: the transport
+        // knobs bugwarden sets by name are only tested if the harness
+        // serves what a deployment serves.
+        bugwarden::server::http_server_config(),
     );
     let router = axum::Router::new().nest_service("/mcp", service);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -365,6 +368,144 @@ async fn guard_denies_uniformly_over_http() {
 }
 
 #[tokio::test]
+async fn a_client_addressing_the_server_by_name_is_served() {
+    // rmcp 3.1's `allowed_hosts` default is loopback only, so inheriting it
+    // would answer every request whose `Host` is the name the operator
+    // actually deployed under — every containerised one — with a rejection.
+    // main.rs disables that validation by name; this pins the decision,
+    // since the test harness would otherwise always speak to 127.0.0.1 and
+    // never notice.
+    let mock = MockServer::start().await;
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock, None).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{addr}/mcp"))
+        .header("Host", "bugwarden.example:8080")
+        .header("Accept", "application/json, text/event-stream")
+        .header("Content-Type", "application/json")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "host-probe", "version": "1" }
+            }
+        }))
+        .send()
+        .await
+        .expect("the request must reach the server");
+    let status = response.status();
+    let body = response.text().await.expect("a body");
+    assert!(
+        status.is_success(),
+        "a non-loopback Host must be served, got {status}: {body}"
+    );
+    assert!(
+        body.contains("protocolVersion"),
+        "the handshake must be answered: {body}"
+    );
+}
+
+#[tokio::test]
+async fn a_handshake_free_call_is_refused_and_never_names_a_client() {
+    // rmcp routes a request to its handshake-free lifecycle on the mere
+    // PRESENCE of `_meta.io.modelcontextprotocol/protocolVersion` — whatever
+    // revision that key names — and synthesises the peer with the SDK's own
+    // build identity. So a client naming 2025-11-25, a revision this build
+    // does serve, reaches a tool with no `initialize` behind it, and the
+    // record would name `rmcp`/<sdk version>: a client the server never
+    // spoke to. Narrowing SUPPORTED_PROTOCOL_VERSIONS cannot close this —
+    // the routing never consults it — so the handler refuses the request.
+    let mock = MockServer::start().await;
+    mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
+
+    let dir = tempfile::tempdir().expect("audit temp dir");
+    let audit_path = dir.path().join("audit.jsonl");
+    let sink = AuditSink::open(AuditConfig {
+        path: audit_path.clone(),
+        fsync: false,
+        fail_mode: None,
+        rotate_max_bytes: 0,
+        rotate_keep: 8,
+        suppressed_ids: true,
+    })
+    .expect("audit sink must open");
+    let audit = Arc::new(AuditState::new(sink, FailMode::Open, None));
+
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock, Some(audit)).await;
+
+    // Raw HTTP: no rmcp client will build this request, which is the point.
+    let response = reqwest::Client::new()
+        .post(format!("http://{addr}/mcp"))
+        .header("Accept", "application/json, text/event-stream")
+        .header("Content-Type", "application/json")
+        .header("MCP-Protocol-Version", "2025-11-25")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "bug_info",
+                "arguments": { "bug_ids": [7] },
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2025-11-25",
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                }
+            }
+        }))
+        .send()
+        .await
+        .expect("the request must reach the server");
+    let body = response.text().await.expect("a body");
+    assert!(
+        !body.contains("world-readable"),
+        "a handshake-free call must not be served: {body}"
+    );
+
+    // The guard never ran because the call never reached a tool, so
+    // Bugzilla was never contacted on its behalf.
+    let upstream = mock.received_requests().await.unwrap_or_default();
+    assert!(
+        upstream.is_empty(),
+        "a refused call must contact no upstream: {} request(s)",
+        upstream.len()
+    );
+
+    // Refused, but not silently: the stream carries the attempt, and the
+    // client it could not identify is absent rather than a placeholder.
+    let raw = std::fs::read_to_string(&audit_path).expect("audit file must be readable");
+    assert!(
+        !raw.contains("\"rmcp\""),
+        "no record may name the SDK as the calling client: {raw}"
+    );
+    let events: Vec<AuditEvent> = raw
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str(l).expect("every audit line must parse"))
+        .collect();
+    let calls: Vec<_> = events
+        .iter()
+        .filter_map(|e| match &e.kind {
+            AuditEventKind::ToolCall(ev) => Some(ev.as_ref()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(calls.len(), 1, "the refused call is recorded exactly once");
+    assert_eq!(calls[0].request.tool, "bug_info");
+    assert_eq!(calls[0].client.name, None, "no client can be named");
+    assert!(
+        calls[0].guard.is_none(),
+        "the guard never ran, so no verdict may be recorded"
+    );
+}
+
+#[tokio::test]
 async fn traceparent_over_http_lands_in_the_audit_record() {
     // End-to-end over REAL streamable http: the client's `params._meta`
     // traceparent survives serialization, transport, and deserialization
@@ -373,7 +514,7 @@ async fn traceparent_over_http_lands_in_the_audit_record() {
     // `CallToolRequestParams.meta` arrives `None` here — and delivers it
     // to the handler as the extensions-backed `RequestContext.meta`, so
     // this test pins the `context.meta` fallback that every serialized
-    // transport depends on (see the rmcp 2.2 usage notes in DESIGN.md).
+    // transport depends on (see the rmcp 3.1 usage notes in DESIGN.md).
     let mock = MockServer::start().await;
     mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
 
@@ -403,7 +544,7 @@ async fn traceparent_over_http_lands_in_the_audit_record() {
         panic!("tool arguments must be a JSON object");
     };
     let mut params = CallToolRequestParams::new("bug_info".to_string()).with_arguments(args);
-    let mut meta = rmcp::model::Meta::new();
+    let mut meta = rmcp::model::RequestMetaObject::new();
     meta.set_traceparent(traceparent);
     params.meta = Some(meta);
     let traced = client

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -11,7 +11,7 @@ Cargo workspace, two crates:
 
 - `crates/bugwarden-core` — guard policy engine + async Bugzilla REST client.
   MUST NOT depend on rmcp, axum, clap, or any MCP/transport crate.
-- `crates/bugwarden` — the binary: clap CLI, rmcp 2.2 MCP server, stdio and
+- `crates/bugwarden` — the binary: clap CLI, rmcp 3.1 MCP server, stdio and
   streamable-HTTP transports. Depends on `bugwarden-core`. The crate also
   has a lib target (`lib.rs` re-exporting `config` and `server`) consumed by
   `main.rs` and by the integration tests under `crates/bugwarden/tests/`,
@@ -881,14 +881,59 @@ Decisions, all deliberate:
   untouched. Client-invisible by construction (I3): the response is built
   from the window's bugs alone, byte-identical with or without drops.
 
-## rmcp 2.2 usage notes
+## rmcp 3.1 usage notes
 
 Cached reference files (read them): `/tmp/counter.rs` (tool_router + #[tool] +
 Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
 (stdio main), `/tmp/chttp.rs` (StreamableHttpService + axum main),
 `/tmp/rmcp-toolrouter.rs` (ToolRouter API incl. remove_route/has_route).
 
-- `rmcp = { version = "2.2", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }`
+- `rmcp = { version = "3.1", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }`
+- Protocol revisions: `SUPPORTED_PROTOCOL_VERSIONS` (server.rs) lists what
+  this build serves and `supported_protocol_versions()` returns it, narrowing
+  the SDK default of every revision it knows. What that override bounds is
+  precisely which **declared** revisions `initialize`, per-request `_meta` and
+  `server/discover` may agree to; it does not decide which request *lifecycle*
+  the transport routes to (see the trap below). `2026-07-28` is excluded
+  because this build has not adopted it (issue #34, stage 2).
+  The hand-written `initialize` tests the same list — the SDK negotiates
+  again afterwards using the handler's answer as its fallback, so a handler
+  that echoed an unsupported request would make the SDK echo it too — and
+  records the negotiated revision, never the requested one. `get_info` pins
+  `DEFAULT_PROTOCOL_VERSION` rather than inheriting `ProtocolVersion::default()`,
+  which moves with the SDK.
+- **rmcp trap — the handshake-free lifecycle is chosen by `_meta` shape, not
+  by revision.** `message_has_per_request_protocol_version`
+  (`transport/streamable_http_server/tower.rs`) routes a request to the
+  stateless path when `_meta.io.modelcontextprotocol/protocolVersion` is
+  merely PRESENT, whatever revision it names, and that path synthesises a
+  peer whose `client_info` is `Implementation::default()` — the SDK's own
+  crate name and version. Narrowing the revision list therefore does **not**
+  keep a request off it: a client naming `2025-11-25`, which this build
+  serves, would otherwise reach a tool with no `initialize` behind it and
+  land in the audit stream as a client the server never spoke to. So
+  `call_tool` and `list_tools` refuse any request carrying that key
+  (`skips_the_handshake`), and a refused call is recorded with `client`
+  absent rather than with the placeholder. `server/discover` takes the same
+  path unconditionally in rmcp; it answers `get_info` only and reaches no
+  tool, guard or router. General rule: **no `_meta` key and no `Mcp-*` header
+  may carry a security decision** — like `KNOWN_VERSIONS`, they are the SDK's
+  vocabulary, not this build's contract.
+- `list_tools` names every `ListToolsResult` field: `result_type` is
+  `COMPLETE`, and the 2026-07-28 cache hints stay absent while that revision
+  is unserved. When it is adopted, `cache_scope` is `Private` — the listing is
+  pruned per deployment (I13), so a shared cache must never serve one
+  deployment's list to another — and `CacheScope::default()` is `Public`.
+- **Two rmcp 3.1 transport defaults are set by name, not inherited** (main.rs).
+  `allowed_hosts` defaults to loopback only — a DNS-rebinding defence for MCP
+  servers a browser can reach on localhost — which would refuse every
+  deployment not addressed as `localhost`, containers included; bugwarden
+  disables it deliberately, since its access control is the network boundary
+  and, when it lands, per-caller authentication (#32). `max_request_body_bytes`
+  is a 4 MiB POST cap with no rmcp 2.2 equivalent: kept as a memory bound but
+  pinned to the current SDK value, because it also ceilings `add_attachment`
+  independently of `global.max_attachment_bytes` and an SDK bump must not move
+  an operator-visible limit. Reconciling the two ceilings is #52.
 - axum MUST be 0.8 (rmcp's version — extension extraction breaks otherwise);
   schemars 1.x with feature `chrono04`; tokio 1; tokio-util 0.7.
 - Server struct: `#[derive(Clone)] pub struct BugWarden { cfg: Arc<Cli>, guard: Arc<Guard>, bz: Arc<BugzillaClient>, tool_router: ToolRouter<Self>, key_custody: KeyCustody, audit: Option<Arc<AuditState>> }`


### PR DESCRIPTION
Stage 1 of #34: the SDK bump, with every behaviour it would otherwise change by default made explicit. No MCP revision is adopted here — audit schema v1 is untouched. **MSRV moves to 1.85 → 1.88**, which rmcp 3.1.0 requires (`rust-version` in its manifest); the `rust-msrv` CI job moves with it.

## The mechanical half

`call_tool` returns `CallToolResponse` — the enum wrapping `CallToolResult` for revisions with intermediate results — and the outcome classification reads `is_error` off its completed variant. `model::Meta` became `RequestMetaObject`. `ListToolsResult` gained three fields and is written out by name, so a later SDK field cannot be inherited silently; the 2026-07-28 cache hints stay absent while that revision is unserved.

## The half that needed deciding

**Revisions served** are declared in `SUPPORTED_PROTOCOL_VERSIONS` and returned from `supported_protocol_versions`, instead of inheriting every revision rmcp knows. The hand-written `initialize` tests that same list rather than `KNOWN_VERSIONS`: the SDK negotiates *again* after the handler returns, using the handler's answer as its fallback, so a handler that echoed an unsupported revision made the SDK echo it too. The `initialize` record now names the revision negotiated rather than the one requested, and `get_info` pins its default instead of inheriting `ProtocolVersion::default()`, which moves with the SDK.

**That is not sufficient on its own — the adversarial review found why, and it is the reason this PR is bigger than a bump.** rmcp routes a request to its handshake-free lifecycle on the mere *presence* of `_meta.io.modelcontextprotocol/protocolVersion`, whatever revision that key names, never consulting the supported list; that path synthesises the peer with the SDK's own build identity. A client declaring **2025-11-25 — a revision this build does serve** — could therefore reach a tool with no `initialize` behind it and land in the audit stream as `rmcp`/`3.1.0`: a client the server never spoke to, which is the attribution an audit trail can least afford. It was reproduced end to end over HTTP (including from inside a live session, carrying that session's real id) and over stdio. `call_tool` and `list_tools` now refuse such a request, and the refused call is recorded with `client` absent rather than with the placeholder.

**Two transport defaults** are likewise set by name, in a shared `http_server_config` that the integration tests now serve — the harness previously built its own config, so these were untestable. `allowed_hosts` defaults to loopback only, which would refuse every deployment not addressed as `localhost`, containers included. `max_request_body_bytes` is a 4 MiB POST cap with no rmcp 2.2 equivalent: kept as a memory bound but pinned, because it also ceilings `add_attachment` independently of the operator's `global.max_attachment_bytes` — #52 reconciles the two.

## Verification

`cargo fmt --check`, both clippy legs, `cargo test --workspace --all-targets --locked` (347), `cargo deny check` and `typos` are clean.

Adversarial review across four lenses plus a mutation verifier. It returned three blockers — the handshake-free path (found independently by three reviewers, and again by the stage 2 design work), the MSRV conflict, and DESIGN.md documenting a protection the code did not have — plus majors on the body cap and on `InitializeEvent::protocol_version`'s rustdoc, which this change made false. All are fixed here. Every decision is pinned by a test that fails without it: an HTTP-level reproduction of the handshake-free call (verified red without the guard, serving bug content), a non-loopback `Host` (403 without the config), and both halves of the version narrowing (red when either is widened to `KNOWN_VERSIONS`).

Two things the review surfaced that are deliberately **not** here: #52 (body cap vs `max_attachment_bytes`) and #53 (the server identifies itself to clients as `rmcp` — pre-existing, identical in rmcp 2.2, so not a regression from this bump).