### PR TITLE
docs(design): record the stateless-metadata decision for #34

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1059,8 +1059,17 @@ wired, `server.rs` and `main.rs` are the reference.
   ordinary requests, and the field's own rustdoc says a server using it should
   advertise only `2026-07-28` and later. Adopting the revision (#34) therefore
   has to pick one — enforce at the transport and drop `2024-11-05` through
-  `2025-11-25`, or keep them and enforce in the handler — and that choice
-  belongs to #34, not here. Moot today: `skips_the_handshake` refuses the whole
+  `2025-11-25`, or keep them and enforce in the handler. **DECIDED 2026-08-05:
+  keep the legacy revisions and enforce in the handler**, so this field stays
+  `false` and #34 adds `2026-07-28` to the existing list rather than replacing
+  it. Flipping it to `true` is not a tuning knob: it silently drops every
+  revision this build serves. The rejected alternative is rejected on timing,
+  not on cleanliness — transport-level enforcement is the tidier mechanism, but
+  `2026-07-28` is not yet even rmcp's own `LATEST` (upstream PR #1105 is open),
+  so taking it now would strand every current client to gain validation the
+  handler can do itself, in a handler that already polices this exact request
+  class. Revisit when the ecosystem has moved and dropping the legacy revisions
+  costs little. Moot until then: `skips_the_handshake` refuses the whole
   request class before it reaches a tool. `legacy_session_mode` is inherited
   `true`, so sessions exist for the revisions served; per SEP-2567 rmcp serves
   `2026-07-28` requests statelessly whatever this flag says, which #34 inherits


### PR DESCRIPTION
Records the decision that `docs/DESIGN.md` previously deferred to #34.

The `StreamableHttpServerConfig` inventory laid out the either/or that
adopting `2026-07-28` forces, then said the choice "belongs to #34, not
here". **Decided: keep the legacy revisions and enforce the per-request
`_meta` in the handler**, leaving `stateless_protocol_metadata_required` at
`false`.

## Why record it in DESIGN.md rather than only in the issue

The field sits one line away from two that *are* set by name, so it reads
like a knob someone could flip. It isn't: setting it `true` silently
refuses every client negotiated below `2026-07-28` — which is every
revision this build currently serves (`2024-11-05` through `2025-11-25`).
The note now says so at the point of use.

## Why the alternative lost

On timing, not on design — kept legible per this document's practice of
recording rejected options. Transport-level enforcement is the tidier
mechanism, but `2026-07-28` is not yet rmcp's own `LATEST` (upstream PR
\#1105 is still open), so taking it now would strand every existing client
to gain validation the handler can perform itself — in a handler that
already polices this exact request class via `skips_the_handshake`. It
becomes the right answer once dropping the legacy revisions is cheap, and
the note says to revisit it then.

## Effect on #34

None of #34's acceptance criteria are contradicted by this; they were
silent on where enforcement happens. It confirms the plan as written —
`2026-07-28` is *added* to `SUPPORTED_PROTOCOL_VERSIONS` rather than
replacing its contents. I've noted the missing criterion on the issue.

No behaviour change: the field was already `false` by inheritance, and no
code path moves.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D
warnings`, `cargo test --workspace --all-targets --locked` (357 passed, 0
failed) — green.