### PR TITLE
fix(policy): stop shipping the whoami-dependent example rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ write two consecutive rules.
 | `summary_contains` | array of strings | case-insensitive substring search in the bug's one-line summary |
 | `group_restricted` | boolean | `true` matches bugs readable only through at least one Bugzilla group, `false` matches world-readable bugs |
 | `younger_than_days` | integer | matches bugs created within the last N days |
-| `created_by_me` | boolean | whether the API key's account authored the bug: the caller's login is resolved per request via Bugzilla's `whoami` endpoint (at most one lookup per tool call, and none at all under a policy without an access-covering `created_by_me` rule — a rule scoped to `operations = ["create"]` alone never triggers a lookup) and compared case-insensitively to the bug's creator. `true` matches the caller's own reports, `false` everyone else's. An unresolvable identity (`whoami` failure) makes the criterion **unknown**, which denies (see Unreadable metadata). In the create gate the prospective bug always counts as created by the caller — no lookup happens there. Older bugwarden versions reject a policy using this key at startup (strict parsing fails closed) |
+| `created_by_me` | boolean | whether the API key's account authored the bug: the caller's login is resolved per request via Bugzilla's `whoami` endpoint (at most one lookup per tool call, and none at all under a policy without an access-covering `created_by_me` rule — a rule scoped to `operations = ["create"]` alone never triggers a lookup) and compared case-insensitively to the bug's creator. `true` matches the caller's own reports, `false` everyone else's. **`whoami` is not part of stock Bugzilla Core v1** — it is a fork/BMO extension — so on a deployment without it every lookup fails. An unresolvable identity (`whoami` failure or absence) makes the criterion **unknown**, which denies (see Unreadable metadata); a policy that consults this criterion therefore denies everything it reaches on such a deployment. In the create gate the prospective bug always counts as created by the caller — no lookup happens there. Older bugwarden versions reject a policy using this key at startup (strict parsing fails closed) |
 
 #### Unreadable metadata
 
@@ -447,14 +447,16 @@ of an unexpected type, or a list with an element the parser cannot read. Such
 a field is **unknown**, and a rule that consults one is undecidable: it neither
 holds nor fails. One criterion needs more than the bug object:
 `created_by_me` also needs the caller's identity, and if either half is
-missing — an unreadable creator, or a `whoami` lookup that failed — it is
-just as undecidable and resolves the same way. A policy consulting identity
-therefore denies everything its identity rules are consulted for while
-`whoami` is failing; that is deliberate (treating unknown identity as "does
-not match" would let a `created_by_me` deny rule be defeated by breaking
-`whoami`). The criterion cannot widen exposure beyond the credential:
-Bugzilla enforces its own permissions on every fetch, so an authorship rule
-only surfaces bugs the API key could already read.
+missing — an unreadable creator, or a `whoami` lookup that failed or does
+not exist on the deployment — it is just as undecidable and resolves the
+same way. A policy consulting identity therefore denies everything its
+identity rules are consulted for while `whoami` is unavailable — including
+permanently, on a stock Bugzilla Core v1 deployment that never exposes it;
+that is deliberate (treating unknown identity as "does not match" would let
+a `created_by_me` deny rule be defeated by breaking `whoami`). The criterion
+cannot widen exposure beyond the credential: Bugzilla enforces its own
+permissions on every fetch, so an authorship rule only surfaces bugs the API
+key could already read.
 
 bugwarden resolves an undecidable rule by **denying the bug**, whatever the
 rule's action. A `deny` rule denies because the bug may well be what it was

--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -1830,9 +1830,12 @@ products = ["NoView*"]
         assert!(!g.may_create(&req), "claimed groups: refused");
 
         // Every read below runs with the caller's identity KNOWN, as
-        // resolve_caller provides it in production: the "my-own-reports"
-        // rule consults created_by_me, so identity-unknown classification
-        // is a different (pinned further down) regime.
+        // resolve_caller provides it in production. The shipped file's
+        // "my-own-reports" rule (section 0b) ships commented out — see
+        // `identity_carveout_grants_own_restricted_bugs_and_blackouts_on_unknown_identity`
+        // below for that opt-in's pin — so these reads never actually
+        // consult created_by_me; the caller value only has to be threaded
+        // through BugMeta::from_json's signature.
         let caller = Some("reporter@example.com");
 
         // Issue #26: the create grant is scoped away from access, so an
@@ -1886,10 +1889,88 @@ products = ["NoView*"]
             "group-restricted desktop bugs must stay denied"
         );
 
