### PR TITLE
build: inherit the workspace version in bugwarden-core

### DIFF
--- a/crates/bugwarden-core/Cargo.toml
+++ b/crates/bugwarden-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bugwarden-core"
-version = "0.3.0"
+version.workspace = true
 description = "Guard policy engine and async Bugzilla REST client for the bugwarden MCP server"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## What

`crates/bugwarden-core/Cargo.toml` carried `version = "0.3.0"` as a literal while every other shared field of that manifest — `edition`, `rust-version`, `license`, `authors`, `repository`, `homepage` — already inherits, and the binary crate inherits its version too. Now it inherits as well.

## Why

The workspace version had two sources of truth with nothing keeping them equal. They agree today and `chore: bump version to 0.3.0` moved both by hand, so nothing is broken — the cost is the failure mode when that hand-edit is missed.

The two literals fail differently, which is the point:

- The dependency requirement in `crates/bugwarden/Cargo.toml` (`bugwarden-core = { path = "…", version = "0.3.0" }`) **cannot drift silently** — cargo refuses to resolve a path dependency whose version does not satisfy the requirement, so a missed bump breaks the first local build.
- `bugwarden-core`'s own version **can**. Local builds stay green; the release job publishes the crate at its old version, takes its own "already published, skipping" branch, and the binary crate then resolves against the previous core. Nothing says a word, and only on the release path.

This removes the silent one. The loud one is left alone deliberately: cargo has no way to express "the workspace version" in a dependency requirement, and a failure that stops the first build needs no guard.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --all-targets --locked`, `cargo deny check`, `typos`.

`cargo metadata` reports both crates at `0.3.0`, unchanged, and `Cargo.lock` is untouched. `cargo package -p bugwarden-core` succeeds and normalises the field back to a literal `version = "0.3.0"` in the published manifest — so a distro building from the `.crate`, with no workspace root present, reads exactly what it read before.