### PR TITLE
feat(server): fail startup when identity cannot be resolved

### DIFF
--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -830,8 +830,19 @@ impl Guard {
             Ok(login) => Some(login),
             Err(err) => {
                 // Sanitized by the client (I12); identity stays unknown and
-                // every consulted identity rule fails closed (I4).
-                tracing::debug!(error = %err, "whoami failed; caller identity unresolved");
+                // every consulted identity rule fails closed (I4). warn!,
+                // not debug!: under per-request key custody this per-call
+                // failure is the only diagnosis available (server-held
+                // custody also gets a startup preflight — see
+                // `BugWarden::preflight`) — a server that starts and then
+                // silently denies everything is exactly the blackout this
+                // is meant to surface.
+                tracing::warn!(
+                    error = %err,
+                    "whoami failed; caller identity unresolved (this endpoint may not exist \
+                     on this deployment — stock Bugzilla Core v1 does not define \
+                     /rest/whoami)"
+                );
                 None
             }
         }

--- a/crates/bugwarden/src/main.rs
+++ b/crates/bugwarden/src/main.rs
@@ -60,6 +60,11 @@ async fn main() -> anyhow::Result<()> {
     let cfg = Arc::new(cli);
     let server =
         server::BugWarden::new(cfg.clone(), guard, bz).context("failed to build the MCP server")?;
+    // Turns a silent whoami-blackout (I4 denying every created_by_me
+    // classification) into an actionable startup failure. Before the audit
+    // sink below: a failed preflight must not create or rotate an audit
+    // file (the same ordering rationale as key custody resolution above).
+    server.preflight().await?;
 
     // Audit stream, when configured. The fail mode falls back to the
     // transport-derived default; the policy digest ties every record to

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -1064,6 +1064,76 @@ impl BugWarden {
         self
     }
 
+    /// Turn a silent identity blackout into a loud startup failure.
+    ///
+    /// `Guard::resolve_caller` maps every `whoami` failure to `None`, and
+    /// I4 then denies every classification a `created_by_me` rule is
+    /// consulted for (see DESIGN.md, "Identity resolution") — correct, but
+    /// invisible: the server starts, looks healthy, and blacks out
+    /// silently. This probes the SAME endpoint once, before the server
+    /// serves a single tool call, so a deployment missing it (stock
+    /// Bugzilla Core v1 does not define `/rest/whoami`) fails to start
+    /// with a reason instead of failing open-looking-closed.
+    ///
+    /// Deliberately kept OUT of [`BugWarden::new`], which is sync and is
+    /// the construction path every integration test drives: moving the
+    /// probe there would give every one of those tests an unwanted
+    /// `whoami` call to account for. Call this once, after `new`, before
+    /// opening the audit sink (a failed preflight must not create or
+    /// rotate an audit file).
+    ///
+    /// Behaviour, by key custody:
+    /// - the policy consults no identity (`!Policy::needs_identity()`):
+    ///   `Ok(())` with ZERO upstream requests — the laziness contract
+    ///   (DESIGN.md) now covers startup too, not just tool calls;
+    /// - [`KeyCustody::Server`]: one `GET /rest/whoami`. Success logs the
+    ///   resolved login at `info!` and returns `Ok(())`; failure bails,
+    ///   naming the endpoint, that stock Bugzilla Core v1 does not define
+    ///   it, and that starting anyway would deny every access
+    ///   classification the policy's identity rules reach. The sanitized
+    ///   client error (I12: `whoami` already strips the URL) is attached
+    ///   as the error's source;
+    /// - [`KeyCustody::PerRequest`]: there is no server-held key to probe
+    ///   with — each caller authenticates, and therefore resolves
+    ///   identity, on their own request. `warn!` the same compatibility
+    ///   statement and return `Ok(())`: per-request custody stays
+    ///   correct per call (DESIGN.md, "Identity resolution"), it is only
+    ///   unverifiable up front.
+    pub async fn preflight(&self) -> anyhow::Result<()> {
+        use anyhow::Context as _;
+
+        if !self.guard.policy.needs_identity() {
+            return Ok(());
+        }
+        match &self.key_custody {
+            KeyCustody::Server(key) => match self.bz.whoami(key).await {
+                Ok(login) => {
+                    tracing::info!(login, "identity endpoint verified");
+                    Ok(())
+                }
+                Err(err) => Err(err).context(
+                    "GET /rest/whoami failed during startup preflight; the guard policy \
+                     consults created_by_me, which needs this endpoint to resolve the \
+                     caller's identity. Stock Bugzilla Core v1 does not define /rest/whoami \
+                     (it is a fork/BMO extension) — if this deployment does not have it, \
+                     starting anyway would deny every access classification the policy's \
+                     identity rules reach (I4). Confirm the endpoint exists, or remove the \
+                     created_by_me criteria from the policy",
+                ),
+            },
+            KeyCustody::PerRequest => {
+                tracing::warn!(
+                    "the policy consults created_by_me, but per-request key custody holds no \
+                     server-side key to verify /rest/whoami with at startup; each caller's \
+                     identity is still resolved per call, but an unreachable endpoint on this \
+                     deployment will only surface as a denial once a tool is called — stock \
+                     Bugzilla Core v1 does not define /rest/whoami (it is a fork/BMO extension)"
+                );
+                Ok(())
+            }
+        }
+    }
+
     /// The session an audit record belongs to. http: the server-assigned
     /// `mcp-session-id` header and, when the listener was built with
     /// connect-info, the remote peer address — both from the HTTP request

--- a/crates/bugwarden/tests/preflight_wiremock.rs
+++ b/crates/bugwarden/tests/preflight_wiremock.rs
@@ -1,0 +1,218 @@
+//! `BugWarden::preflight` — the startup identity probe (issue: `whoami`
+//! blackout, `plans/ISSUE_WHOAMI_IDENTITY.md` PR B).
+//!
+//! `Guard::resolve_caller` maps every `whoami` failure to `None`, and I4
+//! then denies every classification a `created_by_me` rule reaches — a
+//! deployment missing `/rest/whoami` (stock Bugzilla Core v1 does not
+//! define it) starts up looking healthy and silently blacks out every
+//! access classification the shipped `my-own-reports` carve-out covers.
+//! `preflight()` turns that into a startup failure the operator can act on.
+//!
+//! Coverage contract (each of these mutations must fail at least one test):
+//! - `preflight` returning `Ok` when `/rest/whoami` fails under server
+//!   custody;
+//! - `preflight` issuing a `whoami` request when the policy consults no
+//!   identity criterion (the laziness contract must hold at startup too);
+//! - `preflight` bailing under `KeyCustody::PerRequest` instead of
+//!   warning-and-continuing (there is no server-held key to probe with);
+//! - an API key leaking into a preflight error's text (I12).
+
+use std::sync::Arc;
+
+use bugwarden::config::Cli;
+use bugwarden::server::{BugWarden, USER_AGENT};
+use bugwarden_core::client::BugzillaClient;
+use bugwarden_core::guard::Guard;
+use bugwarden_core::policy::Policy;
+use clap::Parser as _;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// The issue's policy shape: an access-scoped `created_by_me` carve-out
+/// above a blanket group-restricted deny. This is what makes
+/// `Policy::needs_identity()` true.
+const IDENTITY_POLICY: &str = concat!(
+    "[[rule]]\nname = \"my-own-reports\"\naction = \"restrict\"\n",
+    "capabilities = [\"read\", \"comments\", \"history\", \"attachments\"]\n",
+    "operations = [\"access\"]\n",
+    "[rule.match]\ncreated_by_me = true\n",
+    "[[rule]]\nname = \"group-restricted\"\naction = \"deny\"\n",
+    "[rule.match]\ngroup_restricted = true\n",
+);
+
+/// A policy that never consults identity at all.
+const NO_IDENTITY_POLICY: &str = concat!(
+    "[[rule]]\nname = \"group-restricted\"\naction = \"deny\"\n",
+    "[rule.match]\ngroup_restricted = true\n",
+);
+
+/// Mount `GET /rest/whoami` answering with `login`, expected `hits` times.
+async fn mount_whoami(mock: &MockServer, login: &str, hits: u64) {
+    Mock::given(method("GET"))
+        .and(path("/rest/whoami"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": 1, "name": login, "real_name": "Reporter",
+        })))
+        .expect(hits)
+        .mount(mock)
+        .await;
+}
+
+/// Build a stdio (server-held key) `BugWarden` against `mock` with `policy`.
+fn server_custody_server(policy: &str, mock: &MockServer) -> BugWarden {
+    let mut cli = Cli::parse_from([
+        "bugwarden",
+        "--bugzilla-server",
+        &mock.uri(),
+        "--transport",
+        "stdio",
+        "--api-key",
+        "test-key",
+    ]);
+    cli.api_key_file = None; // the ambient environment must not leak in
+    let cfg = Arc::new(cli);
+    let guard = Arc::new(Guard {
+        policy: Policy::from_toml_str(policy).expect("test policy must parse"),
+    });
+    let bz =
+        Arc::new(BugzillaClient::new(&mock.uri(), false, USER_AGENT).expect("client must build"));
+    BugWarden::new(cfg, guard, bz).expect("server must build")
+}
+
+/// Build an http, per-request-key-custody `BugWarden` against `mock` with
+/// `policy` (no `--api-key`/`--api-key-file`, so custody stays
+/// `PerRequest`).
+fn per_request_custody_server(policy: &str, mock: &MockServer) -> BugWarden {
+    let mut cli = Cli::parse_from([
+        "bugwarden",
+        "--bugzilla-server",
+        &mock.uri(),
+        "--transport",
+        "http",
+    ]);
+    cli.api_key = None;
+    cli.api_key_file = None; // the ambient environment must not leak in
+    let cfg = Arc::new(cli);
+    let guard = Arc::new(Guard {
+        policy: Policy::from_toml_str(policy).expect("test policy must parse"),
+    });
+    let bz =
+        Arc::new(BugzillaClient::new(&mock.uri(), false, USER_AGENT).expect("client must build"));
+    BugWarden::new(cfg, guard, bz).expect("server must build")
+}
+
+#[tokio::test]
+async fn preflight_fails_closed_when_whoami_is_unavailable_under_server_custody() {
+    // Stock Bugzilla Core v1: no /rest/whoami. An identity-consulting
+    // policy plus a server-held key must refuse to start, naming the
+    // endpoint, rather than start and blackout silently.
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/whoami"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&mock)
+        .await;
+    let server = server_custody_server(IDENTITY_POLICY, &mock);
+
+    let err = server
+        .preflight()
+        .await
+        .expect_err("a missing whoami endpoint must fail preflight");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("GET /rest/whoami"),
+        "preflight error must name the failing endpoint: {msg}"
+    );
+    assert!(
+        msg.contains("created_by_me"),
+        "preflight error must say WHY it matters: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn preflight_succeeds_when_whoami_answers_under_server_custody() {
+    // A deployment that DOES answer whoami starts cleanly, and the probe
+    // costs exactly one request (verified when the mock server drops).
+    let mock = MockServer::start().await;
+    mount_whoami(&mock, "reporter@example.com", 1).await;
+    let server = server_custody_server(IDENTITY_POLICY, &mock);
+
+    server
+        .preflight()
+        .await
+        .expect("a working whoami must pass preflight");
+}
+
+#[tokio::test]
+async fn preflight_costs_zero_requests_without_an_identity_policy() {
+    // The laziness contract extends to startup: a policy that never
+    // consults created_by_me must not probe whoami at all — pre-identity
+    // deployments keep their exact upstream request pattern, startup
+    // included. expect(0) is verified when the mock server drops.
+    let mock = MockServer::start().await;
+    mount_whoami(&mock, "reporter@example.com", 0).await;
+    let server = server_custody_server(NO_IDENTITY_POLICY, &mock);
+
+    server
+        .preflight()
+        .await
+        .expect("a policy without identity criteria must never probe whoami");
+}
+
+#[tokio::test]
+async fn preflight_warns_but_succeeds_under_per_request_custody() {
+    // There is no server-held key to verify whoami with at startup under
+    // per-request http custody (A5) — the probe would authenticate as
+    // nobody in particular. preflight() must not attempt it (expect(0))
+    // and must still return Ok: per-request custody stays correct
+    // per-call, it is only unverifiable up front.
+    let mock = MockServer::start().await;
+    mount_whoami(&mock, "reporter@example.com", 0).await;
+    let server = per_request_custody_server(IDENTITY_POLICY, &mock);
+
+    server
+        .preflight()
+        .await
+        .expect("per-request custody must not fail preflight");
+}
+
+#[tokio::test]
+async fn preflight_transport_error_does_not_leak_the_api_key_i12() {
+    // Point the server at a closed port: the whoami lookup fails at the
+    // transport level, where the unsanitized error would carry the
+    // request URL with api_key=... in it. Nothing in the preflight error
+    // text may contain the key.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    drop(listener); // free the port so every connection is refused
+
+    let mut cli = Cli::parse_from([
+        "bugwarden",
+        "--bugzilla-server",
+        &format!("http://{addr}"),
+        "--transport",
+        "stdio",
+        "--api-key",
+        "SUPERSECRETKEY123",
+    ]);
+    cli.api_key_file = None; // the ambient environment must not leak in
+    let cfg = Arc::new(cli);
+    let guard = Arc::new(Guard {
+        policy: Policy::from_toml_str(IDENTITY_POLICY).expect("test policy must parse"),
+    });
+    let bz = Arc::new(
+        BugzillaClient::new(&format!("http://{addr}"), false, USER_AGENT)
+            .expect("client must build"),
+    );
+    let server = BugWarden::new(cfg, guard, bz).expect("server must build");
+
+    let err = server
+        .preflight()
+        .await
+        .expect_err("an unreachable whoami endpoint must fail preflight");
+    let msg = format!("{err:#}");
+    assert!(
+        !msg.contains("SUPERSECRETKEY123"),
+        "API key leaked into a preflight error: {msg}"
+    );
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -690,7 +690,9 @@ where every other criterion describes bug content. Decisions, all deliberate:
   Because of this, `examples/policy.toml` ships its `created_by_me` rule
   ("my-own-reports") commented out — documented as an opt-in the operator
   enables only after confirming their Bugzilla answers `whoami` — rather
-  than active by default.
+  than active by default. `BugWarden::preflight` (see "MCP tool surface")
+  turns an unconfirmed deployment into a loud startup failure instead of a
+  silent per-call blackout.
 
 ## MCP tool surface (crates/bugwarden/src/server.rs)
 
@@ -752,6 +754,36 @@ units and container specs). Decisions, all deliberate:
   `tracing::warn` recommending 0600 (the read-bit analogue of the policy
   file's write-bit warning). The startup log line states mode and source
   only — never key material (I12).
+
+### Identity preflight (`BugWarden::preflight`)
+
+`Guard::resolve_caller` maps every `whoami` failure to `None`, and I4 then
+denies every classification a `created_by_me` rule reaches (see "Identity
+resolution") — correct, but silent: the server starts, looks healthy, and
+blacks out every access classification those rules cover while the cause
+sits at `tracing::warn!` on the first tool call. `preflight()` probes the
+same endpoint once, BEFORE the server serves a tool call, so a deployment
+that cannot answer it fails to start with a named reason instead.
+
+Deliberately a separate `async fn`, not folded into the sync
+`BugWarden::new`: `new` is the construction path every integration test in
+`tools_wiremock.rs`/`http_transport_wiremock.rs` drives, and moving the
+probe there would give each of those tests an unaccounted-for `whoami`
+call. `main.rs` calls `server.preflight().await?` right after `new`, BEFORE
+the audit sink is opened — the same ordering rationale as key custody
+resolution: a failed preflight must not create or rotate an audit file.
+
+Behaviour, by `Policy::needs_identity()` and key custody:
+
+| `needs_identity()` | custody | preflight does |
+|---|---|---|
+| false | any | `Ok(())`, ZERO upstream requests — the laziness contract now covers startup too |
+| true | `Server(key)` | one `GET /rest/whoami`; success logs the resolved login at `info!` and returns `Ok(())`; failure `anyhow::bail!`s naming the endpoint, that stock Bugzilla Core v1 does not define it, and that starting anyway would deny every access classification the policy's identity rules reach (I4) |
+| true | `PerRequest` | `tracing::warn!` the same compatibility statement and return `Ok(())` — there is no server-held key to probe with (A5); each caller still resolves identity correctly per call, an unreachable endpoint here only surfaces as a denial once a tool is called |
+
+The failure path attaches the sanitized client error (I12: `whoami`
+already strips the URL) as the `anyhow` error's source/context — no key
+material reaches the bailed-out message either.
 
 Tool descriptions: concise and action-oriented; state the defaults and
 constraints the model must know.
@@ -1312,6 +1344,17 @@ wired, `server.rs` and `main.rs` are the reference.
   own reports POSTs the comment for the caller's bug and refuses a
   foreign one with nothing POSTed), and a whoami transport error leaking
   no API key into any client-visible text (I12).
+- Integration tests (crates/bugwarden/tests/preflight_wiremock.rs,
+  wiremock): `BugWarden::preflight` — a missing `/rest/whoami` under
+  server-held key custody plus an identity-consulting policy fails
+  preflight naming `GET /rest/whoami` and `created_by_me`; a working
+  `whoami` under the same custody/policy passes it (one request, verified
+  by the mock's drop-time expectation); a policy without any identity
+  criterion costs ZERO whoami requests at preflight (the laziness contract
+  extends to startup); `KeyCustody::PerRequest` under an identity policy
+  passes preflight (warn only) while issuing zero whoami requests, since
+  there is no server-held key to verify it with (A5); and a transport-level
+  whoami failure leaks no API key into the preflight error text (I12).
 - Integration tests (crates/bugwarden/tests/http_transport_wiremock.rs,
   wiremock + rmcp client over REAL streamable HTTP — the only harness in
   which the per-request key header physically exists; the wiremock upstream


### PR DESCRIPTION
Second of three PRs addressing the `created_by_me` / `whoami` portability
gap. The first PR shipped the example's `my-own-reports` rule commented
out; this one turns the silent failure mode into a loud one.

Part of #71 (item B — the startup preflight probe). Item C — a portable,
verified identity source for stock Bugzilla — is a separate follow-up
PR; #71 stays open until that one lands too.

## What changed

`Guard::resolve_caller` maps every `/rest/whoami` failure to `None`, and
I4 then denies every classification a `created_by_me` rule reaches. On a
deployment that does not define `/rest/whoami` (stock Bugzilla Core v1
does not), that was silent: the server starts, looks healthy, and blacks
out every access classification an identity rule covers, while the cause
sat at `debug!` only.

- Added `BugWarden::preflight()`, an async startup probe kept out of the
  sync `BugWarden::new` (so the existing integration-test construction
  path gains no unaccounted-for `whoami` call). It costs zero upstream
  requests when the policy never consults identity; under a server-held
  key it performs one `GET /rest/whoami` and bails, naming the endpoint,
  on failure; under per-request custody there is no server-held key to
  probe with, so it warns the same compatibility note and returns `Ok`.
- `main.rs` calls `preflight()` right after `BugWarden::new`, before the
  audit sink opens, so a failed preflight never creates or rotates an
  audit file.
- Raised `resolve_caller`'s per-call whoami failure log from `debug!` to
  `warn!`, since under per-request custody it is the only diagnosis
  available. The client-visible uniform denial text is unchanged (I2).

No policy-format change: existing 0.3.0 policies keep working unmodified
on deployments that have `whoami`.

## Invariants touched

- **I2** — unaffected. The per-call log-level change is server-side only;
  the uniform denial text sent to clients is byte-identical, pinned by
  existing tests.
- **I4** — unaffected. A whoami failure still denies; this PR only makes
  the failure loud instead of silent, it never relaxes the deny.
- **I12** — the preflight failure message attaches the sanitized client
  error (whoami already strips the URL) as its source; a dedicated test
  asserts the API key never appears in the preflight error text.

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p bugwarden --features gen --all-targets -- -D warnings`
- `cargo test --workspace --all-targets --locked` (367 tests, including 5
  new ones in `crates/bugwarden/tests/preflight_wiremock.rs`: missing
  whoami fails preflight naming the endpoint, a working whoami passes it,
  a policy without identity criteria costs zero whoami requests, per-
  request custody warns-and-succeeds with zero requests, and a transport-
  level failure leaks no API key)
- `cargo deny check`
