### PR TITLE
feat(core): portable identity via a declared, verified login

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,8 @@ A complete, commented example ships in
 | `read_only` | boolean | `false` | Strip write capabilities from every grant and remove write tools from the tool listing. The `--read-only` flag ORs into this |
 | `disabled_tools` | array of strings | `[]` | Tool names to remove from the tool listing entirely |
 | `max_attachment_bytes` | integer | `2097152` (2 MiB) | Largest attachment `download_attachment` may return, and the same ceiling on what `add_attachment` may upload — both measured on the decoded size. `0` removes this cap; over http the transport still refuses a request body above 4 MiB, so an upload stays bounded either way. Downloaded content is embedded base64 in the tool result and lands in the model's context — raise deliberately |
+| `identity_source` | `"whoami"` \| `"declared"` | `"whoami"` | How `created_by_me` resolves the caller's login. `whoami` calls Bugzilla's `GET /rest/whoami` — a fork/BMO extension absent from stock Bugzilla Core v1. `declared` names an operator-configured login instead (see `identity_login`), verified once at startup against the *stock* `GET /rest/valid_login` endpoint and never looked up again per call — the portable path when the deployment has no identity endpoint at all. See the `created_by_me` row below and "Identity resolution" in `docs/DESIGN.md` |
+| `identity_login` | string | none | Required (and must be non-blank) exactly when `identity_source = "declared"`; a hard startup error if set under `identity_source = "whoami"` (it would otherwise be silently ignored). Names the account that owns *this server's* API key, so it is only meaningful under a server-held key (stdio, or http server-held mode) — a startup error under http per-request key custody, where there is no server-held key for it to describe. Bugzilla compares logins case-sensitively (Perl `eq`); declare it exactly as Bugzilla stores it |
 
 ### `[[rule]]`
 
@@ -438,7 +440,18 @@ write two consecutive rules.
 | `summary_contains` | array of strings | case-insensitive substring search in the bug's one-line summary |
 | `group_restricted` | boolean | `true` matches bugs readable only through at least one Bugzilla group, `false` matches world-readable bugs |
 | `younger_than_days` | integer | matches bugs created within the last N days |
-| `created_by_me` | boolean | whether the API key's account authored the bug: the caller's login is resolved per request via Bugzilla's `whoami` endpoint (at most one lookup per tool call, and none at all under a policy without an access-covering `created_by_me` rule — a rule scoped to `operations = ["create"]` alone never triggers a lookup) and compared case-insensitively to the bug's creator. `true` matches the caller's own reports, `false` everyone else's. **`whoami` is not part of stock Bugzilla Core v1** — it is a fork/BMO extension — so on a deployment without it every lookup fails. An unresolvable identity (`whoami` failure or absence) makes the criterion **unknown**, which denies (see Unreadable metadata); a policy that consults this criterion therefore denies everything it reaches on such a deployment. In the create gate the prospective bug always counts as created by the caller — no lookup happens there. Older bugwarden versions reject a policy using this key at startup (strict parsing fails closed) |
+| `created_by_me` | boolean | whether the caller's account authored the bug, compared case-insensitively to the bug's creator. `true` matches the caller's own reports, `false` everyone else's. How the caller's login is resolved depends on `global.identity_source` (default `whoami`): see the source × custody table below. Either source costs at most one lookup per tool call — `whoami` a fresh `GET /rest/whoami`, `declared` zero HTTP requests, since it was verified once at startup — and none at all under a policy without an access-covering `created_by_me` rule (a rule scoped to `operations = ["create"]` alone never triggers one). An unresolvable identity makes the criterion **unknown**, which denies (see Unreadable metadata); a policy that consults this criterion therefore denies everything it reaches while identity cannot be resolved. In the create gate the prospective bug always counts as created by the caller — no lookup happens there. Older bugwarden versions reject a policy using this key, or `global.identity_source`/`global.identity_login`, at startup (strict parsing fails closed) |
+
+Identity resolution by source and API-key custody:
+
+| `identity_source` | stdio / http server-held key | http per-request key |
+|---|---|---|
+| `whoami` (default) | verified at startup (`BugWarden::preflight`); one `GET /rest/whoami` per tool call | unverifiable at startup (warns instead); one `GET /rest/whoami` per tool call |
+| `declared` | verified once at startup via `GET /rest/valid_login`; **zero** identity requests per tool call | **startup error** — there is no server-held key for the declared login to describe |
+
+`whoami` is a fork/BMO extension absent from stock Bugzilla Core v1;
+`valid_login` is documented there, which is what makes `declared` the
+portable path on a deployment that has no identity endpoint at all.
 
 #### Unreadable metadata
 
@@ -447,13 +460,17 @@ of an unexpected type, or a list with an element the parser cannot read. Such
 a field is **unknown**, and a rule that consults one is undecidable: it neither
 holds nor fails. One criterion needs more than the bug object:
 `created_by_me` also needs the caller's identity, and if either half is
-missing — an unreadable creator, or a `whoami` lookup that failed or does
-not exist on the deployment — it is just as undecidable and resolves the
-same way. A policy consulting identity therefore denies everything its
-identity rules are consulted for while `whoami` is unavailable — including
-permanently, on a stock Bugzilla Core v1 deployment that never exposes it;
-that is deliberate (treating unknown identity as "does not match" would let
-a `created_by_me` deny rule be defeated by breaking `whoami`). The criterion
+missing — an unreadable creator, or an identity lookup that failed (under
+`identity_source = "whoami"`) or does not exist on the deployment — it is
+just as undecidable and resolves the same way. A policy consulting identity
+therefore denies everything its identity rules are consulted for while
+identity is unavailable — including permanently, under `whoami` on a stock
+Bugzilla Core v1 deployment that never exposes it; that is deliberate
+(treating unknown identity as "does not match" would let a `created_by_me`
+deny rule be defeated by breaking `whoami`). `identity_source = "declared"`
+sidesteps this on such a deployment: the login is verified once at startup
+(`BugWarden::preflight` fails to start rather than serve a blackout) and
+never looked up again, so there is no per-call failure mode left. The criterion
 cannot widen exposure beyond the credential: Bugzilla enforces its own
 permissions on every fetch, so an authorship rule only surfaces bugs the API
 key could already read.

--- a/crates/bugwarden-core/src/client.rs
+++ b/crates/bugwarden-core/src/client.rs
@@ -116,6 +116,41 @@ impl BugzillaClient {
             .ok_or_else(|| anyhow!("bugzilla /whoami response carries no usable \"name\" field"))
     }
 
+    /// GET `/rest/valid_login?login=<login>` — whether the API key
+    /// authenticates as exactly `login` (Bugzilla `Bugzilla->login`
+    /// compares with Perl `eq`, i.e. case-sensitively).
+    ///
+    /// This is a portable identity *verifier*, not a discoverer: unlike
+    /// `whoami` (a fork/BMO extension), `valid_login` is documented in the
+    /// current Bugzilla Core v1 REST reference, so it works against a
+    /// stock deployment. It answers exactly one question — "does this key
+    /// authenticate as this login" — never "who does this key
+    /// authenticate as".
+    ///
+    /// Bugzilla's REST layer normally wraps a scalar result as
+    /// `{"result": true}`; a bare `true`/`false` body is accepted too. Any
+    /// other shape (an object without a boolean `result`, a string, a
+    /// number, `null`, …) is an error, never read as `false` — a response
+    /// shape neither of those forms silently reading as "not this account"
+    /// would be a fail-open surface hiding behind a fail-closed name.
+    /// Authentication and error sanitization are identical to every other
+    /// call: the key never appears in any error this returns (I12).
+    pub async fn valid_login(&self, key: &str, login: &str) -> Result<bool> {
+        let v = self
+            .get_json(key, "/valid_login", &[("login", login.to_string())])
+            .await?;
+        match &v {
+            Value::Bool(b) => Ok(*b),
+            Value::Object(_) => v.get("result").and_then(Value::as_bool).ok_or_else(|| {
+                anyhow!("bugzilla /valid_login response carries no usable boolean \"result\" field")
+            }),
+            _ => bail!(
+                "bugzilla /valid_login response is neither a boolean nor an object with a \
+                 boolean \"result\" field"
+            ),
+        }
+    }
+
     /// Sequential GET of `/rest/version`, `/rest/extensions`, `/rest/time`
     /// and `/rest/parameters`, combined into
     /// `{url, version, extensions, timezone, time, parameters}`.

--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -22,7 +22,7 @@ use chrono::Utc;
 use serde_json::{Map, Value};
 
 use crate::client::{BugzillaClient, CLASSIFY_FIELDS};
