### PR TITLE
fix(server): introduce this build by name in the handshake

### DIFF
--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -53,6 +53,27 @@ const SUPPORTED_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
 /// lists would otherwise make the fallback a revision this build rejects.
 const DEFAULT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V_2025_11_25;
 
+/// The name this server reports as its own, in the handshake and in
+/// `mcp_server_info`.
+const SERVER_NAME: &str = env!("CARGO_PKG_NAME");
+
+/// The version this server reports as its own, in the handshake and in
+/// `mcp_server_info`.
+const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// This build's identity, as sent in the `initialize` handshake.
+///
+/// Deliberately not `Implementation::from_build_env()` (nor
+/// `Implementation::default()`, which calls it): that constructor expands
+/// `env!("CARGO_CRATE_NAME")` and `env!("CARGO_PKG_VERSION")` *inside
+/// rmcp*, so it names the SDK — every rmcp-based server then introduces
+/// itself identically, and the one question `serverInfo` exists to answer,
+/// which build is deployed, becomes unanswerable from the handshake
+/// (issue #53). The `env!`s here expand in this crate.
+fn server_identity() -> Implementation {
+    Implementation::new(SERVER_NAME, SERVER_VERSION)
+}
+
 /// Names of the tools that modify bug state. These routes are removed from
 /// the router in read-only mode (I13).
 pub const WRITE_TOOLS: &[&str] = &[
@@ -2408,7 +2429,7 @@ impl BugWarden {
     }
 
     #[tool(
-        description = "Returns information about this MCP server instance (version, bugzilla server, transport) and a summary of the active guard policy.",
+        description = "Returns information about this MCP server instance (name, version, bugzilla server, transport) and a summary of the active guard policy.",
         annotations(read_only_hint = true, open_world_hint = false)
     )]
     fn mcp_server_info(&self) -> Result<CallToolResult, McpError> {
@@ -2418,8 +2439,11 @@ impl BugWarden {
         // criteria.
         let policy = &self.guard.policy;
         Ok(ok_json(json!({
-            "name": "bugwarden",
-            "version": env!("CARGO_PKG_VERSION"),
+            // The same two constants the handshake sends, so a client
+            // cannot be told one identity by `initialize` and another by
+            // this tool.
+            "name": SERVER_NAME,
+            "version": SERVER_VERSION,
             "bugzilla_server": self.bz.base_url(),
             "transport": match self.cfg.transport {
                 Transport::Http => "http",
@@ -2779,7 +2803,7 @@ impl ServerHandler for BugWarden {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_protocol_version(DEFAULT_PROTOCOL_VERSION)
-            .with_server_info(Implementation::from_build_env())
+            .with_server_info(server_identity())
             .with_instructions(
                 "MCP server for Bugzilla. Provides tools to search bugs \
                  (bugs_quicksearch), read bug details, comments, history, and \
@@ -4046,6 +4070,98 @@ mod tests {
             recorded,
             DEFAULT_PROTOCOL_VERSION.as_str(),
             "the record names the revision the session speaks, not the one requested"
+        );
+    }
+
+    #[test]
+    fn mcp_server_info_reports_the_identity_the_handshake_advertises() {
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz).expect("server must build");
+
+        // The values, not just the constants: comparing `advertised.name`
+        // to `SERVER_NAME` alone would hold for any value either of them
+        // took, so an empty or renamed constant would pass.
+        let advertised = server.get_info().server_info;
+        assert_eq!(advertised.name, "bugwarden");
+        assert_eq!(advertised.version, env!("CARGO_PKG_VERSION"));
+        // `ServerInfo::new` seeds `server_info` with
+        // `Implementation::from_build_env()`, whose `env!`s expand inside
+        // rmcp, so `get_info` starts from the SDK's identity and only the
+        // explicit `with_server_info` displaces it: dropping that call, or
+        // refactoring back to the constructor, must fail here (issue #53).
+        assert_ne!(
+            advertised.name,
+            Implementation::from_build_env().name,
+            "the handshake must not borrow the SDK's crate name"
+        );
+
+        let reported: Value = serde_json::from_str(&text_of(
+            &server.mcp_server_info().expect("the tool answers"),
+        ))
+        .expect("the tool returns JSON");
+        assert_eq!(
+            reported["name"], advertised.name,
+            "the tool and the handshake must not name two different servers"
+        );
+        assert_eq!(reported["version"], advertised.version);
+    }
+
+    #[test]
+    fn rmcp_default_still_names_the_sdk() {
+        // A pin on the SDK, not on this build, and the reason inheriting
+        // its identity is no substitute for building one: `Default` is
+        // `from_build_env()`, which expands its `env!`s inside rmcp. If a
+        // future rmcp changes that, this is the notice to rewrite the trap
+        // note in DESIGN.md — nothing here is wrong when it fails.
+        assert_eq!(
+            Implementation::default().name,
+            Implementation::from_build_env().name
+        );
+        assert_ne!(Implementation::default().name, SERVER_NAME);
+    }
+
+    #[tokio::test]
+    async fn the_handshake_names_this_build_over_a_real_session() {
+        // Asserted on a served session rather than on `get_info()` alone:
+        // this is the field as a client reads it, which means it survived
+        // serialization into `ServerPeerInfo.server_info` — `Option` on
+        // that side, so "no identity at all" is a shape the wire allows.
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz).expect("server must build");
+
+        let (client_io, server_io) = tokio::io::duplex(1 << 16);
+        tokio::spawn(async move {
+            if let Ok(running) = server.serve(server_io).await {
+                let _ = running.waiting().await;
+            }
+        });
+        // Bounded: a handler that never answers should fail this test, not
+        // stall the run until CI's own timeout kills it.
+        let client = tokio::time::timeout(std::time::Duration::from_secs(10), ().serve(client_io))
+            .await
+            .expect("the handshake must not hang")
+            .expect("the handshake must succeed");
+
+        let advertised = client
+            .peer_info()
+            .expect("the server answers initialize")
+            .server_info
+            .clone()
+            .expect("the handshake carries a serverInfo");
+        // The name is spelled out — it is meant to be stable, so a package
+        // rename should fail here and be noticed — while the version is
+        // read from the environment, since it moves every release.
+        assert_eq!(
+            advertised.name, "bugwarden",
+            "a client must be told which server answered, not which SDK it was built on"
+        );
+        assert_eq!(advertised.version, env!("CARGO_PKG_VERSION"));
+        // `title` is the field a client DISPLAYS in preference to `name`,
+        // so an SDK identity parked there would reproduce #53 in the only
+        // place a human looks, while every assertion above still passed.
+        assert_eq!(
+            advertised.title, None,
+            "nothing may be displayed in place of the name asserted here"
         );
     }
 }

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -506,6 +506,64 @@ async fn a_handshake_free_call_is_refused_and_never_names_a_client() {
 }
 
 #[tokio::test]
+async fn discover_names_this_build_and_reaches_nothing_else() {
+    // `server/discover` is the SECOND place a peer learns who answered, and
+    // it is served with no handshake behind it. It says `bugwarden` today
+    // only because rmcp's default implementation delegates to `get_info` —
+    // an override (#34 stage 2 plausibly adds one) would take the identity
+    // with it, and the handshake tests would not notice.
+    let mock = MockServer::start().await;
+    mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock, None).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{addr}/mcp"))
+        .header("Accept", "application/json, text/event-stream")
+        .header("Content-Type", "application/json")
+        .header("MCP-Protocol-Version", "2025-11-25")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "server/discover",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2025-11-25",
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                }
+            }
+        }))
+        .send()
+        .await
+        .expect("the request must reach the server");
+    let body = response.text().await.expect("a body");
+
+    // Compared whole rather than by field: an extra key here is how the
+    // identity gets undermined without contradicting it — `title` is what
+    // a client displays in preference to `name`.
+    let payload: Value = body
+        .lines()
+        .find_map(|line| line.strip_prefix("data: "))
+        .and_then(|data| serde_json::from_str(data).ok())
+        .unwrap_or_else(|| panic!("discover must answer with a JSON-RPC result: {body}"));
+    assert_eq!(
+        payload["result"]["_meta"]["io.modelcontextprotocol/serverInfo"],
+        json!({ "name": "bugwarden", "version": env!("CARGO_PKG_VERSION") }),
+        "discover must name this build, and nothing else: {body}"
+    );
+    // It answers `get_info` and nothing else: no tool, no guard, no
+    // upstream. That is what makes an unauthenticated pre-request surface
+    // acceptable while #32 is open.
+    let upstream = mock.received_requests().await.unwrap_or_default();
+    assert!(
+        upstream.is_empty(),
+        "discover must contact no upstream: {} request(s)",
+        upstream.len()
+    );
+}
+
+#[tokio::test]
 async fn traceparent_over_http_lands_in_the_audit_record() {
     // End-to-end over REAL streamable http: the client's `params._meta`
     // traceparent survives serialization, transport, and deserialization

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -686,7 +686,7 @@ constraints the model must know.
 | bug_url | bug_id | none (I8 exception) | `{base_url}/show_bug.cgi?id={id}` |
 | bugzilla_server_info | — | none | client.server_info |
 | quicksearch_syntax | — | none | HTML doc page |
-| mcp_server_info | — | none | version (CARGO_PKG_VERSION), bugzilla server url, transport, and policy summary per I1 |
+| mcp_server_info | — | none | name (CARGO_PKG_NAME) and version (CARGO_PKG_VERSION), the same two the handshake sends; bugzilla server url, transport, and policy summary per I1 |
 | summarize_bug | id | comments | fetches comments (private filtered with include_private=false), returns the summarization prompt text (fixed prompt template) |
 
 ### Update-field surface (issue #38)
@@ -894,7 +894,7 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   the SDK default of every revision it knows. What that override bounds is
   precisely which **declared** revisions `initialize`, per-request `_meta` and
   `server/discover` may agree to; it does not decide which request *lifecycle*
-  the transport routes to (see the trap below). `2026-07-28` is excluded
+  the transport routes to (see the `_meta`-shape trap below). `2026-07-28` is excluded
   because this build has not adopted it (issue #34, stage 2).
   The hand-written `initialize` tests the same list — the SDK negotiates
   again afterwards using the handler's answer as its fallback, so a handler
@@ -902,6 +902,32 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   records the negotiated revision, never the requested one. `get_info` pins
   `DEFAULT_PROTOCOL_VERSION` rather than inheriting `ProtocolVersion::default()`,
   which moves with the SDK.
+- **rmcp trap — `Implementation::from_build_env()` names the SDK, not this
+  crate.** It expands `env!("CARGO_CRATE_NAME")` / `env!("CARGO_PKG_VERSION")`
+  *inside rmcp*, so a server built on it introduces itself as `rmcp` at the
+  SDK's version. It is not opt-in: `ServerInfo::new()` (i.e.
+  `InitializeResult::new`, model.rs) seeds `server_info` with it, and
+  `Implementation::default()` is that same constructor — so `get_info`
+  starts from the SDK's identity every time and only the explicit
+  `.with_server_info(server_identity())` displaces it. Dropping that one
+  call silently restores the SDK's answer, which is why a test asserts the
+  identity rather than a review. bugwarden builds `server_identity()` from
+  its own `CARGO_PKG_*` (`SERVER_NAME` / `SERVER_VERSION`, server.rs) via
+  `Implementation::new`; the struct-literal form is unavailable anyway, the
+  type being `#[non_exhaustive]`. `mcp_server_info` reports those same two
+  constants — the handshake and the tool must never name two different
+  servers — and the identity is also read back off a served session, which
+  pins that it survives serialization into `ServerPeerInfo.server_info`, a
+  field that is `Option` on the client side. Same constructor as the
+  placeholder `client_info` in the `_meta`-shape trap below, in the other
+  direction: the SDK's build environment is not this build's identity
+  (issue #53). `server/discover` is the second place a peer reads it, and
+  it is answered with no handshake — so until #32 lands, anything that can
+  open the port learns the exact deployed version, unauthenticated and
+  unrecorded. Accepted deliberately: `serverInfo` is a required field of
+  `InitializeResult`, so withholding it is not protocol-legal, and the
+  value being replaced was rmcp's own exact release — a dependency
+  fingerprint, which is not the smaller disclosure.
 - **rmcp trap — the handshake-free lifecycle is chosen by `_meta` shape, not
   by revision.** `message_has_per_request_protocol_version`
   (`transport/streamable_http_server/tower.rs`) routes a request to the


### PR DESCRIPTION
## What

`get_info` built its `serverInfo` with `Implementation::from_build_env()`, which expands `env!("CARGO_CRATE_NAME")` / `env!("CARGO_PKG_VERSION")` **inside rmcp**. Every client was told it had reached `rmcp` at the SDK's version, while the instructions string in the same response described bugwarden.

`SERVER_NAME` / `SERVER_VERSION` now expand this crate's `CARGO_PKG_*` here, `server_identity()` is what `get_info` sends, and `mcp_server_info` reports those same two constants instead of a hand-written copy.

## Why it is not a one-liner

Inheriting the SDK's identity is not opt-in. `ServerInfo::new` seeds `server_info` with that same constructor and `Implementation::default()` *is* it, so `get_info` starts from the SDK's answer every time and only the explicit `with_server_info` displaces it — **dropping that one call silently restores `rmcp`**, which is why this is pinned by a test rather than by review.

`server/discover` is a second identity surface, answered with no handshake behind it, carrying `serverInfo` in `_meta`. It is correct today only by inheriting rmcp's default `discover`, which delegates to `get_info` — an override (#34 stage 2 plausibly adds one) would take the identity with it while the handshake tests stayed green. Pinned separately, along with the property that makes an unauthenticated pre-request surface acceptable while #32 is open: it answers `get_info` and reaches no tool, guard or upstream.

The issue's own suggested fix does not compile — `Implementation` is `#[non_exhaustive]`, so the struct-literal form is `E0639` outside rmcp. `Implementation::new` is the available shape, and the better one: it sets `title` and the rest to `None` explicitly rather than inheriting whatever a future `from_build_env` might populate.

**Not a regression from the rmcp 3.1 bump.** `from_build_env` is byte-identical in 2.2.0 and 3.1.0, so 0.3.0 and every release before it advertised the SDK the same way; only the version in the answer changed.

## Invariants

None move. `mcp_server_info` gains no field and its JSON is byte-identical — both values were already this crate's — so the I1 disclosure surface is unchanged. No guard, denial text, filtering path or router pruning is involved.

One consequence is accepted rather than papered over, and `docs/DESIGN.md` now says so: until #32 lands, a real build version is readable pre-authentication by anything that can open the port, unrecorded, from `discover` alone. `serverInfo` is a *required* field of `InitializeResult`, so withholding it is not protocol-legal — and the value being replaced was rmcp's own exact release, a dependency fingerprint, which is not the smaller disclosure.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo clippy -p bugwarden --features gen --all-targets -- -D warnings`, `cargo test --workspace --all-targets --locked` (351), `cargo deny check`, `typos`.

Probed against the built binary on both transports — stdio and streamable HTTP now answer `"serverInfo":{"name":"bugwarden","version":"0.3.0"}`, the same surface the issue observed the defect on.

Every new assertion is mutation-verified. Reverting `server_identity()` to `from_build_env()` — or to `Default`, or dropping `with_server_info` entirely — fails all three surfaces with `left: "rmcp" / right: "bugwarden"`. Emptying or renaming either constant, swapping the two arguments, and hardcoding the tool's fields divergently are each caught. So is a `title` parked on the identity: `title` is what a client *displays* in preference to `name`, so an SDK string there would reproduce the defect where a human actually looks while every name assertion still passed — both the handshake and the discover test now reject it.

The adversarial review also produced two findings outside this change's scope, filed rather than folded in: #55 (no `User-Agent` on requests to Bugzilla — the same question in the other direction, with the trap that fixing it inside `bugwarden-core` yields `bugwarden-core` as the name) and a `version.workspace = true` drift in `bugwarden-core`, to follow separately.

Closes #53
