### PR TITLE
ci: exempt the rust-cache action from the copyleft deny-list

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -49,3 +49,20 @@ jobs:
             EPL-2.0,
             MPL-1.1,
             OSL-3.0
+          # Swatinem/rust-cache is LGPL-3.0 and exempt from the list above,
+          # which exists for dependencies that get COMPILED INTO the binary
+          # we distribute. This is a GitHub Action: it runs on the runner,
+          # saves and restores ~/.cargo and target/, is never linked, never
+          # vendored, and never conveyed — so its copyleft cannot reach an
+          # artifact we ship. release.yml, which builds the tarballs and
+          # publishes to crates.io, does not use it at all; only ci.yml does.
+          # The exemption changes nothing in substance: the same LGPL-3.0
+          # code is already pinned on main, and only a version bump makes
+          # dependency-review look at it (it inspects CHANGED dependencies),
+          # so without this every future bump fails identically.
+          # deny.toml remains the sole authority for crates, where copyleft
+          # would be a real distribution problem — it is deliberately NOT
+          # relaxed here. Exempt one action, not `pkg:githubactions/*`, so a
+          # new copyleft action still trips the check and gets a decision.
+          allow-dependencies-licenses: >-
+            pkg:githubactions/Swatinem/rust-cache


### PR DESCRIPTION
Unblocks #80, which Dependabot cannot merge today: bumping
`Swatinem/rust-cache` trips our own `deny-licenses` list on **LGPL-3.0**.

## Why the check is misfiring

The deny-list's stated purpose is that this is a permissive Apache-2.0
project, so copyleft **dependencies compiled into the binary we
distribute** are rejected. That is exactly right for crates — and
`deny.toml` enforces it against the real crate graph, untouched by this PR.

A GitHub Action is not that. `rust-cache` runs on the runner, saves and
restores `~/.cargo` and `target/`, and is never linked, vendored, or
conveyed. Its copyleft cannot reach anything we ship — the same reason
proprietary software may be compiled with GCC. `release.yml`, which builds
the release tarballs and publishes to crates.io, does not use it at all;
all five occurrences are in `ci.yml`.

## This changes nothing in substance

**The identical LGPL-3.0 code is already pinned on `main`** (`e18b4977` —
verified same licence as the proposed SHA). `dependency-review` only
inspects *changed* dependencies, so the existing pin was never examined;
only a bump makes it look. Without this exemption every future
`rust-cache` bump fails the same way and Dependabot reopens it forever.

## Scope

- `deny.toml` untouched — crates keep the full copyleft policy.
- `deny-licenses` untouched — all 15 entries remain, `LGPL-3.0-only`
  included.
- Exempts **one action**, not `pkg:githubactions/*`, so a new copyleft
  action still trips the check and gets a deliberate decision rather than
  a blanket pass.

The reasoning is recorded in a comment beside the exemption, since the two
policies now differ by one entry and a future reader would otherwise read
that as drift from `deny.toml`.