-use crate::policy::{Access, BugMeta, Capability, Operation, Policy};
+use crate::policy::{Access, BugMeta, Capability, IdentitySource, Operation, Policy};
 
 /// Fields kept by the redacted summary-only projection of a bug
 /// ([`Guard::summary_view`]). Everything else — assignee, CC, groups,
@@ -811,13 +811,19 @@ impl Guard {
     /// - when the policy consults no identity for access classification
     ///   ([`Policy::needs_identity`] is false), returns `None` WITHOUT any
     ///   HTTP request — a policy without `created_by_me` never costs a
-    ///   `whoami` lookup;
-    /// - otherwise performs exactly one `GET /rest/whoami` and returns the
-    ///   account's login, mapping every failure to `None` (the sanitized
-    ///   error is debug-logged only — never the key, I12). `None` makes
-    ///   every `created_by_me` criterion undecidable, which denies every
+    ///   lookup, under either identity source;
+    /// - `global.identity_source = "whoami"` (the default): performs
+    ///   exactly one `GET /rest/whoami` and returns the account's login,
+    ///   mapping every failure to `None` (the sanitized error is
+    ///   warn-logged — never the key, I12). `None` makes every
+    ///   `created_by_me` criterion undecidable, which denies every
     ///   classification consulting it (I4): a whoami outage blacks out
-    ///   what the identity rules cover, it never fails open.
+    ///   what the identity rules cover, it never fails open;
+    /// - `global.identity_source = "declared"`: returns
+    ///   `global.identity_login` directly, with **zero** HTTP requests —
+    ///   it was verified once at startup against `GET /rest/valid_login`
+    ///   (see `BugWarden::preflight`), so nothing here can fail and there
+    ///   is nothing left to look up.
     ///
     /// Callers (the MCP tools) invoke this at most once per tool call and
     /// thread the result to every classification within that call. The
@@ -826,25 +832,28 @@ impl Guard {
         if !self.policy.needs_identity() {
             return None;
         }
-        match bz.whoami(key).await {
-            Ok(login) => Some(login),
-            Err(err) => {
-                // Sanitized by the client (I12); identity stays unknown and
-                // every consulted identity rule fails closed (I4). warn!,
-                // not debug!: under per-request key custody this per-call
-                // failure is the only diagnosis available (server-held
-                // custody also gets a startup preflight — see
-                // `BugWarden::preflight`) — a server that starts and then
-                // silently denies everything is exactly the blackout this
-                // is meant to surface.
-                tracing::warn!(
-                    error = %err,
-                    "whoami failed; caller identity unresolved (this endpoint may not exist \
-                     on this deployment — stock Bugzilla Core v1 does not define \
-                     /rest/whoami)"
-                );
-                None
-            }
+        match self.policy.global.identity_source {
+            IdentitySource::Declared => self.policy.global.identity_login.clone(),
+            IdentitySource::Whoami => match bz.whoami(key).await {
+                Ok(login) => Some(login),
+                Err(err) => {
+                    // Sanitized by the client (I12); identity stays unknown and
+                    // every consulted identity rule fails closed (I4). warn!,
+                    // not debug!: under per-request key custody this per-call
+                    // failure is the only diagnosis available (server-held
+                    // custody also gets a startup preflight — see
+                    // `BugWarden::preflight`) — a server that starts and then
+                    // silently denies everything is exactly the blackout this
+                    // is meant to surface.
+                    tracing::warn!(
+                        error = %err,
+                        "whoami failed; caller identity unresolved (this endpoint may not \
+                         exist on this deployment — stock Bugzilla Core v1 does not define \
+                         /rest/whoami)"
+                    );
+                    None
+                }
+            },
         }
     }
 

--- a/crates/bugwarden-core/src/policy.rs
+++ b/crates/bugwarden-core/src/policy.rs
@@ -527,6 +527,27 @@ impl Rule {
     }
 }
 
+/// Where [`Guard::resolve_caller`](crate::guard::Guard::resolve_caller) gets
+/// the caller's identity from, for `created_by_me` matching.
+///
+/// `whoami` (the default) calls the fork/BMO-only `GET /rest/whoami` once
+/// per tool call and is unaffected by existing 0.3.0 policies, which never
+/// write this key. `declared` names an operator-configured login instead,
+/// verified once at startup against `GET /rest/valid_login` and never
+/// looked up again — the portable path for a stock Bugzilla Core v1
+/// deployment that has no identity endpoint at all. See DESIGN.md,
+/// "Identity resolution".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IdentitySource {
+    /// `GET /rest/whoami`, resolved fresh on every tool call.
+    #[default]
+    Whoami,
+    /// `global.identity_login`, verified once at startup and never looked
+    /// up again.
+    Declared,
+}
+
 /// Policy-wide guards applied on top of (and before) the rule list.
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -556,6 +577,18 @@ pub struct GlobalGuards {
     /// in the model's context, so unlimited is an explicit operator choice.
     #[serde(default = "default_max_attachment_bytes")]
     pub max_attachment_bytes: u64,
+    /// How `created_by_me` resolves the caller's identity. Defaults to
+    /// `whoami`, so every 0.3.0 policy keeps its current behaviour
+    /// unmodified. See [`IdentitySource`].
+    #[serde(default)]
+    pub identity_source: IdentitySource,
+    /// The login `identity_source = "declared"` asserts. Required (and
+    /// validated non-blank) exactly when `identity_source = "declared"`;
+    /// setting it under `whoami` is a hard startup error rather than a
+    /// silently ignored key (see [`Policy::validate`]). Compared with
+    /// Bugzilla's own `eq` — case-sensitive (see DESIGN.md).
+    #[serde(default)]
+    pub identity_login: Option<String>,
 }
 
 fn default_max_attachment_bytes() -> u64 {
@@ -572,6 +605,8 @@ impl Default for GlobalGuards {
             read_only: false,
             disabled_tools: Vec::new(),
             max_attachment_bytes: default_max_attachment_bytes(),
+            identity_source: IdentitySource::default(),
+            identity_login: None,
         }
     }
 }
@@ -673,6 +708,27 @@ impl Policy {
                 "default_action must be \"allow\" or \"deny\": \"restrict\" is only \
                  meaningful on a rule, where it names the granted capabilities"
             );
+        }
+        let login_is_blank = self
+            .global
+            .identity_login
+            .as_deref()
+            .is_none_or(|l| l.trim().is_empty());
+        match self.global.identity_source {
+            IdentitySource::Declared if login_is_blank => {
+                anyhow::bail!(
+                    "global.identity_source = \"declared\" requires a non-blank \
+                     global.identity_login"
+                );
+            }
+            IdentitySource::Whoami if !login_is_blank => {
+                anyhow::bail!(
+                    "global.identity_login is set but global.identity_source is \
+                     \"whoami\" (the default), so it would be silently ignored; \
+                     set identity_source = \"declared\" or remove identity_login"
+                );
+            }
+            _ => {}
         }
         for rule in &self.rules {
             match rule.action {
@@ -2063,6 +2119,77 @@ products = ["SUSE*"]
         ))
         .unwrap()
         .needs_identity());
+    }
+
+    // ---------- global.identity_source / identity_login ----------
+
+    #[test]
+    fn identity_source_defaults_to_whoami_with_no_login() {
+        let p = Policy::default();
+        assert_eq!(p.global.identity_source, IdentitySource::Whoami);
+        assert_eq!(p.global.identity_login, None);
+
+        // An empty policy file parses to the same default.
+        let p = Policy::from_toml_str("").unwrap();
+        assert_eq!(p.global.identity_source, IdentitySource::Whoami);
+    }
+
+    #[test]
+    fn identity_source_declared_with_login_parses() {
+        let p = Policy::from_toml_str(concat!(
+            "[global]\n",
+            "identity_source = \"declared\"\n",
+            "identity_login = \"svc@example.com\"\n",
+        ))
+        .unwrap();
+        assert_eq!(p.global.identity_source, IdentitySource::Declared);
+        assert_eq!(p.global.identity_login.as_deref(), Some("svc@example.com"));
+    }
+
+    #[test]
+    fn identity_source_declared_without_login_is_a_hard_error() {
+        let err = Policy::from_toml_str("[global]\nidentity_source = \"declared\"\n").unwrap_err();
+        assert!(
+            err.to_string().contains("identity_login"),
+            "error should name identity_login: {err}"
+        );
+    }
+
+    #[test]
+    fn identity_source_declared_with_blank_login_is_a_hard_error() {
+        // Whitespace-only counts as blank, not "set" — the same rule the
+        // whoami /name field applies (client.rs::whoami).
+        let err = Policy::from_toml_str(concat!(
+            "[global]\n",
+            "identity_source = \"declared\"\n",
+            "identity_login = \"   \"\n",
+        ))
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("identity_login"),
+            "error should name identity_login: {err}"
+        );
+    }
+
+    #[test]
+    fn identity_login_under_whoami_is_a_hard_error() {
+        // Setting identity_login without identity_source = "declared" would
+        // otherwise be silently ignored — that is exactly the class of
+        // typo `deny_unknown_fields` exists to catch elsewhere.
+        let err =
+            Policy::from_toml_str("[global]\nidentity_login = \"svc@example.com\"\n").unwrap_err();
+        assert!(
+            err.to_string().contains("identity_source"),
+            "error should name identity_source: {err}"
+        );
+    }
+
+    #[test]
+    fn identity_source_unknown_value_is_rejected() {
+        let err = Policy::from_toml_str("[global]\nidentity_source = \"guessed\"\n").unwrap_err();
+        // toml/serde's own unknown-variant message; just confirm it fails
+        // rather than silently defaulting.
+        assert!(!err.to_string().is_empty());
     }
 
     // ---------- Policy::load ----------

