### PR TITLE
test(audit): pin the empty-set guards at the note call sites

### DIFF
--- a/crates/bugwarden/tests/audit_wiremock.rs
+++ b/crates/bugwarden/tests/audit_wiremock.rs
@@ -900,6 +900,140 @@ async fn bug_comments_with_nothing_filtered_stays_served_and_counts_zero() {
     );
 }
 
+/// The counterpart to [`mount_hidden_link`]: bug 7 names bug 808 twice —
+/// its `depends_on` links it, and its one comment is a duplicate marker
+/// naming it — and 808 is a plain bug [`HIDE_SECRET_POLICY`] lets through.
+/// That comment is public, so the I5 gate drops nothing either.
+///
+/// The point is that each id-set call site HAS a candidate to weigh: a
+/// clean record over this fixture means "the guard withheld nothing", not
+/// "there was nothing to withhold". A guard that never classified 808 —
+/// or classified it and said no — fails closed and scrubs the link, which
+/// shows up here as a suppression rather than as a pass.
+///
+/// Every row is load-bearing, which is the property a fixture built
+/// against vacuity had better have: deleting 808's classification mock,
+/// making 808 a hidden `Secret*` bug, dropping the `depends_on` link,
+/// emptying the comment list, making the comment private, and replacing
+/// the marker with plain text each turn one of the two tests below red.
+async fn mount_disclosable_link(mock: &MockServer) {
+    let mut linked = world_bug(7);
+    linked["depends_on"] = json!([808]);
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "7"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [linked] })))
+        .mount(mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "808"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [world_bug(808)] })))
+        .mount(mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug/7/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "bugs": { "7": { "comments": [
+                { "id": 1, "bug_id": 7, "is_private": false,
+                  "text": "*** Bug 808 has been marked as a duplicate of this bug ***" },
+            ] } }
+        })))
+        .mount(mock)
+        .await;
+}
+
+#[tokio::test]
+async fn summarize_bug_with_nothing_filtered_stays_served_and_counts_zero() {
+    // Issue #88, the sibling of the bug_comments case above: summarize_bug
+    // feeds BOTH tallies on every call — the id-less counter
+    // unconditionally, the id set under `if !hidden.is_empty()`. Drop that
+    // guard and `note_suppressed` fires with an empty iterator and merges
+    // `served_filtered` into every summarize_bug record, over an empty
+    // `suppressed_ids`; the one field an operator filters on to find the
+    // calls the guard acted upon would then say the same thing about all
+    // of them. The other tally leans on the `n == 0` early return inside
+    // `note_suppressed_count`, which the issue #87 tests pin for
+    // bug_comments and list_attachments but not at this third call site.
+    let mock = MockServer::start().await;
+    mount_disclosable_link(&mock).await;
+    let audited = audited_client_for(HIDE_SECRET_POLICY, &mock, "test-key").await;
+
+    let result = call(&audited.client, "summarize_bug", json!({ "id": 7 })).await;
+    assert_ne!(result.is_error, Some(true), "the summary prompt is served");
+    let envelope = serde_json::to_string(&result).unwrap();
+    assert!(
+        envelope.contains("Bug 808 has been marked as a duplicate"),
+        "the marker names a bug the policy allows, so the scrub keeps it \
+         and the recorded zero means nothing was withheld: {envelope}"
+    );
+
+    let events = read_events(&audited.audit_path);
+    let tc = last_tool_call(&events);
+    assert_eq!(tc.request.tool, "summarize_bug");
+    let guard = tc.guard.as_ref().expect("guard info recorded");
+    assert_eq!(
+        guard.verdict,
+        Verdict::Served,
+        "every comment is public and the only bug they name is disclosable, \
+         so nothing was withheld: {guard:?}"
+    );
+    assert_eq!(guard.suppressed_count, 0);
+    assert!(guard.suppressed_ids.is_empty());
+    assert_eq!(
+        guard.rule.as_deref(),
+        Some("default"),
+        "and the rule that decided the call survives — a filtered merge \
+         outranks a clean serve and would clear it"
+    );
+}
+
+#[tokio::test]
+async fn bug_info_with_every_link_disclosable_stays_served_and_redacts_nothing() {
+    // The same defect class at bug_info's two notes, neither of which
+    // anything was pinning: the I14-scrubbed link ids under
+    // `if !hidden_links.is_empty()`, and the summary-view marker under
+    // `if redacted`. Both notes fire unconditionally once their guard is
+    // gone, and either one merges `served_filtered` into every bug_info
+    // record — the redaction note additionally naming a view the client
+    // was never put into.
+    let mock = MockServer::start().await;
+    mount_disclosable_link(&mock).await;
+    let audited = audited_client_for(HIDE_SECRET_POLICY, &mock, "test-key").await;
+
+    let result = call(&audited.client, "bug_info", json!({ "bug_ids": [7] })).await;
+    assert_ne!(result.is_error, Some(true), "bug 7 is served");
+    let envelope = serde_json::to_string(&result).unwrap();
+    assert!(
+        envelope.contains("808"),
+        "the link names a bug the policy allows, so I14 keeps it and the \
+         empty suppression means nothing was withheld: {envelope}"
+    );
+
+    let events = read_events(&audited.audit_path);
+    let tc = last_tool_call(&events);
+    assert_eq!(tc.request.tool, "bug_info");
+    let guard = tc.guard.as_ref().expect("guard info recorded");
+    assert_eq!(
+        guard.verdict,
+        Verdict::Served,
+        "bug 7 is served whole and its only link was disclosable: {guard:?}"
+    );
+    assert_eq!(guard.suppressed_count, 0);
+    assert!(guard.suppressed_ids.is_empty());
+    assert!(
+        guard.redacted_fields.is_empty(),
+        "and the bug was served whole, not as a summary view: {:?}",
+        guard.redacted_fields
+    );
+    assert_eq!(
+        guard.rule.as_deref(),
+        Some("default"),
+        "and the rule that decided the call survives — a filtered merge \
+         outranks a clean serve and would clear it"
+    );
+}
+
 /// One row of bug 7's attachment metadata, as Bugzilla serves it with the
 /// content excluded.
 fn attachment(id: u64, is_private: bool, file_name: &str) -> Value {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1755,7 +1755,29 @@ wired, `server.rs` and `main.rs` are the reference.
   counter call, counting the whole list rather than the drop, and adding
   any unconditional note beside it (a `note_redacted`, a rule-less
   `note_verdict`) — which the zero guard, living inside
-  `note_suppressed_count`, cannot stop — are all detectable.
+  `note_suppressed_count`, cannot stop — are all detectable; and the
+  empty-set guards at the note call sites themselves (issue #88), where
+  the counter's zero guard reaches nothing: `note_suppressed` merges
+  `served_filtered` whatever it is handed, so a call site that drops its
+  `if !hidden.is_empty()` claims a filtered serve over an EMPTY
+  `suppressed_ids` on every call, and `note_redacted` does the same over
+  a `redacted_fields` naming a view the client was never put into. A
+  `summarize_bug` call whose comments are all public and name one
+  DISCLOSABLE bug records verdict `served`, `suppressed_count == 0`, no
+  id and the rule that decided it — pinning that tool's id-set guard and
+  giving the counter's third call site the clean-call record #87 left it
+  without; a `bug_info` call over a bug served whole whose only link the
+  guard weighed and allowed records the same clean serve with an empty
+  `redacted_fields`, pinning both of that tool's notes on the side no
+  assertion had reached — its link suppression had only ever been read
+  on a call that DID suppress, its redaction note on no record at all.
+  The one shared fixture hands each id-set site a candidate to weigh
+  instead of an empty set, and earns bug 7 a FULL grant rather than a
+  summary view, so a clean record means "the guard withheld nothing" and
+  not "there was nothing to withhold". The remaining note sites —
+  `bug_history`'s and `bug_comments`' id sets, `bugs_quicksearch`'s two
+  id sets and its redaction note — already fail on a clean-call record
+  above, but over fixtures with nothing to weigh.
 - Identity tests (#[cfg(test)] in crates/bugwarden/src/server.rs and
   crates/bugwarden-core/src/client.rs; crates/bugwarden/tests/
   http_transport_wiremock.rs, crates/bugwarden/tests/binary_user_agent.rs


### PR DESCRIPTION
Closes #88.

`note_suppressed` merges `served_filtered` whatever it is handed, and
`note_redacted` does the same, so a call site that loses its empty-set
guard claims a filtered serve on every call — over an empty
`suppressed_ids`, or naming a summary view the client was never put
into. `verdict` is the field an operator filters on to find the calls
where the guard actually did something, so collapsing that distinction
is silent: the records still validate, and `suppressed_count: 0` beside
`served_filtered` reads as a rounding artefact.

The behaviour is correct today. Only the coverage was missing.

## The survey #88 asked for

Decided by mutation, not by reading — reading is how this class of gap
survived twice already. Every `note_suppressed` / `note_suppressed_count`
/ `note_redacted` call site in the workspace:

| site | tool | pinned before? |
|---|---|---|
| 1777 | `bug_info` `note_redacted` | **no** — suite stayed green |
| 1797 | `bug_info` `note_suppressed` | **no** — suite stayed green |
| 1835 | `bug_history` `note_suppressed` | yes |
| 1893 | `bug_comments` `note_suppressed_count` | yes |
| 1896 | `bug_comments` `note_suppressed` | yes |
| 2009 | `bugs_quicksearch` `note_suppressed` | yes |
| 2015 | `bugs_quicksearch` `note_redacted` | yes |
| 2020 | `bugs_quicksearch` `note_suppressed` | yes |
| 2727 | `list_attachments` `note_suppressed_count` | yes |
| 3125 | `summarize_bug` `note_suppressed_count` | **no** — the third and last call site of the `n == 0` guard, the one without a clean-call record |
| 3128 | `summarize_bug` `note_suppressed` | **no** — the issue's target |

Four gaps, two tools, so two tests. All eight guarded note sites are now
mutation-covered.

## Anti-vacuity

A previous PR here shipped a test that provably could not fail, and
DESIGN.md booked it as coverage. The fixture is built against that: bug 7
names bug 808 twice (a `depends_on` link and a duplicate marker among its
comments) and 808 is a plain bug the policy allows, so each id-set site
under test is handed a candidate to *weigh*. A clean record therefore
means "the guard withheld nothing", not "there was nothing to withhold" —
if the guard never classified 808, or classified it and said no, it fails
closed, scrubs the link, and the tests go red.

Every row of the fixture is load-bearing. Deleting 808's classify mock,
making 808 a hidden `Secret*` bug, dropping the `depends_on` link,
emptying the comment list, making the comment private, and replacing the
marker with plain text each turn one of the two tests red.

## Adversarial review before opening

Three reviewers with distinct lenses went over the uncommitted diff, each
re-running the mutations independently rather than trusting the report.
Two returned MERGE-SAFE; the third blocked on documentation. What they
found and how it was resolved:

- **Two false statements in the DESIGN.md paragraph** (blocking, fixed).
  It claimed neither `bug_info` note "any record assertion had reached" —
  false for the link suppression, which `suppressed_ids_reach_the_log_never_the_envelope`
  already asserts on a bug_info record; what was unreached is its
  *empty-set branch*. And it called all three of `bugs_quicksearch`'s
  notes id sets, when two are id sets and the third is a redaction note.
  Both were prose lifted from a neighbouring sentence where they were
  true. Rewritten and re-verified against the code.
- **Overstated credit** at summarize_bug's counter site (fixed): deleting
  that counter call is already killed by
  `summarize_bug_records_the_same_total_as_bug_comments`. What #87 left
  absent is the clean-call record, and the text now says only that.
- **A PR number where the file cites issues** (fixed): `#89` → `#87`.
- **One decorative fixture row** (fixed): a plain public comment could be
  deleted with the suite green. Dropped, so "every row is load-bearing"
  is now a true property of a fixture whose whole job is anti-vacuity.
- A reviewer's own proposed replacement text carried a further
  imprecision — that the fixture hands *every* site a candidate to weigh,
  which is false for the redaction note, where nothing is weighed and
  declined. Its contribution there is that bug 7 earns a full grant
  rather than a summary view. Corrected before use.

A gap they found that is **out of scope and now tracked as #94**: both
`note_redacted` sites can be made to *never fire* with the suite green.
That is the opposite direction from this issue — an absent note and a
correctly-empty one produce identical records — so it is not covered here.

## Verification

All five commands from AGENTS.md, re-run independently of the
implementation: `cargo fmt --check`, `cargo clippy --workspace
--all-targets -- -D warnings`, `cargo clippy -p bugwarden --features gen
--all-targets -- -D warnings`, `cargo test --workspace --all-targets
--locked` (**433 passed, 0 failed**), `cargo deny check`.

No production code is touched.
