### PR TITLE
docs(readme): use an absolute URL for the logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/logo.svg" alt="bugwarden logo" width="180">
+  <img src="https://raw.githubusercontent.com/plusky/bugwarden/main/assets/logo.svg" alt="bugwarden logo" width="180">
 </p>
 
 # bugwarden


### PR DESCRIPTION
The logo does not render on either crate's crates.io page
([bugwarden](https://crates.io/crates/bugwarden),
[bugwarden-core](https://crates.io/crates/bugwarden-core)), while it has
always rendered correctly on GitHub.

## Cause

Not a missing file, and not HTML sanitization — crates.io keeps the `<img>`
tag. It resolves relative README paths against **the directory the crate's
README lives in**. Both crates set `readme = "README.md"`, and both of those
are symlinks to the root `README.md`, so the base becomes `crates/bugwarden/`
rather than the repository root. `assets/logo.svg` was therefore baked into
the published page as:

| URL | status |
|---|---|
| `.../raw/HEAD/crates/bugwarden/assets/logo.svg` — what crates.io generated | **404** |
| `.../raw/HEAD/assets/logo.svg` — where the file actually is | 200 |

GitHub renders the same file with the repository root as its base, so the
relative path resolves there. One README, two different bases — no relative
path can satisfy both.

## Fix

Name the source absolutely:

```html
<img src="https://raw.githubusercontent.com/plusky/bugwarden/main/assets/logo.svg" ...>
```

Verified 200, and it renders under both renderers. `main` is pinned rather
than a tag so each page shows the current logo; a tag would freeze every
release page to the logo of its time.

This is the only relative asset reference in the README, and because both
crates share the file, the one change fixes both pages.

## Scope limit

crates.io renders a README **once at publish time** and serves the frozen
HTML from `static.crates.io`. This cannot repair the already-published pages
for 0.1.0–0.3.0; it takes effect with the next published version.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace --all-targets --locked` (357 passed, 0 failed) — all
green. The rendered-URL claims above were checked against the live
`crates.io/api/v1/crates/bugwarden/0.3.0/readme` output and by requesting
both GitHub URLs.