--- a/crates/bugwarden-core/tests/guard_wiremock.rs
+++ b/crates/bugwarden-core/tests/guard_wiremock.rs
@@ -9,7 +9,7 @@
 use bugwarden_core::client::BugzillaClient;
 use bugwarden_core::guard::{Guard, SearchRequest};
 use bugwarden_core::policy::{Access, Capability, Policy};
-use serde_json::json;
+use serde_json::{json, Value};
 use wiremock::matchers::{method, path, query_param, query_param_contains};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
@@ -1059,6 +1059,86 @@ async fn whoami_api_key_absent_from_transport_error_i12() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// valid_login (portable identity verifier for declared-login identity)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn client_valid_login_accepts_wrapped_and_bare_boolean_bodies() {
+    for body in [json!({ "result": true }), json!(true)] {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/valid_login"))
+            .and(query_param("login", "svc@example.com"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body.clone()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let bz = client(&server);
+        assert!(
+            bz.valid_login(KEY, "svc@example.com").await.unwrap(),
+            "body {body} should read as true"
+        );
+    }
+
+    for body in [json!({ "result": false }), json!(false)] {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/valid_login"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body.clone()))
+            .mount(&server)
+            .await;
+        let bz = client(&server);
+        assert!(
+            !bz.valid_login(KEY, "someone@example.com").await.unwrap(),
+            "body {body} should read as false"
+        );
+    }
+}
+
+#[tokio::test]
+async fn client_valid_login_unusable_shape_is_an_error_never_false() {
+    // A shape neither a bare bool nor {"result": bool} must fail loudly,
+    // not silently read as "not this account" (fail closed, never fail
+    // open behind a fail-closed-looking `false`).
+    for body in [
+        json!({ "id": 1 }),
+        json!({ "result": "true" }),
+        json!("true"),
+        json!(1),
+        Value::Null,
+    ] {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/valid_login"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body.clone()))
+            .mount(&server)
+            .await;
+        let bz = client(&server);
+        let err = bz.valid_login(KEY, "svc@example.com").await.unwrap_err();
+        assert!(
+            err.to_string().contains("result"),
+            "unexpected error for body {body}: {err:#}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn valid_login_api_key_absent_from_transport_error_i12() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    drop(listener); // free the port so the connection is refused
+    let bz =
+        BugzillaClient::new(&format!("http://{addr}"), false, TEST_USER_AGENT).expect("client");
+
+    let err = bz.valid_login(KEY, "svc@example.com").await.unwrap_err();
+    let full = format!("{err:#} {err:?}");
+    assert!(
+        !full.contains(KEY),
+        "API key leaked into valid_login transport error: {full}"
+    );
+}
+
 #[tokio::test]
 async fn resolve_caller_is_lazy_and_maps_failure_to_none() {
     // No identity criterion in the policy: no request at all — the
@@ -1112,6 +1192,42 @@ async fn resolve_caller_is_lazy_and_maps_failure_to_none() {
         .await;
     let g = guard(identity);
     assert_eq!(g.resolve_caller(&client(&server), KEY).await, None);
+}
+
+#[tokio::test]
+async fn resolve_caller_under_declared_identity_makes_zero_http_requests() {
+    // Verified once at startup (BugWarden::preflight), never looked up
+    // again per call — the whole point of a declared login on a stock
+    // deployment with no whoami at all. `.expect(0)` on BOTH endpoints
+    // proves neither is consulted here.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/whoami"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "name": "should-not-be-called" })),
+        )
+        .expect(0)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/valid_login"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!(true)))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let g = guard(concat!(
+        "[global]\n",
+        "identity_source = \"declared\"\n",
+        "identity_login = \"svc@example.com\"\n",
+        "[[rule]]\nname = \"mine\"\naction = \"restrict\"\ncapabilities = [\"read\"]\n",
+        "operations = [\"access\"]\n[rule.match]\ncreated_by_me = true\n",
+        "[[rule]]\nname = \"rest\"\naction = \"deny\"\n",
+    ));
+    assert_eq!(
+        g.resolve_caller(&client(&server), KEY).await,
+        Some("svc@example.com".to_string())
+    );
 }
 
 #[tokio::test]

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -13,7 +13,7 @@ use std::time::Instant;
 
 use bugwarden_core::client::{BugzillaClient, CLASSIFY_FIELDS};
 use bugwarden_core::guard::{Guard, SearchRequest, SearchWindow};
-use bugwarden_core::policy::{Access, Action, Capability};
+use bugwarden_core::policy::{Access, Action, Capability, IdentitySource};
 use chrono::{DateTime, Utc};
 use rmcp::{
     handler::server::{router::tool::ToolRouter, tool::ToolCallContext, wrapper::Parameters},
@@ -1018,6 +1018,25 @@ impl BugWarden {
                  clients, never an individual caller's"
             );
         }
+        // A declared login names the account owning the SERVER's key
+        // (A5, plans/ISSUE_WHOAMI_IDENTITY.md). Per-request custody holds
+        // no server-side key at all — each caller supplies their own — so
+        // there is nothing the declared login could describe, and unlike
+        // `whoami` (which stays per-caller-correct there and only warns)
+        // this is a hard startup error rather than a warning.
+        if matches!(key_custody, KeyCustody::PerRequest)
+            && guard.policy.global.identity_source == IdentitySource::Declared
+            && guard.policy.needs_identity()
+        {
+            anyhow::bail!(
+                "guard policy sets global.identity_source = \"declared\", but this server \
+                 holds no API key of its own under per-request key custody: a declared \
+                 login names the account owning the SERVER's key, and there is no such \
+                 key here for it to describe. Use identity_source = \"whoami\" (verified \
+                 per caller) instead, or run with a server-held key (--api-key / \
+                 --api-key-file)"
+            );
+        }
         let mut tool_router = Self::tool_router();
         // Validate disabled_tools against the FULL router, before any route
         // removal: a write-tool name stays a valid entry even when read-only
@@ -1099,37 +1118,96 @@ impl BugWarden {
     ///   statement and return `Ok(())`: per-request custody stays
     ///   correct per call (DESIGN.md, "Identity resolution"), it is only
     ///   unverifiable up front.
+    ///
+    /// `global.identity_source = "declared"` (see DESIGN.md) replaces the
+    /// probe with one `GET /rest/valid_login?login=<identity_login>`: a
+    /// `true` result verifies the server's key at startup so
+    /// `Guard::resolve_caller` never looks it up again per call; `false`
+    /// bails naming the login the key does NOT authenticate as (fail
+    /// closed, distinct from a transport failure so the operator does not
+    /// mistake a wrong login for a broken key); a transport/parse error
+    /// bails naming the endpoint, the same as the `whoami` arm.
+    /// [`BugWarden::new`] already refuses to construct a declared-identity
+    /// server under per-request custody (A5), so that combination cannot
+    /// reach this method — the match below still names it explicitly
+    /// rather than relying on that invariant silently.
     pub async fn preflight(&self) -> anyhow::Result<()> {
         use anyhow::Context as _;
 
         if !self.guard.policy.needs_identity() {
             return Ok(());
         }
-        match &self.key_custody {
-            KeyCustody::Server(key) => match self.bz.whoami(key).await {
-                Ok(login) => {
-                    tracing::info!(login, "identity endpoint verified");
+        match self.guard.policy.global.identity_source {
+            IdentitySource::Whoami => match &self.key_custody {
+                KeyCustody::Server(key) => match self.bz.whoami(key).await {
+                    Ok(login) => {
+                        tracing::info!(login, "identity endpoint verified");
+                        Ok(())
+                    }
+                    Err(err) => Err(err).context(
+                        "GET /rest/whoami failed during startup preflight; the guard policy \
+                         consults created_by_me, which needs this endpoint to resolve the \
+                         caller's identity. Stock Bugzilla Core v1 does not define /rest/whoami \
+                         (it is a fork/BMO extension) — if this deployment does not have it, \
+                         starting anyway would deny every access classification the policy's \
+                         identity rules reach (I4). Confirm the endpoint exists, set \
+                         global.identity_source = \"declared\" instead, or remove the \
+                         created_by_me criteria from the policy",
+                    ),
+                },
+                KeyCustody::PerRequest => {
+                    tracing::warn!(
+                        "the policy consults created_by_me, but per-request key custody holds \
+                         no server-side key to verify /rest/whoami with at startup; each \
+                         caller's identity is still resolved per call, but an unreachable \
+                         endpoint on this deployment will only surface as a denial once a \
+                         tool is called — stock Bugzilla Core v1 does not define /rest/whoami \
+                         (it is a fork/BMO extension)"
+                    );
                     Ok(())
                 }
-                Err(err) => Err(err).context(
-                    "GET /rest/whoami failed during startup preflight; the guard policy \
-                     consults created_by_me, which needs this endpoint to resolve the \
-                     caller's identity. Stock Bugzilla Core v1 does not define /rest/whoami \
-                     (it is a fork/BMO extension) — if this deployment does not have it, \
-                     starting anyway would deny every access classification the policy's \
-                     identity rules reach (I4). Confirm the endpoint exists, or remove the \
-                     created_by_me criteria from the policy",
-                ),
             },
-            KeyCustody::PerRequest => {
-                tracing::warn!(
-                    "the policy consults created_by_me, but per-request key custody holds no \
-                     server-side key to verify /rest/whoami with at startup; each caller's \
-                     identity is still resolved per call, but an unreachable endpoint on this \
-                     deployment will only surface as a denial once a tool is called — stock \
-                     Bugzilla Core v1 does not define /rest/whoami (it is a fork/BMO extension)"
-                );
-                Ok(())
+            IdentitySource::Declared => {
+                let key = match &self.key_custody {
+                    KeyCustody::Server(key) => key,
+                    // BugWarden::new bails on this combination before a
+                    // server is ever constructed (A5); fail closed rather
+                    // than trust that invariant silently if it is ever
+                    // reordered.
+                    KeyCustody::PerRequest => anyhow::bail!(
+                        "guard policy sets global.identity_source = \"declared\" under \
+                         per-request key custody, which holds no server-side key for the \
+                         declared login to describe; this should have been rejected at \
+                         server construction"
+                    ),
+                };
+                // Policy::validate requires a non-blank login whenever
+                // identity_source = "declared"; needs_identity() already
+                // confirmed a rule consults it, so this is always Some.
+                let login = self
+                    .guard
+                    .policy
+                    .global
+                    .identity_login
+                    .as_deref()
+                    .unwrap_or_default();
+                match self.bz.valid_login(key, login).await {
+                    Ok(true) => {
+                        tracing::info!(login, "declared identity verified");
+                        Ok(())
+                    }
+                    Ok(false) => anyhow::bail!(
+                        "GET /rest/valid_login says the configured API key does not \
+                         authenticate as \"{login}\" (global.identity_login); Bugzilla \
+                         compares logins case-sensitively, so check for a case mismatch as \
+                         well as a wrong account. Fail closed: starting anyway would deny \
+                         every access classification the policy's identity rules reach (I4)",
+                    ),
+                    Err(err) => Err(err).context(format!(
+                        "GET /rest/valid_login failed during startup preflight while \
+                         verifying the declared login \"{login}\" (global.identity_login)",
+                    )),
+                }
             }
         }
     }
@@ -3345,6 +3423,76 @@ mod tests {
                 "startup logs: {logs}"
             );
         }
+    }
+
+    #[test]
+    fn new_rejects_declared_identity_under_per_request_custody() {
+        // A5: a declared login names the account owning the SERVER's key.
+        // Per-request http custody holds no server-side key at all, so
+        // there is nothing for the declared login to describe — this must
+        // be a hard startup error, unlike whoami's warn-and-continue.
+        use clap::Parser as _;
+        let mut cli = Cli::parse_from([
+            "bugwarden",
+            "--bugzilla-server",
+            "https://bugzilla.example.com",
+            "--transport",
+            "http",
+        ]);
+        cli.api_key = None;
+        cli.api_key_file = None; // stays per-request: no server-held key
+        let guard = Arc::new(Guard {
+            policy: Policy::from_toml_str(concat!(
+                "[global]\n",
+                "identity_source = \"declared\"\n",
+                "identity_login = \"svc@example.com\"\n",
+                "[[rule]]\nname = \"mine\"\naction = \"allow\"\n",
+                "[rule.match]\ncreated_by_me = true\n",
+            ))
+            .expect("test policy must parse"),
+        });
+        let bz = Arc::new(
+            BugzillaClient::new("https://bugzilla.example.com", false, USER_AGENT)
+                .expect("client must build"),
+        );
+        let err = match BugWarden::new(Arc::new(cli), guard, bz) {
+            Err(e) => e,
+            Ok(_) => panic!("declared identity under per-request custody must fail to build"),
+        };
+        let msg = format!("{err:#}");
+        assert!(msg.contains("declared"), "{msg}");
+        assert!(msg.contains("per-request"), "{msg}");
+    }
+
+    #[test]
+    fn new_allows_declared_identity_under_server_held_custody() {
+        // The companion positive case: a server-held key is exactly what a
+        // declared login describes, so construction must succeed.
+        use clap::Parser as _;
+        let cli = Cli::parse_from([
+            "bugwarden",
+            "--bugzilla-server",
+            "https://bugzilla.example.com",
+            "--transport",
+            "stdio",
+            "--api-key",
+            "test-key",
+        ]);
+        let guard = Arc::new(Guard {
+            policy: Policy::from_toml_str(concat!(
+                "[global]\n",
+                "identity_source = \"declared\"\n",
+                "identity_login = \"svc@example.com\"\n",
+                "[[rule]]\nname = \"mine\"\naction = \"allow\"\n",
+                "[rule.match]\ncreated_by_me = true\n",
+            ))
+            .expect("test policy must parse"),
+        });
+        let bz = Arc::new(
+            BugzillaClient::new("https://bugzilla.example.com", false, USER_AGENT)
+                .expect("client must build"),
+        );
+        BugWarden::new(Arc::new(cli), guard, bz).expect("server must build");
     }
 
     #[test]

--- a/crates/bugwarden/tests/preflight_wiremock.rs
+++ b/crates/bugwarden/tests/preflight_wiremock.rs
@@ -25,7 +25,7 @@ use bugwarden_core::client::BugzillaClient;
 use bugwarden_core::guard::Guard;
 use bugwarden_core::policy::Policy;
 use clap::Parser as _;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// The issue's policy shape: an access-scoped `created_by_me` carve-out
@@ -46,12 +46,41 @@ const NO_IDENTITY_POLICY: &str = concat!(
     "[rule.match]\ngroup_restricted = true\n",
 );
 
+/// The declared-login counterpart of [`IDENTITY_POLICY`]: same rule shape,
+/// but resolved without `whoami` at all (PR C,
+/// `plans/ISSUE_WHOAMI_IDENTITY.md`).
+const DECLARED_IDENTITY_POLICY: &str = concat!(
+    "[global]\n",
+    "identity_source = \"declared\"\n",
+    "identity_login = \"svc@example.com\"\n",
+    "[[rule]]\nname = \"my-own-reports\"\naction = \"restrict\"\n",
+    "capabilities = [\"read\", \"comments\", \"history\", \"attachments\"]\n",
+    "operations = [\"access\"]\n",
+    "[rule.match]\ncreated_by_me = true\n",
+    "[[rule]]\nname = \"group-restricted\"\naction = \"deny\"\n",
+    "[rule.match]\ngroup_restricted = true\n",
+);
+
 /// Mount `GET /rest/whoami` answering with `login`, expected `hits` times.
 async fn mount_whoami(mock: &MockServer, login: &str, hits: u64) {
     Mock::given(method("GET"))
         .and(path("/rest/whoami"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "id": 1, "name": login, "real_name": "Reporter",
+        })))
+        .expect(hits)
+        .mount(mock)
+        .await;
+}
+
+/// Mount `GET /rest/valid_login?login=<login>` answering `result`,
+/// expected `hits` times.
+async fn mount_valid_login(mock: &MockServer, login: &str, result: bool, hits: u64) {
+    Mock::given(method("GET"))
+        .and(path("/rest/valid_login"))
+        .and(query_param("login", login))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": result,
         })))
         .expect(hits)
         .mount(mock)
