### PR TITLE
feat: identify this build to Bugzilla with a User-Agent

### DIFF
--- a/crates/bugwarden-core/src/client.rs
+++ b/crates/bugwarden-core/src/client.rs
@@ -7,6 +7,11 @@
 //! sanitized with [`reqwest::Error::without_url`] before it is wrapped, and
 //! request logging records only the HTTP method and path — never the query
 //! string.
+//!
+//! The `User-Agent` every request carries is supplied by the caller and
+//! never derived here: this is a library, so a value built from its own
+//! `CARGO_PKG_*` would name `bugwarden-core` in the access log of every
+//! binary that embeds it (issue #55).
 
 use std::time::Duration;
 
@@ -25,9 +30,10 @@ const TIMESTAMP_FORMAT: &str = "%Y-%m-%dT%H:%M:%SZ";
 /// Async client for the Bugzilla REST API.
 ///
 /// Built once at startup; the underlying [`reqwest::Client`] carries a 30
-/// second timeout and is reused for every request. Authentication is
-/// applied per request: `Authorization: Bearer {key}` when
-/// `use_auth_header` is set, otherwise an `api_key` query parameter.
+/// second timeout and the caller's `User-Agent`, and is reused for every
+/// request. Authentication is applied per request: `Authorization: Bearer
+/// {key}` when `use_auth_header` is set, otherwise an `api_key` query
+/// parameter.
 #[derive(Debug, Clone)]
 pub struct BugzillaClient {
     /// Server base URL with any trailing `/` trimmed.
@@ -40,12 +46,34 @@ pub struct BugzillaClient {
 
 impl BugzillaClient {
     /// Create a client for the Bugzilla instance at `base_url` (trailing
-    /// slashes are trimmed).
-    pub fn new(base_url: &str, use_auth_header: bool) -> Result<Self> {
+    /// slashes are trimmed), sending `user_agent` with every request.
+    ///
+    /// `user_agent` must name the *program* making the request, and is
+    /// deliberately a parameter rather than a constant of this crate: a
+    /// value built here from `CARGO_PKG_NAME`/`CARGO_PKG_VERSION` would
+    /// name `bugwarden-core` in the access log of every binary that embeds
+    /// it, which is both wrong and entirely plausible-looking (issue #55).
+    /// Bugzilla's operator reads the value, so it belongs to the program's
+    /// public identity — a name and version, never the API key, the policy
+    /// path, or anything else about the deployment. That is the discipline
+    /// of I12 applied to a surface I12 does not itself name (it governs
+    /// logs, error messages and tool results).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `user_agent` is blank — an anonymous client is
+    /// what this parameter exists to prevent, so it fails at startup rather
+    /// than sending an empty header — when it is not a valid HTTP header
+    /// value, or when the underlying HTTP client cannot be built.
+    pub fn new(base_url: &str, use_auth_header: bool, user_agent: &str) -> Result<Self> {
+        if user_agent.trim().is_empty() {
+            bail!("bugzilla client: user_agent must name the calling program, and was blank");
+        }
         let base_url = base_url.trim_end_matches('/').to_string();
         let api_url = format!("{base_url}/rest");
         let http = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
+            .user_agent(user_agent)
             .build()
             .map_err(sanitize)?;
         Ok(Self {
@@ -469,17 +497,50 @@ mod tests {
     use chrono::TimeZone;
     use reqwest::StatusCode;
 
+    /// Stands in for a real program's identity, naming neither this crate
+    /// nor the binary that ships it; the point of the parameter is that
+    /// this crate never picks one (#55).
+    const UA: &str = "probe-agent/0.0.0";
+
     #[test]
     fn new_trims_trailing_slashes() {
-        let c = BugzillaClient::new("https://bugzilla.example.com/", false).unwrap();
+        let c = BugzillaClient::new("https://bugzilla.example.com/", false, UA).unwrap();
         assert_eq!(c.base_url(), "https://bugzilla.example.com");
         assert_eq!(c.api_url, "https://bugzilla.example.com/rest");
 
-        let c = BugzillaClient::new("https://bugzilla.example.com///", true).unwrap();
+        let c = BugzillaClient::new("https://bugzilla.example.com///", true, UA).unwrap();
         assert_eq!(c.base_url(), "https://bugzilla.example.com");
 
-        let c = BugzillaClient::new("https://bugzilla.example.com", false).unwrap();
+        let c = BugzillaClient::new("https://bugzilla.example.com", false, UA).unwrap();
         assert_eq!(c.base_url(), "https://bugzilla.example.com");
+    }
+
+    #[test]
+    fn new_refuses_to_build_an_anonymous_client() {
+        // A blank identity is the state #55 exists to end, so it fails at
+        // startup rather than sending an empty header to Bugzilla.
+        for blank in ["", " ", "\t\n "] {
+            let e = BugzillaClient::new("https://bugzilla.example.com", false, blank)
+                .expect_err("a blank user agent must not build a client");
+            assert!(
+                e.to_string().contains("user_agent"),
+                "the error must name what is missing: {e:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn new_refuses_a_user_agent_that_is_not_a_header_value() {
+        // reqwest defers this to build(); it must surface as an error and
+        // not a panic, since the value crosses a public API boundary.
+        let e = BugzillaClient::new("https://bugzilla.example.com", false, "bad\nagent/1.0")
+            .expect_err("a user agent with a newline must not build a client");
+        // And it must be reqwest's refusal, not the blank-identity bail
+        // widened until it swallows this case too.
+        assert!(
+            !e.to_string().contains("blank"),
+            "a malformed identity is not a missing one: {e:#}"
+        );
     }
 
     #[test]

--- a/crates/bugwarden-core/tests/attachment_wiremock.rs
+++ b/crates/bugwarden-core/tests/attachment_wiremock.rs
@@ -13,8 +13,13 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 /// Deliberately distinctive so a leak into any error text is unmistakable (I12).
 const KEY: &str = "SUPERSECRETKEY123";
 
+/// Any identity will do here — the client requires one (#55) but these
+/// suites assert nothing about it; `user_agent_wiremock.rs` owns that
+/// proof. Names neither crate, so a check for either finds nothing.
+const TEST_USER_AGENT: &str = "probe-agent/0.0.0";
+
 fn client(server: &MockServer) -> BugzillaClient {
-    BugzillaClient::new(&server.uri(), false).expect("client must build")
+    BugzillaClient::new(&server.uri(), false, TEST_USER_AGENT).expect("client must build")
 }
 
 #[tokio::test]

--- a/crates/bugwarden-core/tests/guard_wiremock.rs
+++ b/crates/bugwarden-core/tests/guard_wiremock.rs
@@ -16,6 +16,11 @@ use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 /// Deliberately distinctive so a leak into any error text is unmistakable (I12).
 const KEY: &str = "SUPERSECRETKEY123";
 
+/// Any identity will do here — the client requires one (#55) but these
+/// suites assert nothing about it; `user_agent_wiremock.rs` owns that
+/// proof. Names neither crate, so a check for either finds nothing.
+const TEST_USER_AGENT: &str = "probe-agent/0.0.0";
+
 fn guard(toml: &str) -> Guard {
     Guard {
         policy: Policy::from_toml_str(toml).expect("test policy must parse"),
@@ -23,7 +28,7 @@ fn guard(toml: &str) -> Guard {
 }
 
 fn client(server: &MockServer) -> BugzillaClient {
-    BugzillaClient::new(&server.uri(), false).expect("client must build")
+    BugzillaClient::new(&server.uri(), false, TEST_USER_AGENT).expect("client must build")
 }
 
 fn bug(id: u64, groups: &[&str], creation_time: &str) -> serde_json::Value {
@@ -396,7 +401,8 @@ async fn api_key_absent_from_transport_error_i12() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("addr");
     drop(listener); // free the port so the connection is refused
-    let bz = BugzillaClient::new(&format!("http://{addr}"), false).expect("client");
+    let bz =
+        BugzillaClient::new(&format!("http://{addr}"), false, TEST_USER_AGENT).expect("client");
 
     let err = bz.get_bugs(KEY, &[1], None).await.unwrap_err();
     let full = format!("{err:#} {err:?}");
@@ -428,7 +434,7 @@ async fn auth_header_mode_sends_bearer_and_no_query_key() {
         .mount(&server)
         .await;
 
-    let bz = BugzillaClient::new(&server.uri(), true).expect("client");
+    let bz = BugzillaClient::new(&server.uri(), true, TEST_USER_AGENT).expect("client");
     let v = bz.get_bugs(KEY, &[1], None).await.unwrap();
     assert_eq!(v["seen_auth"], json!(format!("Bearer {KEY}")));
     assert_eq!(v["query_key"], json!(false));
@@ -1042,7 +1048,8 @@ async fn whoami_api_key_absent_from_transport_error_i12() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("addr");
     drop(listener); // free the port so the connection is refused
-    let bz = BugzillaClient::new(&format!("http://{addr}"), false).expect("client");
+    let bz =
+        BugzillaClient::new(&format!("http://{addr}"), false, TEST_USER_AGENT).expect("client");
 
     let err = bz.whoami(KEY).await.unwrap_err();
     let full = format!("{err:#} {err:?}");

--- a/crates/bugwarden-core/tests/user_agent_wiremock.rs
+++ b/crates/bugwarden-core/tests/user_agent_wiremock.rs
@@ -1,0 +1,98 @@
+//! HTTP-level proof that the client identifies its caller on the wire and
+//! never itself (issue #55).
+//!
+//! `BugzillaClient` builds requests three ways — the authenticated GET, the
+//! authenticated POST/PUT body, and the unauthenticated `page.cgi` fetch —
+//! and both authentication modes reach the builder through the same
+//! constructor, so all of them are exercised. A header set on the shared
+//! `reqwest::Client` does reach every request, but only a test says so: a
+//! construction that made the identity conditional on the auth mode, or a
+//! per-request header on one method, is invisible in review and silently
+//! replaces the client default rather than duplicating it.
+
+use bugwarden_core::client::BugzillaClient;
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Names neither this crate nor the binary that ships it, so the assertions
+/// below can only pass with the caller's value on the wire — an identity
+/// this crate invented for itself would read as plausibly correct and fail
+/// here.
+const CALLER_AGENT: &str = "probe-agent/9.9 (+https://example.invalid/probe)";
+
+/// Deliberately distinctive so a leak into the header is unmistakable (I12).
+const KEY: &str = "SUPERSECRETKEY123";
+
+/// Drive one request of every shape the client builds, in one auth mode.
+async fn every_request_shape(use_auth_header: bool) {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/version"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "version": "5.0.4" })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 42 })))
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/rest/bug/42"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [{ "id": 42 }] })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/page.cgi"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("<html></html>"))
+        .mount(&server)
+        .await;
+
+    let bz = BugzillaClient::new(&server.uri(), use_auth_header, CALLER_AGENT)
+        .expect("client must build");
+    bz.version(KEY).await.expect("version must parse");
+    bz.create_bug(KEY, json!({ "summary": "boom" }))
+        .await
+        .expect("create must parse");
+    bz.update_bug(KEY, 42, json!({ "summary": "less boom" }))
+        .await
+        .expect("update must parse");
+    bz.quicksearch_syntax_html()
+        .await
+        .expect("syntax page must fetch");
+
+    let requests = server.received_requests().await.expect("recording enabled");
+    assert_eq!(
+        requests.len(),
+        4,
+        "the GET, the POST and PUT bodies and the unauthenticated page must all have been sent"
+    );
+    for req in requests {
+        let agent = req
+            .headers
+            .get("user-agent")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        let what = format!("{} {}", req.method, req.url.path());
+        assert_eq!(
+            agent, CALLER_AGENT,
+            "{what} (use_auth_header={use_auth_header}) must identify the caller, not this crate"
+        );
+        assert!(
+            !agent.contains("bugwarden-core"),
+            "{what}: the library must never name itself to Bugzilla: {agent}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn every_request_carries_the_callers_user_agent() {
+    // Both auth modes, because the identity and the credential are set on
+    // the same builder: a construction that attached the header only in
+    // one of them sends no `User-Agent` at all in the other — the exact
+    // anonymity #55 exists to end, and every call site in this workspace
+    // would still pass with the mode it happens to use.
+    every_request_shape(false).await;
+    every_request_shape(true).await;
+}

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -73,5 +73,14 @@ rmcp = { version = "3.1", features = [
 ] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-util"] }
+# `process` and `time`: binary_user_agent spawns the shipped executable
+# and reads its answers under a timeout, so a hung handler fails the test
+# instead of the run.
+tokio = { version = "1", features = [
+    "macros",
+    "rt-multi-thread",
+    "io-util",
+    "process",
+    "time",
+] }
 wiremock = "0.6"

--- a/crates/bugwarden/src/main.rs
+++ b/crates/bugwarden/src/main.rs
@@ -12,7 +12,7 @@ use bugwarden::audit::{
     policy_hash_of, AuditConfig, AuditSink, AuditState, FailMode, TransportKind,
 };
 use bugwarden::{config, server};
-use bugwarden_core::{client::BugzillaClient, guard::Guard, policy::Policy};
+use bugwarden_core::{guard::Guard, policy::Policy};
 use clap::Parser;
 use rmcp::{
     transport::{
@@ -52,10 +52,10 @@ async fn main() -> anyhow::Result<()> {
     // file handling) is resolved inside BugWarden::new — before the audit
     // sink below, so a key misconfiguration aborts startup without first
     // creating or rotating an audit file.
-    let bz = Arc::new(
-        BugzillaClient::new(&cli.bugzilla_server, cli.use_auth_header)
-            .context("failed to build Bugzilla client")?,
-    );
+    // Built in the library target, not here: the client's identity to
+    // Bugzilla (I12-adjacent, issue #55) is only testable where a test can
+    // reach the constructor.
+    let bz = Arc::new(server::bugzilla_client(&cli)?);
     let guard = Arc::new(Guard { policy });
     let cfg = Arc::new(cli);
     let server =

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -74,6 +74,56 @@ fn server_identity() -> Implementation {
     Implementation::new(SERVER_NAME, SERVER_VERSION)
 }
 
+/// The `User-Agent` every request to Bugzilla carries.
+///
+/// The same identity the handshake sends, in the other direction: with a
+/// server-held key (#27) and no per-caller identity yet (#32), one Bugzilla
+/// account carries a whole fleet's traffic, and without this header that
+/// traffic is anonymous — the operator on the other end has no name to
+/// allowlist or complain about — nothing distinguishes it from a person
+/// with a browser (issue #55). The repository is included so that name
+/// leads somewhere; it is read from the manifest rather than written out
+/// again here, so it cannot become a second copy to keep in step.
+///
+/// Everything here is public by construction — it is sent to every
+/// configured Bugzilla and lands in its access log — so it carries the
+/// program's name and version and nothing about the deployment: no key
+/// material, no policy path, no host. That is the discipline of I12 on a
+/// surface I12 does not itself name; the invariant is about logs, error
+/// messages and tool results.
+///
+/// The `env!`s expand in this crate. Built in `bugwarden-core`, where the
+/// client lives, they would expand to `bugwarden-core` and its version —
+/// the shape of issue #53 one layer down, and just as invisible.
+pub const USER_AGENT: &str = concat!(
+    env!("CARGO_PKG_NAME"),
+    "/",
+    env!("CARGO_PKG_VERSION"),
+    " (+",
+    env!("CARGO_PKG_REPOSITORY"),
+    ")"
+);
+
+/// Build the Bugzilla client this build's requests go through.
+///
+/// The single production construction path for [`BugzillaClient`]: it
+/// lives here rather than in `main.rs` so that the identity on the wire is
+/// reachable from a test (`main` is a thin transport wrapper — see the
+/// crate docs), and a second path that skipped it would put an
+/// unidentified client back on the network.
+///
+/// # Errors
+///
+/// Returns an error when [`USER_AGENT`] is not a valid HTTP header value,
+/// or when the underlying HTTP client cannot be built — see
+/// [`BugzillaClient::new`].
+pub fn bugzilla_client(cli: &Cli) -> anyhow::Result<BugzillaClient> {
+    use anyhow::Context as _;
+
+    BugzillaClient::new(&cli.bugzilla_server, cli.use_auth_header, USER_AGENT)
+        .context("failed to build Bugzilla client")
+}
+
 /// Names of the tools that modify bug state. These routes are removed from
 /// the router in read-only mode (I13).
 pub const WRITE_TOOLS: &[&str] = &[
@@ -3126,7 +3176,8 @@ mod tests {
             policy: Policy::from_toml_str(policy).expect("test policy must parse"),
         });
         let bz = Arc::new(
-            BugzillaClient::new("https://bugzilla.example.com", false).expect("client must build"),
+            BugzillaClient::new("https://bugzilla.example.com", false, USER_AGENT)
+                .expect("client must build"),
         );
         (cfg, guard, bz)
     }
@@ -3165,7 +3216,8 @@ mod tests {
             policy: Policy::from_toml_str("").expect("empty policy parses"),
         });
         let bz = Arc::new(
-            BugzillaClient::new("https://bugzilla.example.com", false).expect("client must build"),
+            BugzillaClient::new("https://bugzilla.example.com", false, USER_AGENT)
+                .expect("client must build"),
         );
         let err = match BugWarden::new(Arc::new(cli), guard, bz) {
             Err(e) => e,
@@ -3203,7 +3255,7 @@ mod tests {
                 policy: Policy::from_toml_str(policy).expect("test policy must parse"),
             });
             let bz = Arc::new(
-                BugzillaClient::new("https://bugzilla.example.com", false)
+                BugzillaClient::new("https://bugzilla.example.com", false, USER_AGENT)
                     .expect("client must build"),
             );
             let (server, logs) =
@@ -3484,7 +3536,8 @@ mod tests {
         let guard = Arc::new(Guard {
             policy: Policy::from_toml_str(policy).expect("test policy must parse"),
         });
-        let bz = Arc::new(BugzillaClient::new(mock_uri, false).expect("client must build"));
+        let bz =
+            Arc::new(BugzillaClient::new(mock_uri, false, USER_AGENT).expect("client must build"));
         let mut server = BugWarden::new(cfg, guard, bz).expect("server must build");
         if let Some(audit) = audit {
             server = server.with_audit(audit);
@@ -3958,7 +4011,9 @@ mod tests {
         let guard = Arc::new(Guard {
             policy: Policy::from_toml_str("").expect("test policy must parse"),
         });
-        let bz = Arc::new(BugzillaClient::new(&mock.uri(), false).expect("client must build"));
+        let bz = Arc::new(
+            BugzillaClient::new(&mock.uri(), false, USER_AGENT).expect("client must build"),
+        );
         let server = BugWarden::new(Arc::new(cli), guard, bz)
             .expect("server must build")
             .with_audit(Arc::clone(&audit));
@@ -4030,7 +4085,9 @@ mod tests {
         let guard = Arc::new(Guard {
             policy: Policy::from_toml_str("").expect("test policy must parse"),
         });
-        let bz = Arc::new(BugzillaClient::new(&mock.uri(), false).expect("client must build"));
+        let bz = Arc::new(
+            BugzillaClient::new(&mock.uri(), false, USER_AGENT).expect("client must build"),
+        );
         let server = BugWarden::new(Arc::new(cli), guard, bz)
             .expect("server must build")
             .with_audit(Arc::clone(&audit));
@@ -4162,6 +4219,71 @@ mod tests {
         assert_eq!(
             advertised.title, None,
             "nothing may be displayed in place of the name asserted here"
+        );
+    }
+
+    #[tokio::test]
+    async fn bugzilla_requests_name_this_build_and_never_the_library() {
+        // Driven through `bugzilla_client`, the constructor `main` calls, so
+        // an identity lost between the constant and the wiring fails here
+        // instead of reaching Bugzilla as an anonymous request (issue #55).
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/version"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "version": "5.0.4" })))
+            .mount(&mock)
+            .await;
+
+        let cli = {
+            use clap::Parser as _;
+            Cli::parse_from([
+                "bugwarden",
+                "--bugzilla-server",
+                &mock.uri(),
+                "--transport",
+                "stdio",
+                "--api-key",
+                "test-key",
+            ])
+        };
+        let bz = bugzilla_client(&cli).expect("client must build");
+        bz.version("test-key").await.expect("version must parse");
+
+        let requests = mock.received_requests().await.expect("recording enabled");
+        let agent = requests
+            .first()
+            .expect("the request reached the mock")
+            .headers
+            .get("user-agent")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+
+        // The name and the repository are spelled out rather than read
+        // back from the same `env!`s the code reads: comparing the header
+        // to the manifest it was built from would agree with any value the
+        // manifest took, including a repository pointing somewhere else.
+        // Only the version comes from the environment, since it moves every
+        // release and pinning it would fail on each bump.
+        assert_eq!(
+            agent,
+            format!(
+                "bugwarden/{} (+https://github.com/plusky/bugwarden)",
+                env!("CARGO_PKG_VERSION")
+            ),
+            "Bugzilla's operator must be able to tell what reached them"
+        );
+        assert!(
+            !agent.contains("bugwarden-core"),
+            "the library crate must never be the name in Bugzilla's access log: {agent}"
+        );
+        // The two directions of the same identity: what a client is told in
+        // the handshake and what Bugzilla is told on every request are one
+        // build, and cannot drift into naming two.
+        let identity = server_identity();
+        assert!(
+            agent.starts_with(&format!("{}/{}", identity.name, identity.version)),
+            "the wire identity must match the handshake's {identity:?}: {agent}"
         );
     }
 }

--- a/crates/bugwarden/tests/audit_wiremock.rs
+++ b/crates/bugwarden/tests/audit_wiremock.rs
@@ -17,7 +17,7 @@ use bugwarden::audit::{
     TransportKind, Verdict,
 };
 use bugwarden::config::Cli;
-use bugwarden::server::BugWarden;
+use bugwarden::server::{BugWarden, USER_AGENT};
 use bugwarden_core::client::BugzillaClient;
 use bugwarden_core::guard::Guard;
 use bugwarden_core::policy::Policy;
@@ -84,7 +84,8 @@ async fn audited_client_with(
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(policy).expect("test policy must parse"),
     });
-    let bz = Arc::new(BugzillaClient::new(&mock.uri(), false).expect("client must build"));
+    let bz =
+        Arc::new(BugzillaClient::new(&mock.uri(), false, USER_AGENT).expect("client must build"));
     let server = BugWarden::new(cfg, guard, bz)
         .expect("server must build")
         .with_audit(audit);
@@ -120,7 +121,8 @@ async fn plain_client_for(policy: &str, mock: &MockServer) -> RunningService<Rol
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(policy).expect("test policy must parse"),
     });
-    let bz = Arc::new(BugzillaClient::new(&mock.uri(), false).expect("client must build"));
+    let bz =
+        Arc::new(BugzillaClient::new(&mock.uri(), false, USER_AGENT).expect("client must build"));
     let server = BugWarden::new(cfg, guard, bz).expect("server must build");
     let (client_io, server_io) = tokio::io::duplex(1 << 16);
     tokio::spawn(async move {

--- a/crates/bugwarden/tests/binary_user_agent.rs
+++ b/crates/bugwarden/tests/binary_user_agent.rs
@@ -1,0 +1,190 @@
+//! What the SHIPPED BINARY tells Bugzilla it is (issue #55).
+//!
+//! Every other test of the identity stops one call frame short of `main`,
+//! at `server::bugzilla_client`. That leaves the wiring itself untested: a
+//! `main` that built its own client — with a plausible-looking constant, or
+//! with someone else's — passes all of them while telling every configured
+//! Bugzilla whatever it likes. So this drives the real executable over
+//! stdio against a real HTTP server and reads the header off the request
+//! that arrives.
+
+use std::time::Duration;
+
+use serde_json::json;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Bounded so a binary that never answers fails this test rather than
+/// hanging the suite until CI's own timeout kills it.
+const REPLY_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// The identity this build must present. Spelled out rather than read from
+/// the manifest the code reads: a comparison against `CARGO_PKG_REPOSITORY`
+/// agrees with whatever that field says, including a repository belonging
+/// to someone else. Only the version is read from the environment, since it
+/// moves every release.
+fn expected_agent() -> String {
+    format!(
+        "bugwarden/{} (+https://github.com/plusky/bugwarden)",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+/// Write one newline-delimited JSON-RPC message to the child, the framing
+/// the stdio transport speaks.
+async fn send(stdin: &mut tokio::process::ChildStdin, value: serde_json::Value) {
+    stdin
+        .write_all(format!("{value}\n").as_bytes())
+        .await
+        .expect("the child must accept input");
+}
+
+/// Run the shipped binary against `mock` until it has made at least one
+/// upstream request, and return everything the mock received.
+async fn upstream_requests_of_a_real_run(
+    mock: &MockServer,
+    extra_args: &[&str],
+) -> Vec<wiremock::Request> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_bugwarden"));
+    cmd.args(["--transport", "stdio", "--bugzilla-server", &mock.uri()])
+        .args(["--api-key", "test-key"])
+        .args(extra_args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null());
+    // The ambient environment must not reach the child: every one of these
+    // is read by `Cli` and would change what is under test.
+    for var in [
+        "BUGZILLA_SERVER",
+        "BUGZILLA_API_KEY",
+        "BUGZILLA_API_KEY_FILE",
+        "BUGWARDEN_POLICY",
+        "BUGWARDEN_AUDIT_CONFIG",
+        "MCP_TRANSPORT",
+        "MCP_READ_ONLY",
+        "RUST_LOG",
+    ] {
+        cmd.env_remove(var);
+    }
+    let mut child = cmd.spawn().expect("the built binary must start");
+
+    let mut stdin = child.stdin.take().expect("stdin is piped");
+    let mut stdout = BufReader::new(child.stdout.take().expect("stdout is piped")).lines();
+    // A real MCP session: handshake, then one tool call that must reach
+    // Bugzilla. Nothing here asserts on the responses — the wire is the
+    // subject — but each is read so the next write cannot outrun it.
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "binary-user-agent-test", "version": "0" }
+            }
+        }),
+    )
+    .await;
+    tokio::time::timeout(REPLY_TIMEOUT, stdout.next_line())
+        .await
+        .expect("the handshake must not hang")
+        .expect("stdout must be readable")
+        .expect("the server must answer initialize");
+
+    send(
+        &mut stdin,
+        json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
+    )
+    .await;
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": { "name": "bug_info", "arguments": { "bug_ids": [1] } }
+        }),
+    )
+    .await;
+    tokio::time::timeout(REPLY_TIMEOUT, stdout.next_line())
+        .await
+        .expect("the tool call must not hang")
+        .expect("stdout must be readable")
+        .expect("the server must answer the tool call");
+
+    child.kill().await.expect("the child must be killable");
+    mock.received_requests().await.expect("recording enabled")
+}
+
+#[tokio::test]
+async fn the_shipped_binary_names_this_build_to_bugzilla() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .mount(&mock)
+        .await;
+
+    let requests = upstream_requests_of_a_real_run(&mock, &[]).await;
+    assert!(
+        !requests.is_empty(),
+        "the tool call must have reached Bugzilla, or this test proves nothing"
+    );
+    for req in requests {
+        let agent = req
+            .headers
+            .get("user-agent")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert_eq!(
+            agent,
+            expected_agent(),
+            "the binary as shipped must identify itself on {}",
+            req.url.path()
+        );
+    }
+}
+
+#[tokio::test]
+async fn the_shipped_binary_still_honours_the_auth_mode() {
+    // The identity and the credential are chosen by the same constructor,
+    // so a wiring that dropped `--use-auth-header` would put the API key
+    // back in the query string — into Bugzilla's access log and every proxy
+    // in between — while the header under test stayed perfect.
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .mount(&mock)
+        .await;
+
+    let requests = upstream_requests_of_a_real_run(&mock, &["--use-auth-header"]).await;
+    assert!(
+        !requests.is_empty(),
+        "the tool call must have reached Bugzilla"
+    );
+    for req in requests {
+        let agent = req
+            .headers
+            .get("user-agent")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert_eq!(
+            agent,
+            expected_agent(),
+            "the identity is not auth-mode dependent"
+        );
+        assert_eq!(
+            req.headers
+                .get("authorization")
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer test-key"),
+            "--use-auth-header must reach the client that main builds"
+        );
+        assert!(
+            !req.url.query_pairs().any(|(k, _)| k == "api_key"),
+            "the key must not also travel in the URL: {}",
+            req.url
+        );
+    }
+}

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 
 use bugwarden::audit::{AuditConfig, AuditEvent, AuditEventKind, AuditSink, AuditState, FailMode};
 use bugwarden::config::Cli;
-use bugwarden::server::BugWarden;
+use bugwarden::server::{BugWarden, USER_AGENT};
 use bugwarden_core::client::BugzillaClient;
 use bugwarden_core::guard::Guard;
 use bugwarden_core::policy::Policy;
@@ -77,7 +77,8 @@ async fn serve_http(
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(policy).expect("test policy must parse"),
     });
-    let bz = Arc::new(BugzillaClient::new(&mock.uri(), false).expect("client must build"));
+    let bz =
+        Arc::new(BugzillaClient::new(&mock.uri(), false, USER_AGENT).expect("client must build"));
     let mut server = BugWarden::new(cli, guard, bz).expect("server must build");
     if let Some(audit) = audit {
         server = server.with_audit(audit);

--- a/crates/bugwarden/tests/tools_wiremock.rs
+++ b/crates/bugwarden/tests/tools_wiremock.rs
@@ -22,7 +22,7 @@
 use std::sync::Arc;
 
 use bugwarden::config::Cli;
-use bugwarden::server::{BugWarden, WRITE_TOOLS};
+use bugwarden::server::{BugWarden, USER_AGENT, WRITE_TOOLS};
 use bugwarden_core::client::BugzillaClient;
 use bugwarden_core::guard::Guard;
 use bugwarden_core::policy::Policy;
@@ -57,7 +57,8 @@ async fn client_for(policy: &str, mock: &MockServer) -> RunningService<RoleClien
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(policy).expect("test policy must parse"),
     });
-    let bz = Arc::new(BugzillaClient::new(&mock.uri(), false).expect("client must build"));
+    let bz =
+        Arc::new(BugzillaClient::new(&mock.uri(), false, USER_AGENT).expect("client must build"));
     let server = BugWarden::new(cfg, guard, bz).expect("server must build");
 
     let (client_io, server_io) = tokio::io::duplex(1 << 16);
@@ -1456,8 +1457,10 @@ async fn whoami_transport_error_does_not_leak_the_api_key_i12() {
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(IDENTITY_POLICY).expect("test policy must parse"),
     });
-    let bz =
-        Arc::new(BugzillaClient::new(&format!("http://{addr}"), false).expect("client must build"));
+    let bz = Arc::new(
+        BugzillaClient::new(&format!("http://{addr}"), false, USER_AGENT)
+            .expect("client must build"),
+    );
     let server = BugWarden::new(cfg, guard, bz).expect("server must build");
     let (client_io, server_io) = tokio::io::duplex(1 << 16);
     tokio::spawn(async move {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -488,9 +488,9 @@ impl Guard {
 pub const CLASSIFY_FIELDS: &str =
     "id,summary,product,component,status,resolution,severity,priority,keywords,groups,whiteboard,creation_time,last_change_time,creator";
 
-pub struct BugzillaClient { /* base_url, api_url = base_url + "/rest", reqwest::Client (30s timeout), use_auth_header */ }
+pub struct BugzillaClient { /* base_url, api_url = base_url + "/rest", reqwest::Client (30s timeout + the caller's User-Agent), use_auth_header */ }
 impl BugzillaClient {
-    pub fn new(base_url: &str, use_auth_header: bool) -> anyhow::Result<Self>; // trims trailing '/'
+    pub fn new(base_url: &str, use_auth_header: bool, user_agent: &str) -> anyhow::Result<Self>; // trims trailing '/'; blank or invalid user_agent = error
     pub fn base_url(&self) -> &str;
     pub async fn version(&self, key: &str) -> anyhow::Result<String>;
     pub async fn whoami(&self, key: &str) -> anyhow::Result<String>; // login; missing/non-string/blank "name" = failure
@@ -535,6 +535,52 @@ query param `api_key={key}`. Always `Accept: application/json`.
 Errors: non-2xx status or body `{"error": true}` => anyhow error containing the
 HTTP status and Bugzilla `message` field; reqwest errors sanitized with
 `.without_url()` (I12).
+
+**Caller identity on the wire (issue #55).** Every request carries a
+`User-Agent`, set once on the shared `reqwest::Client` so it reaches the
+authenticated REST calls and the unauthenticated `page.cgi` fetch alike.
+The value is a *parameter*, deliberately: this crate is a library, and a
+value built here from its own `CARGO_PKG_*` would name `bugwarden-core` in
+the access log of every binary that embeds it — the shape of #53 one layer
+down, and just as plausible-looking. The binary supplies
+`server::USER_AGENT`, `{name}/{version} (+{repository})` from its own
+manifest, and builds its client through `server::bugzilla_client(&cli)` so
+the wiring is reachable from a test rather than checkable only by eye.
+Consequences that are decisions, not accidents:
+
+- A blank `user_agent` is a construction error, so an embedder cannot get
+  an anonymous client back — the state this parameter exists to end —
+  from a value that silently resolved to nothing. This binary cannot
+  reach it: `USER_AGENT` is a `concat!` of literals and non-empty `env!`s.
+- The value is public — it is sent to every configured Bugzilla and lands
+  in its access log — so it carries name, version and the project's
+  repository and nothing else: no key material, no policy path, no host.
+  That is the discipline of **I12** applied to a surface I12 does not
+  itself name; the invariant governs logs, error messages and tool
+  results, and is not silently widened here.
+- **Disclosing the version is accepted, and unlike #53's it is a choice.**
+  `serverInfo` had to carry one — it is a required field of
+  `InitializeResult` — but a `User-Agent` is optional and nothing was
+  disclosed before, so this is a deliberate addition, not a replacement.
+  It is accepted because the party learning it is not a passer-by: it is
+  the Bugzilla this deployment authenticates to with an API key and sends
+  every query. Naming a version tells that operator whether a reported
+  misbehaviour is fixed in what is deployed and which builds to allowlist
+  — the whole point of #55 — and tells them nothing they could not learn
+  by asking the account holder. The exposure is that an operator, or
+  anyone reading their access log, can match a fleet against a future
+  advisory for this guard; that is the same trade #53 accepted against a
+  wider audience.
+- It is not operator-configurable. A per-deployment or per-caller identity
+  is #32's job (bearer tokens per caller), and a free-text field an
+  operator fills in is exactly where deployment detail, or a key, would
+  end up.
+- With a server-held key (#27) and no per-caller identity yet, one Bugzilla
+  account carries a whole fleet's traffic: this header is all that
+  distinguishes that traffic from a person with a browser (the value is a
+  compile-time constant, identical in every deployment, so it attributes
+  the program and never the caller). Hence the binary's wire identity and
+  the name it gives in the MCP handshake are asserted to be one build.
 
 ## Identity resolution (the `created_by_me` matcher)
 
@@ -927,7 +973,10 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   unrecorded. Accepted deliberately: `serverInfo` is a required field of
   `InitializeResult`, so withholding it is not protocol-legal, and the
   value being replaced was rmcp's own exact release — a dependency
-  fingerprint, which is not the smaller disclosure.
+  fingerprint, which is not the smaller disclosure. The same trap has a
+  non-MCP twin, and it is not rmcp's: the `User-Agent` sent to Bugzilla
+  must likewise be built in this crate rather than in the library that
+  holds the HTTP client (issue #55, "Caller identity on the wire" above).
 - **rmcp trap — the handshake-free lifecycle is chosen by `_meta` shape, not
   by revision.** `message_has_per_request_protocol_version`
   (`transport/streamable_http_server/tower.rs`) routes a request to the
@@ -1200,5 +1249,30 @@ Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
   `served`; and a pre-#29 record line without `guard.scan`
   deserializes with the scan absent (plus the cell-level note_scan
   merge tests and the updated schema golden in audit.rs).
+- Identity tests (#[cfg(test)] in crates/bugwarden/src/server.rs and
+  crates/bugwarden-core/src/client.rs; crates/bugwarden/tests/
+  http_transport_wiremock.rs, crates/bugwarden/tests/binary_user_agent.rs
+  and crates/bugwarden-core/tests/user_agent_wiremock.rs): what this build
+  calls itself, in both directions. Inbound (issue #53) — `mcp_server_info`
+  and the handshake report the same name and version, asserted as VALUES
+  and against `Implementation::from_build_env()`, so an identity inherited
+  from the SDK fails; the SDK's own default is pinned separately, so its
+  drift reads as upstream news rather than a bug here; the identity is read
+  back off a served session, `title` included, since that is the field a
+  client displays in preference to the name; and `server/discover`, the
+  handshake-free surface, names the same build and reaches nothing else.
+  Outbound (issue #55) — the SHIPPED BINARY is spawned against a real
+  HTTP server and its request read off the wire, because every assertion
+  one call frame in (at `bugzilla_client`) still passes for a `main` that
+  builds its own client; that run also pins `--use-auth-header` reaching
+  the same constructor, since dropping it would put the key back in the
+  URL. The name and repository are spelled out rather than read from the
+  manifest the code reads, which would agree with any value the manifest
+  took. In the library, the caller's value reaches the authenticated GET,
+  the POST and PUT bodies and the unauthenticated `page.cgi` fetch, in
+  BOTH auth modes — the header and the credential are chosen by one
+  constructor, so a per-mode identity would send nothing at all in the
+  other — and a blank or non-header-value identity fails at construction
+  rather than going out anonymously.
 - CI: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
   `cargo test --workspace --locked`, `cargo deny check`.


### PR DESCRIPTION
## What changed

`BugzillaClient::new` takes a `user_agent` and sets it once on the shared
`reqwest::Client`, so every request carries it — the authenticated REST calls,
the POST/PUT bodies, and the unauthenticated `page.cgi` fetch alike.
`bugwarden-core` never picks a value of its own: the binary crate supplies
`server::USER_AGENT`, `{name}/{version} (+{repository})` from its own manifest,
and `main` constructs through the new `server::bugzilla_client(&cli)`.

## Why

Every request to Bugzilla was anonymous — `accept` and `host` and nothing more.
With a server-held key (#27) and no per-caller identity yet (#32), one Bugzilla
account carries a whole fleet's traffic, and the operator on the other end had
no name to allowlist or complain about.

Setting the header where the client lives is the trap:
`env!("CARGO_PKG_NAME")` in `bugwarden-core` expands to `bugwarden-core` and
would name the library in the access log of every binary embedding it — the
shape of #53 one layer down, and it would look entirely plausible. Hence a
parameter, and hence `bugzilla_client` living in `server.rs` where a test can
reach it.

Issue #55 left "whether to include a contact URL" open; this resolves it as
yes, read from `CARGO_PKG_REPOSITORY`, so the name leads somewhere without
becoming a second copy to keep in step.

## Invariants touched

No guard behaviour moves: the policy engine, the tool gates and the audit
schema are untouched, and no CLI flag or policy key is added, so
`examples/policy.toml` and `examples/audit.toml` need no change.

**I12** is cited as a *discipline*, not extended. Its text — the API key must
never appear in logs, error messages, or tool results — does not name outbound
request metadata, and this PR does not widen it. The header is held to the same
standard: it carries name, version and repository only, and cannot carry
runtime data, being a `concat!` of compile-time literals.

**Version disclosure is accepted deliberately** and now recorded in DESIGN.md.
Unlike #53's, this disclosure is not forced — `User-Agent` is optional, and
nothing was disclosed before — so it is a choice. It is accepted because the
party learning it already authenticates this deployment by API key and sees
every query, and because a version is what lets an operator tell whether a
reported misbehaviour is fixed in what is deployed.

## How it was verified

`cargo fmt --check`, both clippy invocations, `cargo test --workspace
--all-targets --locked` (357 tests), `cargo deny check` and `typos` are clean.

- `tests/binary_user_agent.rs` spawns **the shipped executable** against a real
  HTTP server, drives an MCP session over stdio, and reads the header off the
  request that arrives. This exists because every assertion one call frame in
  still passes for a `main` that builds its own client — verified by mutation,
  see below. The same run pins that `--use-auth-header` reaches the constructor.
- `crates/bugwarden-core/tests/user_agent_wiremock.rs`: the caller's value
  reaches all four request shapes in **both** auth modes, using an agent naming
  neither crate.
- `crates/bugwarden/src/server.rs`: a request through `bugzilla_client` carries
  the production value, matching the identity the MCP handshake advertises.
- `crates/bugwarden-core/src/client.rs`: blank and non-header-value identities
  fail at construction.
- Beyond the suite, the built binary was probed by hand over stdio against a
  local HTTP server and sent
  `bugwarden/0.3.0 (+https://github.com/plusky/bugwarden)`.

## Adversarial review

Three reviewers (completeness, test-strength with mutation, docs and process).
Findings addressed in this branch:

- **Five surviving mutants**, all now killed and re-verified: `main.rs`
  bypassing `bugzilla_client` and shipping `curl/7.68.0`; the identity dropped
  whenever `--use-auth-header` is set; `bugzilla_client` ignoring that flag and
  putting the key back in the URL; a per-request header on the PUT path only
  (reqwest *replaces* the client default rather than duplicating it, so this
  class of defect is silent); and an `assert_eq!` comparing the header to the
  same manifest fields the code reads, which agreed with any value they took.
- **I12 cited for constraints it does not contain** (policy path, host,
  outbound headers), in three places — narrowed to "the discipline of I12 on a
  surface I12 does not name".
- **The DESIGN.md Testing bullet named the wrong files** and omitted the
  `discover` test; corrected.
- Prose that outran what the code proves: "cannot drift from where the project
  actually lives", a blank-identity clause reading as if this binary could hit
  it, a test-constant comment claiming a proof that lives in another file, and
  an assertion that no key material reaches a compile-time constant — which
  cannot fail, and which DESIGN.md then recorded as proven. Removed.

Rebutted: validating `base_url` at construction so a transposed
`new(agent, bool, url)` fails at startup rather than at request time. A real
hazard, but a separate concern from #55; the one production call site is
covered, since a transposition there fails the new tests. Worth a follow-up
issue if wanted.

## Note for the reviewer

The DESIGN.md "Identity tests" bullet also covers #53's tests, which landed in
`f944402` without a Testing entry. Documented here because the two directions
of one identity read as a single bullet; say the word and it splits into its
own `docs(design):` commit on this branch.
