### PR TITLE
docs(design): make the rmcp 3.1 usage notes verifiable against the pinned SDK

### DIFF
--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -340,7 +340,7 @@ fn client_of(ctx: &RequestContext<RoleServer>) -> audit::ClientInfo {
 /// The streamable-HTTP transport configuration this build serves with.
 ///
 /// Lives here rather than in `main` so the integration tests serve the
-/// configuration a deployment actually gets. Two rmcp 3.1 defaults are set
+/// configuration a deployment actually gets. These rmcp 3.1 defaults are set
 /// by name rather than inherited, because inheriting them changes how a
 /// deployment behaves without anyone choosing it:
 ///
@@ -357,6 +357,14 @@ fn client_of(ctx: &RequestContext<RoleServer>) -> audit::ClientInfo {
 ///   `global.max_attachment_bytes`, so it is pinned to the SDK's current
 ///   value: an SDK bump must not move an operator-visible limit. Issue #52
 ///   reconciles the two ceilings.
+///
+/// `allowed_origins` is the browser-facing sibling of `allowed_hosts` and the
+/// same reasoning covers it, but it is left inherited: its empty default IS
+/// the disabled state, so naming it would assert nothing. Anything that
+/// changes the `allowed_hosts` call above should decide this one too rather
+/// than leave it behind. The remaining fields, and why each stays inherited,
+/// are inventoried in DESIGN.md under "rmcp 3.1 usage notes"; the caller in
+/// `main` adds `cancellation_token` so shutdown reaches the live transport.
 pub fn http_server_config() -> StreamableHttpServerConfig {
     StreamableHttpServerConfig::default()
         .disable_allowed_hosts()

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1009,16 +1009,66 @@ wired, `server.rs` and `main.rs` are the reference.
   is unserved. When it is adopted, `cache_scope` is `Private` — the listing is
   pruned per deployment (I13), so a shared cache must never serve one
   deployment's list to another — and `CacheScope::default()` is `Public`.
-- **Two rmcp 3.1 transport defaults are set by name, not inherited** (main.rs).
-  `allowed_hosts` defaults to loopback only — a DNS-rebinding defence for MCP
-  servers a browser can reach on localhost — which would refuse every
-  deployment not addressed as `localhost`, containers included; bugwarden
-  disables it deliberately, since its access control is the network boundary
-  and, when it lands, per-caller authentication (#32). `max_request_body_bytes`
-  is a 4 MiB POST cap with no rmcp 2.2 equivalent: kept as a memory bound but
-  pinned to the current SDK value, because it also ceilings `add_attachment`
+- **Every `StreamableHttpServerConfig` field is accounted for below** — set by
+  name or inherited for a stated reason. `http_server_config()` (server.rs)
+  names two; main.rs adds a third at the call site. The struct is
+  `#[non_exhaustive]`, so an SDK bump may grow it: a field this table does not
+  list is an unreviewed default, and adding the row is part of the bump, not a
+  follow-up. Counting them in prose is what let two fields go unlisted here
+  before.
+
+  | field | rmcp 3.1 default | this build |
+  |---|---|---|
+  | `allowed_hosts` | `localhost`, `127.0.0.1`, `::1` | **set** — `disable_allowed_hosts()` |
+  | `max_request_body_bytes` | 4 MiB | **set** — pinned to that same 4 MiB |
+  | `cancellation_token` | fresh token | **set** (main.rs) — a child of the process token |
+  | `allowed_origins` | `[]`, i.e. validation off | inherited, deliberately |
+  | `stateless_protocol_metadata_required` | `false` | inherited; #34 decides it |
+  | `legacy_session_mode` | `true` | inherited |
+  | `session_store` | `None` | inherited |
+  | `json_response` | `false` | inherited |
+  | `sse_keep_alive` / `sse_retry` | 15 s / 3 s | inherited |
+
+  `allowed_hosts` is a DNS-rebinding defence for MCP servers a browser can
+  reach on localhost, and its default would refuse every deployment not
+  addressed as `localhost`, containers included; bugwarden disables it
+  deliberately, since its access control is the network boundary and, when it
+  lands, per-caller authentication (#32). `max_request_body_bytes` is a 4 MiB
+  POST cap with no rmcp 2.2 equivalent: kept as a memory bound but pinned to
+  the current SDK value, because it also ceilings `add_attachment`
   independently of `global.max_attachment_bytes` and an SDK bump must not move
-  an operator-visible limit. Reconciling the two ceilings is #52.
+  an operator-visible limit. Reconciling the two ceilings is #52. The
+  `cancellation_token` is named so ctrl_c tears the live transport down with
+  the process instead of leaving it to outlive the shutdown.
+
+  `allowed_origins` is the browser-facing sibling of `allowed_hosts`, and the
+  #32 argument covers it identically. It is inherited rather than named because
+  the empty default IS the disabled state — `origin_is_allowed` returns true on
+  an empty list, exactly what `disable_allowed_origins()` would produce — so
+  naming it would assert nothing the default does not already say. The
+  asymmetry with `allowed_hosts` is real and not an oversight: the host default
+  refuses ordinary requests from this build's clients, whereas Origin is only
+  checked when the header is present and a non-browser MCP client does not send
+  one. An rmcp that shipped a non-empty `allowed_origins` still would not lock
+  such a client out.
+
+  `stateless_protocol_metadata_required` is the transport-level enforcement of
+  the per-request `_meta` that the handshake-free lifecycle needs. It must stay
+  `false` while this build serves the legacy revisions: rmcp clients negotiated
+  below `2026-07-28` do not attach that metadata, so enabling it refuses their
+  ordinary requests, and the field's own rustdoc says a server using it should
+  advertise only `2026-07-28` and later. Adopting the revision (#34) therefore
+  has to pick one — enforce at the transport and drop `2024-11-05` through
+  `2025-11-25`, or keep them and enforce in the handler — and that choice
+  belongs to #34, not here. Moot today: `skips_the_handshake` refuses the whole
+  request class before it reaches a tool. `legacy_session_mode` is inherited
+  `true`, so sessions exist for the revisions served; per SEP-2567 rmcp serves
+  `2026-07-28` requests statelessly whatever this flag says, which #34 inherits
+  rather than configures. `session_store` stays `None`: the client's
+  `initialize` parameters remain in-process, and there is one process here and
+  no cross-instance recovery to do. `json_response`, `sse_keep_alive` and
+  `sse_retry` set response framing and SSE liveness — client-visible timing,
+  with no guard or operator-visible limit riding on them.
 - axum MUST be 0.8 (rmcp's version — extension extraction breaks otherwise);
   schemars 1.x with feature `chrono04`; tokio 1; tokio-util 0.7.
 - Server struct: `#[derive(Clone)] pub struct BugWarden { cfg: Arc<Cli>, guard: Arc<Guard>, bz: Arc<BugzillaClient>, tool_router: ToolRouter<Self>, key_custody: KeyCustody, audit: Option<Arc<AuditState>> }`
@@ -1028,7 +1078,7 @@ wired, `server.rs` and `main.rs` are the reference.
   update_bug_fields, update_bug_dependencies, add_cc_to_bug, mark_as_duplicate,
   create_bug, add_attachment.
 - API key resolution: a match on `key_custody` (resolved once at startup, see Key custody — never re-read per request): `Server(key)` => the server's key, without touching the request at all; `PerRequest` => `ctx.extensions.get::<axum::http::request::Parts>()`, then `parts.headers.get(lowercased_header_name)`.
-- HTTP serving: `StreamableHttpService::new(move || Ok(server.clone()), LocalSessionManager::default().into(), StreamableHttpServerConfig::default())`, `axum::Router::new().nest_service("/mcp", service)`, `tokio::net::TcpListener::bind`, graceful shutdown on ctrl_c.
+- HTTP serving: `StreamableHttpService::new(move || Ok(server.clone()), LocalSessionManager::default().into(), http_server_config().with_cancellation_token(ct.child_token()))` — never a bare `StreamableHttpServerConfig::default()`, see the field table above — then `axum::Router::new().nest_service("/mcp", service)`, `tokio::net::TcpListener::bind`, graceful shutdown on ctrl_c cancelling `ct`.
 - Request `_meta` (SEP-414, e.g. `traceparent`): over every serialized
   transport the wire `params._meta` does NOT arrive in the params struct
   (`CallToolRequestParams.meta` stays `None`) — the SDK's custom

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -929,10 +929,20 @@ Decisions, all deliberate:
 
 ## rmcp 3.1 usage notes
 
-Cached reference files (read them): `/tmp/counter.rs` (tool_router + #[tool] +
-Parameters + #[tool_handler] ServerHandler + get_info), `/tmp/cstdio.rs`
-(stdio main), `/tmp/chttp.rs` (StreamableHttpService + axum main),
-`/tmp/rmcp-toolrouter.rs` (ToolRouter API incl. remove_route/has_route).
+Reference source is the rmcp this workspace pins, unpacked in the local
+registry: `~/.cargo/registry/src/*/rmcp-3.1.0/` — today's version, and the
+directory holding the `rmcp` package's `manifest_path` in `cargo metadata
+--format-version 1` on any day, so it follows `Cargo.lock` rather than a copy
+of it and is by construction the source this build compiles against. Every rmcp
+path cited below is relative to that tree's `src/`. The modules these notes rest
+on: `transport/streamable_http_server/tower.rs` (the transport config and both
+routing traps), `handler/server/router/tool.rs` (`ToolRouter`, incl.
+`remove_route` / `has_route` — I13), `model.rs` and `model/serde_impl.rs`
+(`InitializeResult`, the `_meta` strip), `service.rs` (the serve loop); the
+`#[tool_router]` / `#[tool_handler]` expansions are in the sibling
+`rmcp-macros-3.1.0` tree. The published crate carries no `examples/` — those
+live upstream at the `rmcp-v3.1.0` tag — but for how this server is actually
+wired, `server.rs` and `main.rs` are the reference.
 
 - `rmcp = { version = "3.1", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }`
 - Protocol revisions: `SUPPORTED_PROTOCOL_VERSIONS` (server.rs) lists what


### PR DESCRIPTION
Closes #59. Closes #60.

Both issues are defects in the same section of `docs/DESIGN.md` ("rmcp 3.1
usage notes"), and both are the same failure: the notes tell a reader to
check them against the SDK, and in two places they cannot. One commit each.

## `docs(design): cite the vendored rmcp tree, not /tmp copies` (#60)

The section opened by instructing the reader to read four files under
`/tmp`. They were working copies pulled during the 3.1 migration —
per-machine, cleared on reboot, no version stamp. It was the one
instruction in DESIGN.md a reader on a fresh checkout cannot satisfy.

Replaced with the unpacked registry source, per the issue's option 1:
present once the crate is fetched, the version in `Cargo.lock` by
construction, and where the traps documented further down were actually
verified. The notes now state that their rmcp paths are relative to that
tree's `src/`, so the citations and the reference agree.

**Correction to the issue's suggested fix:** it proposed citing "the
`examples/` directory of the same tree". The published crate ships no
`examples/` — only `src`, `tests`, `build.rs`, manifests, `CHANGELOG.md`,
`README.md`. Three of the four cached files were examples, so the commit
names the `rmcp-v3.1.0` tag they live at (tag confirmed to exist upstream)
and points at `server.rs`/`main.rs` as the closer reference for this
build's own wiring.

## `docs(design): inventory every StreamableHttpServerConfig field` (#59)

The count was wrong in both directions. Two fields were unlisted, as the
issue says — and a third, `cancellation_token`, is *set by name* in
`main.rs` and was also unlisted. The bullet additionally credited the
whole thing to `main.rs` when two of the three are set in
`http_server_config()` (`server.rs`).

Replaced the count with a table over the whole struct, so an absent field
reads as an unreviewed default rather than a settled one, plus a note that
the struct is `#[non_exhaustive]` and growing the table is part of the next
SDK bump. Every inherited field gets its reason.

**Third defect found while verifying, fixed here:** the HTTP-serving
bullet still showed the service built with a bare
`StreamableHttpServerConfig::default()`. That directly contradicts the
bullet above it and would have made the new completeness claim
self-defeating. It now shows what `main.rs` actually passes.

`http_server_config`'s rustdoc gained a pointer at `allowed_origins`,
since the risk the issue names — a future change to `allowed_hosts`
leaving Origin behind — plays out at that call site, not in DESIGN.md.

### On `allowed_origins`, per the acceptance criteria

Recorded as **inherited, deliberately**. The empty default *is* the
disabled state (`validate_origin_header` returns `Ok(())` on an empty
list), so naming it asserts nothing the default does not already say. The
asymmetry with `allowed_hosts` is not an oversight and is now stated as
such: the host default refuses ordinary requests from this build's
clients, whereas Origin is only validated when the header is present, and
a non-browser MCP client does not send one — so even an rmcp that shipped
a non-empty `allowed_origins` would not lock such a client out.

### On `stateless_protocol_metadata_required`

Named, with the constraint recorded and the decision left to #34: enabling
it refuses ordinary requests from clients negotiated below `2026-07-28`,
and its own rustdoc says a server using it should advertise only
`2026-07-28` and later. #34 must therefore pick one — enforce at the
transport and drop `2024-11-05` through `2025-11-25`, or keep them and
enforce in the handler. This PR records the either/or; it does not decide
it.

## Adversarial review

Run before opening, against the vendored `rmcp-3.1.0` source rather than
its changelog. No guard behaviour is touched (docs and rustdoc only), so
no invariant changes; I1–I15 are untouched and I13's `remove_route`
citation now resolves to `handler/server/router/tool.rs:456`.

Every added factual claim was re-derived from source: all ten struct
defaults against the `Default` impl; `disable_allowed_hosts`/
`disable_allowed_origins` both being `.clear()`; the empty-list early
returns in `host_is_allowed`, `origin_is_allowed` and
`validate_origin_header`; `ct.cancel()` actually firing on `ctrl_c` in
`main.rs`; `tool_router`/`tool_handler` living in `rmcp-macros-3.1.0`;
and the `rmcp-v3.1.0` tag existing upstream.

Two findings against my own draft, both fixed before the commits were
finalised rather than appended as fixups:

1. The first draft said the tree path "is the `rmcp` package's
   `manifest_path`". `manifest_path` is the `Cargo.toml`; the tree is its
   parent directory. Reworded — a reference-accuracy commit must not ship
   an inaccurate reference.
2. The table originally omitted that `cancellation_token` is set by name,
   which would have reproduced #59's exact defect in the fix for it.

Not fixed here, deliberately: rmcp **3.1.1** was published today
(2026-08-05), after these issues were filed. It does not touch
`transport/streamable_http_server/tower.rs`, so the table stays accurate
and `Cargo.lock` still pins 3.1.0. Its changes are to the cache-hint
macros (upstream #1114/#1120), which bugwarden is insulated from by
hand-writing `list_tools`. A bump belongs in its own PR.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D
warnings`, `cargo clippy -p bugwarden --features gen --all-targets -- -D
warnings`, `cargo test --workspace --all-targets --locked` (357 passed, 0
failed), `cargo deny check` (advisories/bans/licenses/sources ok) — all
green on HEAD. The first commit touches only `docs/DESIGN.md`, so both
commits are bisectable. `cargo doc` emits two warnings, both pre-existing
and unrelated (`server.rs:2639`, `config.rs:33`).