@@ -174,6 +203,61 @@ async fn preflight_warns_but_succeeds_under_per_request_custody() {
         .preflight()
         .await
         .expect("per-request custody must not fail preflight");
+}
+
+#[tokio::test]
+async fn preflight_succeeds_for_a_correct_declared_login_with_zero_whoami_hits() {
+    // valid_login verifies the server's key at startup; resolve_caller
+    // never looks it up again per call, so whoami must be untouched too.
+    let mock = MockServer::start().await;
+    mount_valid_login(&mock, "svc@example.com", true, 1).await;
+    mount_whoami(&mock, "svc@example.com", 0).await;
+    let server = server_custody_server(DECLARED_IDENTITY_POLICY, &mock);
+
+    server
+        .preflight()
+        .await
+        .expect("a key that authenticates as the declared login must pass preflight");
+}
+
+#[tokio::test]
+async fn preflight_fails_closed_when_the_key_does_not_own_the_declared_login() {
+    // A wrong declared login is fail-closed (I4): starting anyway would
+    // deny every access classification the identity rules reach.
+    let mock = MockServer::start().await;
+    mount_valid_login(&mock, "svc@example.com", false, 1).await;
+    let server = server_custody_server(DECLARED_IDENTITY_POLICY, &mock);
+
+    let err = server
+        .preflight()
+        .await
+        .expect_err("a login the key does not own must fail preflight");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("svc@example.com"),
+        "preflight error must name the declared login: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn preflight_declared_login_transport_error_names_the_endpoint() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/valid_login"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&mock)
+        .await;
+    let server = server_custody_server(DECLARED_IDENTITY_POLICY, &mock);
+
+    let err = server
+        .preflight()
+        .await
+        .expect_err("a failing valid_login endpoint must fail preflight");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("GET /rest/valid_login"),
+        "preflight error must name the failing endpoint: {msg}"
+    );
 }
 
 #[tokio::test]