-        // The identity carve-out ("my-own-reports"): the SAME
-        // group-restricted bug, authored by the caller, is readable —
-        // reads, comments, history and attachment listing, and nothing
-        // that writes.
+        // The identity carve-out ships DISABLED (section 0b, commented out):
+        // whoami is a fork/BMO extension, not stock Bugzilla Core v1, so the
+        // example cannot assume it exists. Consequently the SAME
+        // group-restricted bug, even authored by the caller, is denied here
+        // exactly like anyone else's — the shipped file never consults
+        // created_by_me at all. The carve-out's enabled behaviour, and its
+        // whoami-failure blackout, are pinned separately below against an
+        // inline literal that turns it on (the shipped file, with the rule
+        // commented out, cannot pin behaviour that never runs).
+        let mut own_restricted_json = restricted_foreign.clone();
+        own_restricted_json["creator"] = json!("reporter@example.com");
+        let own_restricted = BugMeta::from_json(&own_restricted_json, caller);
+        assert!(
+            matches!(
+                g.policy
+                    .classify(&own_restricted, Utc::now(), Operation::Access),
+                Access::Denied { .. }
+            ),
+            "shipped policy denies the caller's own group-restricted bug too: \
+             the my-own-reports carve-out ships commented out"
+        );
+    }
+
+    #[test]
+    fn identity_carveout_grants_own_restricted_bugs_and_blackouts_on_unknown_identity() {
+        // examples/policy.toml documents this exact rule in section 0b, an
+        // opt-in the operator uncomments only after confirming their
+        // Bugzilla answers `GET /rest/whoami` (a fork/BMO extension, absent
+        // from stock Bugzilla Core v1 — see docs/DESIGN.md, "Identity
+        // resolution", Portability). Because the shipped file ships the
+        // rule commented out, it cannot itself pin the enabled behaviour;
+        // this inline literal — "my-own-reports" ahead of a
+        // group-restricting deny rule, the shape section 0b describes —
+        // does instead. Do NOT delete this pin: it is what guards the
+        // whoami-failure blackout (I4) against a later fail-open "fix".
+        let caller = Some("reporter@example.com");
+        let toml = concat!(
+            "default_action = \"allow\"\n",
+            "\n",
+            "[[rule]]\n",
+            "name = \"my-own-reports\"\n",
+            "action = \"restrict\"\n",
+            "capabilities = [\"read\", \"comments\", \"history\", \"attachments\"]\n",
+            "operations = [\"access\"]\n",
+            "[rule.match]\n",
+            "created_by_me = true\n",
+            "\n",
+            "[[rule]]\n",
+            "name = \"group-restricted\"\n",
+            "action = \"deny\"\n",
+            "[rule.match]\n",
+            "group_restricted = true\n",
+        );
+        let g = Guard {
+            policy: policy(toml),
+        };
+
+        let restricted_foreign = json!({
+            "id": 501,
+            "summary": "totem crashes when seeking in a webm file",
+            "product": "GNOME Multimedia",
+            "component": "totem",
+            "groups": ["secteam"],
+            "keywords": [],
+            "whiteboard": "",
+            "status": "NEW",
+            "creator": "other.person@example.com",
+            "creation_time": "2020-01-01T00:00:00Z",
+        });
+        let restricted = BugMeta::from_json(&restricted_foreign, caller);
+        assert!(
+            matches!(
+                g.policy
+                    .classify(&restricted, Utc::now(), Operation::Access),
+                Access::Denied { .. }
+            ),
+            "group-restricted bugs someone else filed must stay denied"
+        );
+
+        // The identity carve-out: the SAME group-restricted bug, authored by
+        // the caller, is readable — reads, comments, history and attachment
+        // listing, and nothing that writes.
         let mut own_restricted_json = restricted_foreign.clone();
         own_restricted_json["creator"] = json!("reporter@example.com");
         let own_restricted = BugMeta::from_json(&own_restricted_json, caller);
@@ -1914,12 +1995,25 @@ products = ["NoView*"]
             );
         }
 
