### PR TITLE
chore: release 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "bugwarden"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "bugwarden-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Martin Pluskal <martin@pluskal.org>"]

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -34,7 +34,7 @@ gen = ["dep:clap_complete", "dep:clap_mangen"]
 workspace = true
 
 [dependencies]
-bugwarden-core = { path = "../bugwarden-core", version = "0.3.0" }
+bugwarden-core = { path = "../bugwarden-core", version = "0.4.0" }
 
 rmcp = { version = "3.1", features = [
     "server",

--- a/crates/bugwarden/man/bugwarden.1
+++ b/crates/bugwarden/man/bugwarden.1
@@ -1,4 +1,4 @@
-.TH bugwarden 1 "" "bugwarden 0.3.0" "General Commands Manual"
+.TH bugwarden 1 "" "bugwarden 0.4.0" "General Commands Manual"
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SH NAME


### PR DESCRIPTION
Version bump for the 0.4.0 release. Per AGENTS.md the bump lands as a normal PR first; the annotated tag then goes on the merge commit and `release.yml` does the rest.

## Why 0.4.0 and not 0.3.1

35 commits since `0.3.0` (2026-08-03), and one of them changes behaviour an operator can be broken by: **#84** makes `Policy::validate` reject rule names colliding with the guard's synthetic ones, so a policy that started under 0.3.0 can now fail at startup. Pre-1.0, that belongs in the minor position.

## What's in the cycle

**Features**
- `--allowed-hosts` for inbound host validation on the HTTP transport
- guarded product and field discovery tools (`bugzilla_products`, `bug_fields`), gated behind `global.allow_discovery` (I16)
- custom fields accepted when filing a bug; the instance's status workflow reported in `bug_fields`
- portable identity via a declared, verified login; startup fails when identity cannot be resolved
- a `User-Agent` identifying this build to Bugzilla, and the build named in the MCP handshake
- generated man page and shell completions

**Fixes**
- rule names the guard decides under are now reserved (#84)
- `suppressed_count` is a total, not a maximum of two disjoint tallies (#68)
- a capped search page is no longer read as the end of results
- the HTTP body cap is derived from the attachment ceiling (#52)
- one instance's status workflow is no longer imposed on others
- the whoami-dependent example rule is gone

**Docs** — the `guard.rule` encoding (#67), the audit stream and MCP surface in the README, the TLS trust-store trade-off, the stateless-metadata decision for #34, and a full `StreamableHttpServerConfig` inventory.

**Build/CI** — rmcp 3.1, reqwest 0.13, sha2 0.11, dependency refreshes, and a scoped copyleft exemption for the `rust-cache` action.

## What this PR touches

| File | Change |
|---|---|
| `Cargo.toml` | `[workspace.package] version` → `0.4.0` |
| `crates/bugwarden/Cargo.toml` | the `bugwarden-core` dependency pins `version` as well as `path`, so it moves in lockstep |
| `Cargo.lock` | both workspace crates |
| `crates/bugwarden/man/bugwarden.1` | regenerated — the man page embeds the version |

The completions carry no version string and are unchanged, which `rust-assets-drift` confirms.

The `bugwarden-core` version requirement is worth noting: nothing single-sources it, so it has to be bumped by hand every release. It fails the build loudly rather than silently resolving a stale core, which is how it was caught here.

## Verification

`cargo fmt --check`, both clippy invocations, `cargo test --workspace --all-targets --locked` (**431 passed, 0 failed**), and `cargo deny check` all pass. Assets regenerated from the clap CLI and re-diffed.