--- a/crates/bugwarden/tests/tools_wiremock.rs
+++ b/crates/bugwarden/tests/tools_wiremock.rs
@@ -1173,6 +1173,56 @@ async fn created_by_me_carves_own_reports_out_of_a_group_restricted_deny() {
     );
 }
 
+/// The declared-login counterpart of [`IDENTITY_POLICY`] (PR C,
+/// `plans/ISSUE_WHOAMI_IDENTITY.md`): the same carve-out, resolved from an
+/// operator-declared, startup-verified login instead of `whoami` — the
+/// portable path for a stock Bugzilla Core v1 deployment with no identity
+/// endpoint at all.
+const DECLARED_IDENTITY_POLICY: &str = concat!(
+    "[global]\n",
+    "identity_source = \"declared\"\n",
+    "identity_login = \"reporter@example.com\"\n",
+    "[[rule]]\nname = \"my-own-reports\"\naction = \"restrict\"\n",
+    "capabilities = [\"read\", \"comments\", \"history\", \"attachments\"]\n",
+    "operations = [\"access\"]\n",
+    "[rule.match]\ncreated_by_me = true\n",
+    "[[rule]]\nname = \"group-restricted\"\naction = \"deny\"\n",
+    "[rule.match]\ngroup_restricted = true\n",
+);
+
+#[tokio::test]
+async fn declared_identity_carves_own_reports_out_with_zero_whoami_hits() {
+    // End to end, mirroring created_by_me_carves_own_reports_out_of_a_group
+    // _restricted_deny, but under a declared login: the caller's own
+    // group-restricted bug is readable, a foreign one takes the uniform
+    // denial (I2), and NOT ONE whoami request is made — the declared login
+    // was verified once at startup (BugWarden::preflight), never looked up
+    // again per call.
+    let mock = MockServer::start().await;
+    mount_whoami(&mock, "reporter@example.com", 0).await;
+    mount_bug_and_padding(&mock, restricted_bug(7, "reporter@example.com")).await;
+    mount_bug_and_padding(&mock, restricted_bug(8, "other.person@example.com")).await;
+    let client = client_for(DECLARED_IDENTITY_POLICY, &mock).await;
+
+    let own = call(&client, "bug_info", json!({ "bug_ids": [7] })).await;
+    let own: Value = serde_json::from_str(&text_of(&own)).expect("bug_info returns JSON");
+    assert_eq!(
+        own["bugs"][0]["id"],
+        json!(7),
+        "the caller's own group-restricted bug is readable under a declared login"
+    );
+    assert!(own["restricted"].as_array().unwrap().is_empty());
+
+    let foreign = call(&client, "bug_info", json!({ "bug_ids": [8] })).await;
+    let foreign: Value = serde_json::from_str(&text_of(&foreign)).expect("bug_info returns JSON");
+    assert!(foreign["bugs"].as_array().unwrap().is_empty());
+    assert_eq!(
+        foreign["restricted"][0]["note"],
+        json!("Bug 8 is not accessible through this server"),
+        "someone else's restricted bug takes the uniform denial (I2)"
+    );
+}
+
 #[tokio::test]
 async fn created_by_me_whoami_failure_yields_the_same_uniform_denial() {
     // whoami down: the caller's own bug must come back with EXACTLY the

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -494,6 +494,7 @@ impl BugzillaClient {
     pub fn base_url(&self) -> &str;
     pub async fn version(&self, key: &str) -> anyhow::Result<String>;
     pub async fn whoami(&self, key: &str) -> anyhow::Result<String>; // login; missing/non-string/blank "name" = failure
+    pub async fn valid_login(&self, key: &str, login: &str) -> anyhow::Result<bool>; // {"result": bool} or bare bool; any other shape = error, never false
     pub async fn server_info(&self, key: &str) -> anyhow::Result<serde_json::Value>;
     pub async fn get_bugs(&self, key: &str, ids: &[u64], include_fields: Option<&str>) -> anyhow::Result<serde_json::Value>;
     pub async fn bug_history(&self, key: &str, id: u64, new_since: Option<chrono::DateTime<chrono::Utc>>) -> anyhow::Result<serde_json::Value>;
@@ -516,6 +517,7 @@ Endpoint mapping:
 |---|---|---|
 | version | GET /rest/version | `.version` string |
 | whoami | GET /rest/whoami | `.name` string (the account's login); missing/non-string/blank = error |
+| valid_login | GET /rest/valid_login?login=\<login\> | boolean: `{"result": bool}` or a bare `bool`; any other shape = error, never read as `false` |
 | server_info | sequential GET /rest/version, /rest/extensions, /rest/time, /rest/parameters | `{url, version, extensions, timezone: tz_name, time: web_time, parameters}` |
 | get_bugs | GET /rest/bug?id=1,2,3[&include_fields=..] | whole envelope |
 | bug_history | GET /rest/bug/{id}/history[?new_since=%Y-%m-%dT%H:%M:%SZ] | `bugs[0].history` array as Value |
@@ -622,27 +624,49 @@ Consequences that are decisions, not accidents:
 the bug–caller relationship (did the requesting account author this bug?)
 where every other criterion describes bug content. Decisions, all deliberate:
 
-- **Source.** The caller's login comes from `GET /rest/whoami` (the `name`
-  field; a missing, non-string, or blank — empty or all-whitespace — value
-  is a FAILED resolution, never an empty login: a blank identity must not
-  compare equal to a blank `creator` and grant on no evidence),
-  authenticated and error-sanitized exactly like every other client
-  call (I12). It is compared case-insensitively (`to_lowercase`, the same
-  normalization the glob matcher applies) against the bug's `creator`
-  field, which joined `CLASSIFY_FIELDS` for this purpose. A non-string
-  `creator` leaves the relationship unknown. "The requesting account" is
-  whatever key custody says authenticates: per-request http custody gives
-  each caller their own identity, while `Server` custody (stdio, or http
-  server-held mode — see "Key custody") resolves EVERY caller to the one
-  account that owns the server's key; under server-held http custody the
-  collapse is warned about at startup.
+- **Source.** `global.identity_source` (default `"whoami"`) picks how
+  `Guard::resolve_caller` gets the caller's login:
+  - `"whoami"` — `GET /rest/whoami` (the `name` field; a missing,
+    non-string, or blank — empty or all-whitespace — value is a FAILED
+    resolution, never an empty login: a blank identity must not compare
+    equal to a blank `creator` and grant on no evidence), authenticated
+    and error-sanitized exactly like every other client call (I12). "The
+    requesting account" is whatever key custody says authenticates:
+    per-request http custody gives each caller their own identity, while
+    `Server` custody (stdio, or http server-held mode — see "Key custody")
+    resolves EVERY caller to the one account that owns the server's key;
+    under server-held http custody the collapse is warned about at
+    startup.
+  - `"declared"` — `global.identity_login` directly, with ZERO HTTP
+    requests per call. It is verified once at startup, not per call
+    (`BugWarden::preflight`, "Identity preflight" below), against
+    `GET /rest/valid_login?login=<login>` — an endpoint Bugzilla Core v1
+    DOES define — so it works on a stock deployment `whoami` cannot reach.
+    A declared login names the account owning the *server's* key, so it is
+    meaningful only under `Server` custody; `BugWarden::new` refuses to
+    construct a `declared` + per-request-custody server at all (a hard
+    startup error, not a warning — unlike `whoami`, which stays
+    per-caller-correct under per-request custody).
+
+  Either source's result is compared case-insensitively (`to_lowercase`,
+  the same normalization the glob matcher applies) against the bug's
+  `creator` field, which joined `CLASSIFY_FIELDS` for this purpose. A
+  non-string `creator` leaves the relationship unknown.
+  `Policy::validate` rejects `identity_source = "declared"` without a
+  non-blank `identity_login`, and rejects `identity_login` set under
+  `identity_source = "whoami"` (a silently-ignored key is exactly the class
+  of typo `deny_unknown_fields` exists to catch elsewhere) — both hard
+  startup errors. `valid_login` compares logins the way Bugzilla's own
+  `Bugzilla->login` does: Perl `eq`, case-sensitively — a declared login
+  differing only in case fails closed at startup, not at some later
+  `created_by_me` evaluation.
 - **Laziness.** `Policy::needs_identity()` = some rule whose `operations`
   cover `Operation::Access` carries a `created_by_me` criterion. When it is
-  false, `Guard::resolve_caller` returns `None` without any HTTP request —
-  a policy that never consults identity costs ZERO whoami lookups, so
-  pre-identity deployments keep their exact upstream request pattern. A
-  create-scoped-only identity rule does not trigger lookups either: the
-  create gate forces the answer (below).
+  false, `Guard::resolve_caller` returns `None` without any HTTP request,
+  under EITHER source — a policy that never consults identity costs ZERO
+  lookups, so pre-identity deployments keep their exact upstream request
+  pattern. A create-scoped-only identity rule does not trigger lookups
+  either: the create gate forces the answer (below).
 - **At most once per MCP tool call.** Each tool resolves the caller at most
   once, near its entry, and threads the result to EVERY classification in
   that call — `Guard::assess`, `quicksearch_window`, `disclosable`,
@@ -665,7 +689,10 @@ where every other criterion describes bug content. Decisions, all deliberate:
   reading. The alternative — resolving identity-unknown as "criterion
   fails" — would let a `created_by_me = true` DENY rule be dodged by
   making whoami fail (fail open), exactly the asymmetry I4 exists to
-  forbid.
+  forbid. `identity_source = "declared"` has no equivalent per-call failure
+  mode: the login was already verified at startup, so `resolve_caller`
+  always returns `Some` there — the only way to blackout under `declared`
+  is to never start (see "Identity preflight").
 - **Create gate: forced true, no lookup.** `may_create` forces the
   prospective bug's `created_by_me` to `Some(true)` unconditionally: the
   creator of a bug being filed is definitionally the caller — Bugzilla
@@ -687,12 +714,24 @@ where every other criterion describes bug content. Decisions, all deliberate:
   a fork/BMO extension. On a stock deployment every lookup fails, every
   `created_by_me` criterion is `Unknown`, and I4 denies everything a
   `created_by_me` rule is consulted for: a blackout, not a narrower grant.
-  Because of this, `examples/policy.toml` ships its `created_by_me` rule
-  ("my-own-reports") commented out — documented as an opt-in the operator
-  enables only after confirming their Bugzilla answers `whoami` — rather
-  than active by default. `BugWarden::preflight` (see "MCP tool surface")
-  turns an unconfirmed deployment into a loud startup failure instead of a
-  silent per-call blackout.
+  `identity_source = "declared"` is the portable answer: it never calls
+  `whoami` at all, verifying the operator's declared login once at startup
+  against `valid_login` instead — an endpoint the same reference DOES
+  document. The source × custody matrix:
+
+  | `identity_source` | stdio / http server-held key | http per-request key |
+  |---|---|---|
+  | `whoami` (default) | verified at startup (`BugWarden::preflight`); one `GET /rest/whoami` per tool call | unverifiable at startup (warns instead); one `GET /rest/whoami` per tool call |
+  | `declared` | verified once at startup via `GET /rest/valid_login`; **zero** identity requests per tool call | **startup error** (`BugWarden::new`) — no server-held key for the declared login to describe |
+
+  Because of the `whoami` row's stock-deployment gap, `examples/policy.toml`
+  ships its `created_by_me` rule ("my-own-reports") commented out —
+  documented as an opt-in the operator enables only after either
+  confirming their Bugzilla answers `whoami`, or declaring and verifying a
+  login instead — rather than active by default. `BugWarden::preflight`
+  (see "MCP tool surface") turns an unconfirmed `whoami` deployment into a
+  loud startup failure instead of a silent per-call blackout, and verifies
+  a declared login the same way.
 
 ## MCP tool surface (crates/bugwarden/src/server.rs)
 
@@ -740,6 +779,14 @@ units and container specs). Decisions, all deliberate:
   consults identity (`Policy::needs_identity`).
 - **`PerRequest` custody** (http without a key file): each request must
   carry the key header; a missing key is `McpError::invalid_request`.
