### PR TITLE
docs: refresh the rmcp reference-tree version to 3.1.2

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1216,7 +1216,7 @@ Decisions, all deliberate:
 ## rmcp 3.1 usage notes
 
 Reference source is the rmcp this workspace pins, unpacked in the local
-registry: `~/.cargo/registry/src/*/rmcp-3.1.1/` — today's version, and the
+registry: `~/.cargo/registry/src/*/rmcp-3.1.2/` — today's version, and the
 directory holding the `rmcp` package's `manifest_path` in `cargo metadata
 --format-version 1` on any day, so it follows `Cargo.lock` rather than a copy
 of it and is by construction the source this build compiles against. Every rmcp
@@ -1226,8 +1226,8 @@ routing traps), `handler/server/router/tool.rs` (`ToolRouter`, incl.
 `remove_route` / `has_route` — I13), `model.rs` and `model/serde_impl.rs`
 (`InitializeResult`, the `_meta` strip), `service.rs` (the serve loop); the
 `#[tool_router]` / `#[tool_handler]` expansions are in the sibling
-`rmcp-macros-3.1.1` tree. The published crate carries no `examples/` — those
-live upstream at the `rmcp-v3.1.1` tag — but for how this server is actually
+`rmcp-macros-3.1.2` tree. The published crate carries no `examples/` — those
+live upstream at the `rmcp-v3.1.2` tag — but for how this server is actually
 wired, `server.rs` and `main.rs` are the reference.
 
 - `rmcp = { version = "3.1", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }`


### PR DESCRIPTION
Follow-up to #98, which bumped `rmcp` 3.1.1 → 3.1.2.

Three version strings in the "rmcp 3.1 usage notes" preamble still named a
tree that no longer exists in the local registry — the registry path itself,
the sibling `rmcp-macros` tree, and the upstream tag the absent `examples/`
live at. The registry-path sentence additionally called 3.1.1 "today's
version", which the bump made false.

Confirmed the real directories are now `rmcp-3.1.2` / `rmcp-macros-3.1.2`
(resolved from the `manifest_path` of each package in `cargo metadata
--format-version 1`).

## Why this is only a version-string refresh

The paragraph is deliberately built to survive a bump: it tells the reader to
resolve the directory from `cargo metadata` so it follows `Cargo.lock` rather
than a copy of it. Nothing the notes rest on changed — the entire
`rmcp-v3.1.1...rmcp-v3.1.2` delta is client-side:

| file | |
|---|---|
| `transport/auth.rs` | client OAuth |
| `transport/common/client_side_sse.rs` | client SSE |
| `transport/common/reqwest/streamable_http_client.rs` | client transport |

None of `transport/streamable_http_server/tower.rs`,
`handler/server/router/tool.rs`, `model.rs`/`model/serde_impl.rs` or
`service.rs` — the four modules the notes actually cite — is touched. So the
`StreamableHttpServerConfig` field table stands, `skips_the_handshake` remains
the thing keeping a client that names a legacy revision off the handshake-free
path, and `DEFAULT_PROTOCOL_VERSION` is unaffected (upstream #1105, which moves
`ProtocolVersion::LATEST`, still has not landed). rmcp's client half is a
dev-dependency here.

Docs-only; no code or test changes.