-        // Identity unknown (whoami failed): the my-own-reports rule cannot
-        // be decided for ANY bug it is consulted for, and an undecidable
-        // consulted rule denies (I4) — the caller's own restricted bug AND
-        // the world-readable public bug alike. This blackout is the
-        // deliberate fail-closed reading; do not "fix" it into fail-open.
-        for bug_json in [&own_restricted_json, &restricted_foreign] {
+        // Identity unknown (whoami failed, or the endpoint does not exist on
+        // this deployment): the my-own-reports rule cannot be decided for
+        // ANY bug it is consulted for, and an undecidable consulted rule
+        // denies (I4) — the caller's own restricted bug AND a world-readable
+        // public bug alike. This blackout is the deliberate fail-closed
+        // reading; do not "fix" it into fail-open.
+        let public_json = json!({
+            "id": 500,
+            "summary": "totem crashes when seeking in a webm file",
+            "product": "GNOME Multimedia",
+            "component": "totem",
+            "groups": [],
+            "keywords": [],
+            "whiteboard": "",
+            "status": "NEW",
+            "creator": "other.person@example.com",
+            "creation_time": "2020-01-01T00:00:00Z",
+        });
+        for bug_json in [&own_restricted_json, &restricted_foreign, &public_json] {
             let unknown = BugMeta::from_json(bug_json, None);
             assert!(
                 matches!(
@@ -1930,29 +2024,6 @@ products = ["NoView*"]
                 bug_json["id"]
             );
         }
-        let public_unknown = BugMeta::from_json(
-            &json!({
-                "id": 500,
-                "summary": "totem crashes when seeking in a webm file",
-                "product": "GNOME Multimedia",
-                "component": "totem",
-                "groups": [],
-                "keywords": [],
-                "whiteboard": "",
-                "status": "NEW",
-                "creator": "other.person@example.com",
-                "creation_time": "2020-01-01T00:00:00Z",
-            }),
-            None,
-        );
-        assert!(
-            matches!(
-                g.policy
-                    .classify(&public_unknown, Utc::now(), Operation::Access),
-                Access::Denied { .. }
-            ),
-            "even a world-readable desktop bug is denied while identity is unknown"
-        );
     }
 
     #[test]

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -681,6 +681,16 @@ where every other criterion describes bug content. Decisions, all deliberate:
 - **Deliberately not implemented.** `assigned_to_me` and `cc_me` are the
   natural extensions of this mechanism; they are intentionally absent, not
   forgotten.
+- **Portability.** `GET /rest/whoami` is not in the current Bugzilla Core v1
+  REST reference (`login`, `logout`, `valid_login`, `user`, `version`,
+  `extensions`, `timezone`, `time`, `last_audit_time`, `parameters`) — it is
+  a fork/BMO extension. On a stock deployment every lookup fails, every
+  `created_by_me` criterion is `Unknown`, and I4 denies everything a
+  `created_by_me` rule is consulted for: a blackout, not a narrower grant.
+  Because of this, `examples/policy.toml` ships its `created_by_me` rule
+  ("my-own-reports") commented out — documented as an opt-in the operator
+  enables only after confirming their Bugzilla answers `whoami` — rather
+  than active by default.
 
 ## MCP tool surface (crates/bugwarden/src/server.rs)
 
@@ -1177,8 +1187,11 @@ wired, `server.rs` and `main.rs` are the reference.
   header: it parses, accepts filing into the desktop products, refuses an
   embargo-marked title everywhere, refuses filing elsewhere (omitted and
   claimed group lists alike), keeps existing world-readable desktop bugs
-  fully readable (the issue-#26 regression surface), and keeps
-  group-restricted desktop bugs denied; created_by_me — the TOML spelling
+  fully readable (the issue-#26 regression surface), keeps group-restricted
+  desktop bugs denied, and — since the "my-own-reports" identity rule ships
+  commented out (Portability, above) — denies the caller's own
+  group-restricted bug exactly like anyone else's, proving the shipped file
+  never consults `created_by_me` at all; created_by_me — the TOML spelling
   `created_by_me = true|false` is pinned and an absent key is None;
   evaluate semantics ((true, Some(true)) holds, (true, Some(false)) fails,
   (true, None) is Unknown and a consulted rule then denies for a deny rule
@@ -1191,13 +1204,16 @@ wired, `server.rs` and `main.rs` are the reference.
   when the only identity rule is operations = ["create"]; may_create
   forces created_by_me true without any client or whoami (a create-covering
   deny rule on created_by_me = true refuses creation, one on
-  created_by_me = false never matches a create); and the shipped-example
-  pin extends to identity: with the caller known, a group-restricted bug
-  the caller authored grants exactly read/comments/history/attachments and
-  no write, the same bug authored by someone else stays Denied, and with
-  identity UNKNOWN both it and a world-readable desktop bug are Denied —
-  the whoami-failure blackout is pinned so it cannot be "fixed" into
-  fail-open later.
+  created_by_me = false never matches a create); and the "my-own-reports"
+  rule's ENABLED behaviour is pinned separately, against an inline literal
+  reproducing the same rule ahead of a group-restricting deny rule (the
+  shipped file cannot pin behaviour a commented-out rule never runs): with
+  the caller known, a group-restricted bug the caller authored grants
+  exactly read/comments/history/attachments and no write, the same bug
+  authored by someone else stays Denied, and with identity UNKNOWN that
+  bug, the foreign one, and a world-readable bug are all Denied — the
+  whoami-failure blackout is pinned so it cannot be "fixed" into fail-open
+  later.
 - Unit tests (#[cfg(test)] in crates/bugwarden/src/server.rs): assemble_bug_info
   re-classification — a body embargoed after the verdict is refused, a body
   that now earns only summary is downgraded, a body granting neither read nor

--- a/examples/policy.toml
+++ b/examples/policy.toml
@@ -3,25 +3,22 @@
 #
 # The scenario this file implements:
 #
-#   * the caller's OWN bug reports — bugs authored by the account whose API
-#     key makes the request — are always readable (read, comments, history,
-#     attachments; no writes), even when a rule below would hide them: see
-#     "my-own-reports" in section 0b, an explicit opt-in that is evaluated
-#     before every deny rule and comes with a documented whoami-failure
-#     blackout;
-#   * undisclosed (embargoed) security bugs are otherwise completely
-#     invisible;
+#   * undisclosed (embargoed) security bugs are completely invisible;
 #   * so is every other bug that is not world-readable — see rule 1, which
 #     is deliberately broader than "security" and can be narrowed;
 #   * bugs in groups NAMED like security groups are invisible in their own
-#     right (except the caller's own — section 0b matches first) — see
-#     "security-groups", which keeps denying them even after rule 1 is
-#     narrowed or removed;
+#     right — see "security-groups", which keeps denying them even after
+#     rule 1 is narrowed or removed;
 #   * bugs labelled "security" are invisible while they are fresher than
-#     5 days (the window in which details are typically still unreviewed),
-#     again excepting the caller's own;
-#   * every other bug (not the caller's own — those take the read-only
-#     grant of "my-own-reports" first) is shown to the user in full;
+#     5 days (the window in which details are typically still unreviewed);
+#   * every other bug is shown to the user in full;
+#   * OPTIONAL, SHIPPED DISABLED: the caller's OWN bug reports — bugs
+#     authored by the account whose API key makes the request — can be made
+#     always readable (read, comments, history, attachments; no writes),
+#     even where a rule above would hide them. This needs a Bugzilla that
+#     exposes an identity endpoint (stock Bugzilla Core v1 does not — see
+#     section 0b) and comes with a documented identity-failure blackout, so
+#     it ships commented out rather than enabled by default;
 #   * new bug reports are accepted into the desktop products ONLY — see the
 #     "reporters" rule in section 0, whose `operations = ["create"]` scope
 #     grants filing without touching what may be read — except that a title
@@ -156,27 +153,42 @@ operations = ["create"]
 products = ["GNOME*", "KDE*"]
 
 # ---------------------------------------------------------------------------
-# 0b. The caller's own reports: readable even where the rules below would
-#     hide them.
+# 0b. OPTIONAL, SHIPPED DISABLED: the caller's own reports, readable even
+#     where the rules below would hide them.
 #
-# `created_by_me = true` matches bugs AUTHORED by the account whose API key
-# makes the request — the one identity-relative criterion. The server
-# resolves the caller's login at most once per tool call (GET /rest/whoami,
-# only when a policy actually uses this criterion) and compares it
-# case-insensitively against the bug's creator. Placed ABOVE the deny rules,
-# this rule carves the caller's own reports out of them: people keep
-# following the bugs they themselves filed — group-restricted ones included
-# — while everyone else's hidden bugs stay hidden. Reading is granted,
-# writing is not, so "follow your own report" does not become "edit your
-# own report". Note the flip side of first-match-wins: the caller's own
-# WORLD-READABLE bugs also take this rule first and are therefore read-only
-# through this server under this example.
+# PREREQUISITE, CHECK THIS FIRST: this rule needs a Bugzilla deployment that
+# exposes an identity endpoint. The current Bugzilla Core v1 REST reference
+# does not define `/rest/whoami` — it is a fork/BMO extension (see
+# docs/DESIGN.md, "Identity resolution", Portability) — so on a stock
+# instance every lookup fails, the caller's identity is always unknown, and
+# — per the fail-closed behaviour below — this rule alone denies EVERY
+# access classification it is consulted for the moment it is enabled. That
+# is why this rule ships commented out rather than active: an example file
+# cannot know whether the operator's Bugzilla has the endpoint, and enabling
+# it against one that does not is a silent blackout, not a carve-out.
+# Confirm your deployment answers `GET /rest/whoami` before uncommenting the
+# `[[rule]]` block below.
 #
-# This rule is an EXPLICIT OPT-IN — an operator who does not want it simply
-# omits it and keeps today's behaviour. In particular, a deployment whose
-# clients share one service-account API key should NOT carry this rule:
-# there, "created by me" means "created by the service account", a set of
-# bugs no individual user has a personal claim to.
+# Once confirmed, `created_by_me = true` matches bugs AUTHORED by the
+# account whose API key makes the request — the one identity-relative
+# criterion. The server resolves the caller's login at most once per tool
+# call (GET /rest/whoami, only when a policy actually uses this criterion)
+# and compares it case-insensitively against the bug's creator. Placed
+# ABOVE the deny rules, this rule carves the caller's own reports out of
+# them: people keep following the bugs they themselves filed —
+# group-restricted ones included — while everyone else's hidden bugs stay
+# hidden. Reading is granted, writing is not, so "follow your own report"
+# does not become "edit your own report". Note the flip side of
+# first-match-wins: the caller's own WORLD-READABLE bugs also take this
+# rule first and are therefore read-only through this server under this
+# example.
+#
+# This rule is an EXPLICIT OPT-IN even where the endpoint exists — an
+# operator who does not want it simply leaves it commented out and keeps
+# today's behaviour. In particular, a deployment whose clients share one
+# service-account API key should NOT enable this rule: there, "created by
+# me" means "created by the service account", a set of bugs no individual
+# user has a personal claim to.
 #
 # The `operations = ["access"]` scope matters: the create gate treats a
 # prospective bug as created by the caller (the account filing a bug IS its
@@ -189,11 +201,12 @@ products = ["GNOME*", "KDE*"]
 # Failure mode, deliberate: if the whoami lookup fails, the caller's
 # identity is unknown, this rule can be decided for NO bug, and an
 # undecidable consulted rule denies whatever its action (see "Unreadable
-# metadata" above). While whoami is down, a policy that leads with this
-# rule therefore denies every read — a blackout — rather than serving what
-# an unverified identity should not see. That is the only uniformly
-# fail-closed reading: treating unknown identity as "criterion fails"
-# would let a created_by_me deny rule be dodged by making whoami fail.
+# metadata" above). While whoami is down (or simply absent — see the
+# prerequisite above), a policy that leads with this rule therefore denies
+# every read — a blackout — rather than serving what an unverified identity
+# should not see. That is the only uniformly fail-closed reading: treating
+# unknown identity as "criterion fails" would let a created_by_me deny rule
+# be dodged by making whoami fail.
 #
 # This criterion cannot widen exposure beyond the credential: Bugzilla
 # still enforces its own permissions on every fetch, so an authorship rule
@@ -204,18 +217,21 @@ products = ["GNOME*", "KDE*"]
 # `created_by_me` at startup — parsing is strict, so the whole file fails
 # closed instead of the rule being silently ignored.
 
-[[rule]]
-name = "my-own-reports"
-description = "Bugs the caller's own account filed stay readable, never writable"
-action = "restrict"
-capabilities = ["read", "comments", "history", "attachments"]
-operations = ["access"]
-[rule.match]
-created_by_me = true
+# Uncomment the block below ONLY after confirming your Bugzilla answers
+# GET /rest/whoami (see the prerequisite above).
+#[[rule]]
+#name = "my-own-reports"
+#description = "Bugs the caller's own account filed stay readable, never writable"
+#action = "restrict"
+#capabilities = ["read", "comments", "history", "attachments"]
+#operations = ["access"]
+#[rule.match]
+#created_by_me = true
 
 # ---------------------------------------------------------------------------
 # 1. Undisclosed security bugs: fully invisible, at any age (the caller's
-#    own excepted, as everywhere below — section 0b matches first).
+#    own excepted too, as everywhere below, if the optional section 0b
+#    carve-out is enabled — it matches first).
 #
 # An issue under embargo is one whose public disclosure date has not arrived
 # yet, and it is normally recognisable two ways, independently: the bug is
@@ -297,18 +313,17 @@ keywords = ["security-embargo", "embargo*"]
 #
 # Both criteria are AND-ed, so these rules hide a bug only while it is BOTH
 # security-labelled AND younger than 5 days. Once a world-readable bug ages
-# past the window, no deny rule matches it any more: unless it is the
-# caller's own (then "my-own-reports" grants it read-only, as at any age),
-# default_action ("allow") applies and it becomes fully visible without any
-# policy change. (A group-restricted bug someone else filed stays hidden at
-# any age: rule 1 catches it first. The caller's own group-restricted bugs
-# take "my-own-reports" first instead — readable, never writable.)
+# past the window, no deny rule matches it any more and default_action
+# ("allow") applies, so it becomes fully visible without any policy change.
+# (A group-restricted bug someone else filed stays hidden at any age: rule 1
+# catches it first. If the optional "my-own-reports" carve-out from section
+# 0b is enabled, the caller's own bugs — group-restricted or not — take that
+# rule first instead: readable, never writable, at any age.)
 #
 # Two rules because "security" can be expressed two ways here; drop the one
 # your instance does not use. A group-based variant would be pointless: any
 # bug in a security group that someone else filed is already denied by
-# rule 1, and the caller's own are already carved out by "my-own-reports",
-# group-based rule or not.
+# rule 1 regardless.
 # ---------------------------------------------------------------------------
 
 [[rule]]


### PR DESCRIPTION
**First of a three-PR series** fixing `created_by_me`'s dependency on
a non-stock `/rest/whoami` endpoint. This PR (A) defuses the shipped
example only; a follow-up PR (B) adds a startup preflight probe so a
missing identity endpoint fails loudly instead of silently, and a
further PR (C) adds a portable, verified identity source usable
without `whoami` at all.

## What

`GET /rest/whoami` is not part of the current Bugzilla Core v1 REST
reference (`login`, `logout`, `valid_login`, `user`, `version`,
`extensions`, `timezone`, `time`, `last_audit_time`, `parameters`) —
it is a fork/BMO extension. `examples/policy.toml` shipped an active
`created_by_me` rule ("my-own-reports") placed above every deny
rule. On a stock deployment every `whoami` lookup fails, the
caller's identity is always unknown, and the fail-closed handling of
an undecidable consulted rule (I4) then denies every access
classification the rule is consulted for — a silent blackout, not
the documented carve-out.

This PR:

- Comments out the `my-own-reports` rule in `examples/policy.toml`
  and reworks section 0b's prose to lead with the `whoami`
  prerequisite; updates every other comment in the file that assumed
  the carve-out was active by default (it is now an explicit,
  documented opt-in, disabled by default).
- Documents in `README.md` and `docs/DESIGN.md` that `whoami` is not
  portable and that an unresolvable identity denies permanently on
  a deployment that lacks it (a new "Portability" bullet under
  "Identity resolution").
- No Rust behavior changes — docs and the example policy only.

## DESIGN.md invariants touched

- **I4** (fail closed on undecidable rules) — untouched in behavior;
  this PR only makes the failure mode explicit in docs/comments and
  keeps its test pin (see below). No guard weakened.
- **I2** (uniform denial text) — untouched.

## Test changes

The shipped-example pin test
(`shipped_example_policy_files_into_desktop_products_only_and_keeps_reads`)
previously asserted the `my-own-reports` carve-out's enabled
behavior straight from the shipped file. Since the rule now ships
commented out, that assertion no longer reflects reality; it is
replaced with an assertion that the shipped file denies the caller's
own group-restricted bug exactly like anyone else's (i.e. the file
never consults `created_by_me` by default).

A new test,
`identity_carveout_grants_own_restricted_bugs_and_blackouts_on_unknown_identity`,
pins the carve-out's *enabled* behavior — including the
whoami-failure blackout (I4) — against an inline policy literal
reproducing the same rule shape. This preserves the blackout pin the
original test carried without relying on a rule the shipped file no
longer runs by default.

## Verification

Ran on this PR in isolation:

```
cargo fmt --check
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo clippy -p bugwarden --features gen --all-targets --locked -- -D warnings
cargo test --workspace --all-targets --locked
cargo deny check
typos
```

All pass. `rg -n 'created_by_me' examples/policy.toml` shows the
criterion only in comments — no active rule.