+- **A declared login is a hard error under `PerRequest` custody.**
+  `identity_source = "declared"` names the account owning the SERVER's
+  key (A5); `PerRequest` custody holds no server-side key at all, so
+  `BugWarden::new` refuses to construct — `anyhow::bail!`, not a warning —
+  when a `needs_identity()` policy pairs `declared` with `PerRequest`. This
+  is stricter than the `whoami` row above precisely because `whoami` stays
+  per-caller-correct under `PerRequest` (it just cannot be verified at
+  startup); a declared login under `PerRequest` describes nobody.
 - **No fallback between custodies, in either direction.** Server-held mode
   exists so fleet clients can hold NOTHING — a client holding the real key
   could bypass the guard by talking to Bugzilla directly — so falling back
@@ -773,17 +820,20 @@ call. `main.rs` calls `server.preflight().await?` right after `new`, BEFORE
 the audit sink is opened — the same ordering rationale as key custody
 resolution: a failed preflight must not create or rotate an audit file.
 
-Behaviour, by `Policy::needs_identity()` and key custody:
+Behaviour, by `Policy::needs_identity()`, `global.identity_source` and key
+custody:
 
-| `needs_identity()` | custody | preflight does |
-|---|---|---|
-| false | any | `Ok(())`, ZERO upstream requests — the laziness contract now covers startup too |
-| true | `Server(key)` | one `GET /rest/whoami`; success logs the resolved login at `info!` and returns `Ok(())`; failure `anyhow::bail!`s naming the endpoint, that stock Bugzilla Core v1 does not define it, and that starting anyway would deny every access classification the policy's identity rules reach (I4) |
-| true | `PerRequest` | `tracing::warn!` the same compatibility statement and return `Ok(())` — there is no server-held key to probe with (A5); each caller still resolves identity correctly per call, an unreachable endpoint here only surfaces as a denial once a tool is called |
+| `needs_identity()` | `identity_source` | custody | preflight does |
+|---|---|---|---|
+| false | any | any | `Ok(())`, ZERO upstream requests — the laziness contract now covers startup too |
+| true | `whoami` | `Server(key)` | one `GET /rest/whoami`; success logs the resolved login at `info!` and returns `Ok(())`; failure `anyhow::bail!`s naming the endpoint, that stock Bugzilla Core v1 does not define it, and that starting anyway would deny every access classification the policy's identity rules reach (I4) |
+| true | `whoami` | `PerRequest` | `tracing::warn!` the same compatibility statement and return `Ok(())` — there is no server-held key to probe with (A5); each caller still resolves identity correctly per call, an unreachable endpoint here only surfaces as a denial once a tool is called |
+| true | `declared` | `Server(key)` | one `GET /rest/valid_login?login=<identity_login>`; `true` logs the verified login at `info!` and returns `Ok(())` — `resolve_caller` never looks it up again per call; `false` `anyhow::bail!`s naming the login the key does NOT authenticate as (distinct wording from a transport failure — a wrong login is not a broken key); a transport/parse error `anyhow::bail!`s naming the endpoint |
+| true | `declared` | `PerRequest` | unreachable: `BugWarden::new` already refuses to construct this combination (A5) — the match arm still exists and fails closed rather than trusting that invariant silently |
 
-The failure path attaches the sanitized client error (I12: `whoami`
-already strips the URL) as the `anyhow` error's source/context — no key
-material reaches the bailed-out message either.
+The failure path attaches the sanitized client error (I12: `whoami` /
+`valid_login` already strip the URL) as the `anyhow` error's source/context
+— no key material reaches the bailed-out message either.
 
 Tool descriptions: concise and action-oriented; state the defaults and
 constraints the model must know.
@@ -1245,7 +1295,14 @@ wired, `server.rs` and `main.rs` are the reference.
   authored by someone else stays Denied, and with identity UNKNOWN that
   bug, the foreign one, and a world-readable bug are all Denied — the
   whoami-failure blackout is pinned so it cannot be "fixed" into fail-open
-  later.
+  later; `global.identity_source`/`identity_login` — the default is
+  `whoami` with no login, `declared` with a non-blank login parses,
+  `declared` without (or with a blank) `identity_login` is a hard startup
+  error, `identity_login` set under `whoami` is a hard startup error (the
+  silently-ignored-key class of typo), and an unknown `identity_source`
+  value is rejected; `resolve_caller` under `declared` returns the login
+  with ZERO HTTP requests (pinned against both `/rest/whoami` and
+  `/rest/valid_login` with `expect(0)`).
 - Unit tests (#[cfg(test)] in crates/bugwarden/src/server.rs): assemble_bug_info
   re-classification — a body embargoed after the verdict is refused, a body
   that now earns only summary is downgraded, a body granting neither read nor
@@ -1253,8 +1310,11 @@ wired, `server.rs` and `main.rs` are the reference.
   identical restricted entries; the distinct-id bound; read-only delists
   create_bug and add_attachment (I13); the upload size gate measures decoded
   (never base64-encoded) bytes, is disabled at 0, and its refusal names no
-  number; and stdio without any key source fails at `BugWarden::new`
-  construction, never at first request.
+  number; stdio without any key source fails at `BugWarden::new`
+  construction, never at first request; and `identity_source = "declared"`
+  under `KeyCustody::PerRequest` plus a `needs_identity()` policy fails at
+  `BugWarden::new` construction naming both "declared" and "per-request",
+  while the same policy under a server-held key builds successfully (A5).
 - Unit tests (#[cfg(test)] in crates/bugwarden/src/config.rs): the key
   custody table — the mutual-exclusion error names both flags (each pinned
   with its env var, since `--api-key` is a substring of `--api-key-file`);
@@ -1295,7 +1355,14 @@ wired, `server.rs` and `main.rs` are the reference.
   failure mapped to None), and the classify projection itself — the bug
   mock answers only an include_fields carrying `creator`, so dropping the
   field from CLASSIFY_FIELDS fails the caller's-own-bug classification
-  instead of passing on a fixture that volunteers fields nobody requested.
+  instead of passing on a fixture that volunteers fields nobody requested;
+  valid_login endpoint mapping (GET /rest/valid_login?login=.. accepts
+  both `{"result": bool}` and a bare bool for true AND false; any other
+  shape — an object without a boolean `result`, a string, a number,
+  `null` — is an ERROR, never silently read as `false`), the API key
+  absent from a valid_login transport error (I12), and
+  resolve_caller under `identity_source = "declared"` costing ZERO HTTP
+  requests to either endpoint for one tool call.
 - Integration tests (crates/bugwarden/tests/tools_wiremock.rs, wiremock +
   rmcp client over an in-memory duplex transport): the tools are CALLED
   through a real MCP session, so a tool that stops calling its guard fails
@@ -1343,7 +1410,12 @@ wired, `server.rs` and `main.rs` are the reference.
   reaching a write gate (a carve-out granting `comment` on the caller's
   own reports POSTs the comment for the caller's bug and refuses a
   foreign one with nothing POSTed), and a whoami transport error leaking
-  no API key into any client-visible text (I12).
+  no API key into any client-visible text (I12); and the declared-login
+  counterpart of the issue-#33 scenario — the same my-own-reports carve-out
+  resolved via `identity_source = "declared"` grants the caller's own
+  group-restricted bug through bug_info and denies a foreign one
+  identically, with `expect(0)` whoami hits proving the endpoint is never
+  touched.
 - Integration tests (crates/bugwarden/tests/preflight_wiremock.rs,
   wiremock): `BugWarden::preflight` — a missing `/rest/whoami` under
   server-held key custody plus an identity-consulting policy fails
@@ -1353,8 +1425,12 @@ wired, `server.rs` and `main.rs` are the reference.
   criterion costs ZERO whoami requests at preflight (the laziness contract
   extends to startup); `KeyCustody::PerRequest` under an identity policy
   passes preflight (warn only) while issuing zero whoami requests, since
-  there is no server-held key to verify it with (A5); and a transport-level
-  whoami failure leaks no API key into the preflight error text (I12).
+  there is no server-held key to verify it with (A5); a transport-level
+  whoami failure leaks no API key into the preflight error text (I12); and
+  the `declared` arm — a correct declared login passes preflight via one
+  `valid_login` request and zero whoami requests, a login the key does NOT
+  authenticate as fails preflight naming that login, and a transport-level
+  `valid_login` failure fails preflight naming the endpoint.
 - Integration tests (crates/bugwarden/tests/http_transport_wiremock.rs,
   wiremock + rmcp client over REAL streamable HTTP — the only harness in
   which the per-request key header physically exists; the wiremock upstream

--- a/examples/policy.toml
+++ b/examples/policy.toml
@@ -15,10 +15,13 @@
 #   * OPTIONAL, SHIPPED DISABLED: the caller's OWN bug reports — bugs
 #     authored by the account whose API key makes the request — can be made
 #     always readable (read, comments, history, attachments; no writes),
-#     even where a rule above would hide them. This needs a Bugzilla that
-#     exposes an identity endpoint (stock Bugzilla Core v1 does not — see
-#     section 0b) and comes with a documented identity-failure blackout, so
-#     it ships commented out rather than enabled by default;
+#     even where a rule above would hide them. This needs a way to resolve
+#     the caller's identity: either `global.identity_source = "whoami"`
+#     (the default; stock Bugzilla Core v1 does not define this endpoint)
+#     or `"declared"` (an operator-configured, startup-verified login that
+#     works on stock Bugzilla too — see section 0b), and comes with a
+#     documented identity-failure blackout, so it ships commented out
+#     rather than enabled by default;
 #   * new bug reports are accepted into the desktop products ONLY — see the
 #     "reporters" rule in section 0, whose `operations = ["create"]` scope
 #     grants filing without touching what may be read — except that a title
@@ -156,26 +159,43 @@ products = ["GNOME*", "KDE*"]
 # 0b. OPTIONAL, SHIPPED DISABLED: the caller's own reports, readable even
 #     where the rules below would hide them.
 #
-# PREREQUISITE, CHECK THIS FIRST: this rule needs a Bugzilla deployment that
-# exposes an identity endpoint. The current Bugzilla Core v1 REST reference
-# does not define `/rest/whoami` — it is a fork/BMO extension (see
-# docs/DESIGN.md, "Identity resolution", Portability) — so on a stock
-# instance every lookup fails, the caller's identity is always unknown, and
-# — per the fail-closed behaviour below — this rule alone denies EVERY
-# access classification it is consulted for the moment it is enabled. That
-# is why this rule ships commented out rather than active: an example file
-# cannot know whether the operator's Bugzilla has the endpoint, and enabling
-# it against one that does not is a silent blackout, not a carve-out.
-# Confirm your deployment answers `GET /rest/whoami` before uncommenting the
-# `[[rule]]` block below.
+# PREREQUISITE, CHECK THIS FIRST: this rule needs a way to resolve the
+# caller's identity, chosen via `global.identity_source` (default
+# `"whoami"`):
 #
-# Once confirmed, `created_by_me = true` matches bugs AUTHORED by the
-# account whose API key makes the request — the one identity-relative
-# criterion. The server resolves the caller's login at most once per tool
-# call (GET /rest/whoami, only when a policy actually uses this criterion)
-# and compares it case-insensitively against the bug's creator. Placed
-# ABOVE the deny rules, this rule carves the caller's own reports out of
-# them: people keep following the bugs they themselves filed —
+#   * "whoami" calls `GET /rest/whoami` on every tool call. The current
+#     Bugzilla Core v1 REST reference does not define this endpoint — it is
+#     a fork/BMO extension (see docs/DESIGN.md, "Identity resolution",
+#     Portability) — so on a stock instance every lookup fails, the
+#     caller's identity is always unknown, and — per the fail-closed
+#     behaviour below — this rule alone denies EVERY access classification
+#     it is consulted for the moment it is enabled. Confirm your deployment
+#     answers `GET /rest/whoami` before choosing this source.
+#   * "declared" names an operator-configured login in `identity_login`
+#     instead, verified ONCE at startup against `GET /rest/valid_login` —
+#     an endpoint the same reference DOES define — and never looked up
+#     again per call. This is the portable choice on a stock deployment: it
+#     needs `global.identity_source = "declared"` plus
+#     `global.identity_login = "you@example.com"` (exactly as Bugzilla
+#     stores it — the comparison is case-sensitive), and only works with a
+#     server-held API key (stdio, or http server-held mode): it names the
+#     account owning THIS server's key, and per-request http key custody
+#     holds no such key for it to describe (a hard startup error there).
+#
+# Either way this rule ships commented out rather than active: an example
+# file cannot know whether the operator's Bugzilla has `/rest/whoami`, nor
+# what the operator's own Bugzilla login is, and enabling it against a
+# wrong assumption is a silent blackout (or a startup failure), not a
+# carve-out.
+#
+# Once you have picked and configured a source, `created_by_me = true`
+# matches bugs AUTHORED by the resolved account — the one identity-relative
+# criterion — comparing case-insensitively against the bug's creator. Under
+# "whoami" the server performs at most one lookup per tool call (only when
+# a policy actually uses this criterion); under "declared" it performs
+# ZERO lookups per call, since the login was already verified at startup.
+# Placed ABOVE the deny rules, this rule carves the caller's own reports
+# out of them: people keep following the bugs they themselves filed —
 # group-restricted ones included — while everyone else's hidden bugs stay
 # hidden. Reading is granted, writing is not, so "follow your own report"
 # does not become "edit your own report". Note the flip side of
@@ -183,7 +203,7 @@ products = ["GNOME*", "KDE*"]
 # rule first and are therefore read-only through this server under this
 # example.
 #
-# This rule is an EXPLICIT OPT-IN even where the endpoint exists — an
+# This rule is an EXPLICIT OPT-IN even where identity resolves cleanly — an
 # operator who does not want it simply leaves it commented out and keeps
 # today's behaviour. In particular, a deployment whose clients share one
 # service-account API key should NOT enable this rule: there, "created by
@@ -196,17 +216,21 @@ products = ["GNOME*", "KDE*"]
 # first match for every request and — granting no "create" capability —
 # would refuse ALL filing, section 0 notwithstanding. Scoped to access, it
 # decides reads only and the create gate never consults it (and never
-# performs a whoami lookup).
+# performs an identity lookup).
 #
-# Failure mode, deliberate: if the whoami lookup fails, the caller's
-# identity is unknown, this rule can be decided for NO bug, and an
+# Failure mode, deliberate: under "whoami", if the lookup fails, the
+# caller's identity is unknown, this rule can be decided for NO bug, and an
 # undecidable consulted rule denies whatever its action (see "Unreadable
 # metadata" above). While whoami is down (or simply absent — see the
 # prerequisite above), a policy that leads with this rule therefore denies
 # every read — a blackout — rather than serving what an unverified identity
 # should not see. That is the only uniformly fail-closed reading: treating
 # unknown identity as "criterion fails" would let a created_by_me deny rule
-# be dodged by making whoami fail.
+# be dodged by making whoami fail. `BugWarden::preflight` fails the server
+# at STARTUP instead of serving this blackout, for either source — see
+# docs/DESIGN.md, "Identity preflight". Under "declared" there is no
+# per-call failure mode left: the login was already verified once at
+# startup, so the only way to blackout is to never start.
 #
 # This criterion cannot widen exposure beyond the credential: Bugzilla
 # still enforces its own permissions on every fetch, so an authorship rule
@@ -214,11 +238,13 @@ products = ["GNOME*", "KDE*"]
 # between the guard and the credential, never escapes it.
 #
 # NOTE: bugwarden versions without identity support REJECT a policy using
-# `created_by_me` at startup — parsing is strict, so the whole file fails
-# closed instead of the rule being silently ignored.
+# `created_by_me`, `identity_source`, or `identity_login` at startup —
+# parsing is strict, so the whole file fails closed instead of the rule
+# being silently ignored.
 
-# Uncomment the block below ONLY after confirming your Bugzilla answers
-# GET /rest/whoami (see the prerequisite above).
+# Uncomment the block below ONLY after picking and configuring an
+# identity_source above (default "whoami" needs no [global] change; a
+# "declared" login needs the [global] keys set first).
 #[[rule]]
 #name = "my-own-reports"
 #description = "Bugs the caller's own account filed stay readable, never writable"


### PR DESCRIPTION
Third of three PRs addressing the `created_by_me` / `whoami` portability
gap (#70, #72). This one closes #71: `created_by_me` is now usable on a
stock Bugzilla that has no identity endpoint at all.

## What changed

`Guard::resolve_caller` could only resolve the caller's identity through
`GET /rest/whoami`, a fork/BMO extension absent from the current Bugzilla
Core v1 REST reference. On a stock deployment every lookup fails and I4
denies everything a `created_by_me` rule reaches — the preflight probe
added in #72 made that failure loud at startup, but there was still no
way to use the criterion at all without a fork.

- New `global.identity_source` (`"whoami"`, the default, or `"declared"`)
  and `global.identity_login` policy keys. Under `"declared"`,
  `Guard::resolve_caller` returns the configured login directly with
  **zero** HTTP requests per call — it is verified exactly once at
  startup instead.
- New `BugzillaClient::valid_login(key, login)` → `GET
  /rest/valid_login?login=<login>`, an endpoint the current Bugzilla
  Core v1 REST reference *does* document (unlike `whoami`). Accepts both
  `{"result": bool}` and a bare `bool`; any other shape is an error,
  never silently read as `false`.
- `Policy::validate` rejects `identity_source = "declared"` without a
  non-blank `identity_login`, and rejects `identity_login` set under
  `"whoami"` (a silently-ignored key) — both hard startup errors.
- A declared login names the account owning the *server's* key, so it is
  only meaningful under a server-held key: `BugWarden::new` refuses to
  construct a `declared` + per-request-key-custody server at all, and
  `BugWarden::preflight` gained a `Declared` arm that bails on a login
  the key does not authenticate as (fail closed, wording distinct from a
  transport failure) or on a `valid_login` transport/parse error.
- `examples/policy.toml` section 0b and `README.md`/`docs/DESIGN.md` now
  document both sources side by side, including a source × custody
  matrix.

No behavior change for existing 0.3.0 policies: `identity_source`
defaults to `whoami`, so every policy using `created_by_me` today keeps
its exact request pattern.

## Invariants touched

- **I1** — unaffected. `identity_source`/`identity_login` are policy-only
  fields; no MCP tool can read or set them.
- **I4** — reinforced, not relaxed. A declared login is verified *before*
  the server ever answers a tool call; a wrong login or a verification
  failure is a startup bail, never a runtime fallback to "assume true".
- **I12** — `valid_login` shares the exact same auth/sanitize path as
  every other client call; a dedicated wiremock test asserts the key
  never appears in its error text.
- **A5** (declared login only meaningful under a server-held key) — new
  hard error at `BugWarden::new`, plus a matching `preflight()` arm that
  fails closed rather than trusting that construction-time invariant
  silently.

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p bugwarden --features gen --all-targets -- -D warnings`
- `cargo test --workspace --all-targets --locked` (all green, including
  new unit tests in `policy.rs` for every `identity_source`/
  `identity_login` combination, wiremock tests for `valid_login` in
  `guard_wiremock.rs`, a zero-HTTP-request test for `resolve_caller`
  under `declared`, `BugWarden::new` construction-bail tests, three new
  `preflight_wiremock.rs` cases for the `Declared` arm, and an
  end-to-end `tools_wiremock.rs` test)
- `cargo deny check` (advisories/bans/licenses/sources ok)
- `typos` — clean

Closes #71.
