### PR TITLE
feat(server): require a bearer token on the http transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "subtle",
  "tempfile",
  "thiserror",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ is `bug_url`, which computes a URL string locally and contacts nothing.
   them.
 - **`update_bug_fields` and `create_bug` custom fields are restricted** to
   `cf_*` keys as described above.
+- **HTTP is deny-by-default.** The http transport refuses to start without a
+  bearer token unless `--insecure-no-auth` says so explicitly; see
+  [Authentication and scopes](#authentication-and-scopes).
 
 ## Installation
 
@@ -224,18 +227,98 @@ no host.
 
 ### HTTP transport (default)
 
-The server listens on `http://<host>:<port>/mcp`. Each client request carries
-the Bugzilla API key in an HTTP header (default header name: `ApiKey`), so one
-server can serve multiple users with their own keys:
+The server listens on `http://<host>:<port>/mcp`.
+
+#### Authentication and scopes
+
+Unlike stdio — where the client already owns the process it launched — HTTP
+serves anyone who can reach the port, and in [server-held key
+mode](#server-held-key-mode-fleet-deployments) that means serving them with the
+deployment's own Bugzilla credential. Authentication is therefore **mandatory
+and deny-by-default**. Two tokens define two scopes:
+
+| Variable | Scope | Tools |
+| --- | --- | --- |
+| `BUGWARDEN_HTTP_TOKEN` | write | every tool this deployment's policy serves |
+| `BUGWARDEN_HTTP_READ_TOKEN` | read | the read tools only |
+
+Either may be set alone. A caller presents its token as `Authorization: Bearer
+<token>`, which is compared in constant time; anything else — no header, the
+wrong token, another scheme, an unrouted path — gets the same empty `401` with
+`WWW-Authenticate: Bearer`, so probing tells a stranger nothing.
+
+A read-scope caller is offered only the read tools in `tools/list`, and calling
+a write tool anyway is answered exactly as calling a tool that does not exist,
+with no Bugzilla request made. The split is the same set `--read-only` removes
+from the tool router, so the two cannot drift. Because the advertised tool set
+depends on the credential, a client that caches `tools/list` across tokens will
+show a stale list.
+
+Tokens are never accepted as command-line flags — argv is world-readable via
+`ps` — so they come from the environment only. bugwarden reads no `.env` file:
+supply them through the container runtime, or through a systemd unit's
+`EnvironmentFile=` written with a restrictive umask.
+
+Mint one token and keep it: the clients have to present the same value, so a
+token generated inline on the command line (`BUGWARDEN_HTTP_TOKEN=$(openssl
+rand -hex 32) bugwarden …`) starts a server nobody can talk to.
 
 ```bash
+umask 077
+openssl rand -hex 32 > /etc/bugwarden/http-token
+```
+
+```bash
+export BUGWARDEN_HTTP_TOKEN="$(cat /etc/bugwarden/http-token)"
+
 bugwarden \
   --bugzilla-server https://bugzilla.opensuse.org \
   --policy /etc/bugwarden/policy.toml \
   --host 127.0.0.1 --port 8000
 ```
 
-MCP client configuration (exact format varies by client):
+Under systemd, name the file in an `EnvironmentFile=` instead — one
+`BUGWARDEN_HTTP_TOKEN=<value>` line, mode 0600 — so the value never reaches a
+shell history or a `ps` listing.
+
+The server refuses to start — before the port is bound, exit status `1` — when:
+
+- the http transport is in use (it is the default) with no token and no
+  `--insecure-no-auth`;
+- `--insecure-no-auth` is combined with either token;
+- a token is shorter than 32 characters, or contains anything but printable
+  non-space ASCII;
+- the read token equals the write token.
+
+Tokens set while running over stdio are ignored, and so is `--insecure-no-auth`
+— there is no network principal to authenticate there.
+
+`--insecure-no-auth` serves the endpoint with no authentication at all: every
+caller reaching the port gets the full write scope. It is a command-line flag
+with no environment variable, so no ambient value can turn authentication off,
+and the server says so loudly at startup.
+
+> **The transport is plaintext HTTP.** A bearer token sent over it is readable
+> by anything on the path, so do not expose the port beyond a trusted network
+> without terminating TLS in front of it (reverse proxy, service mesh, or an
+> SSH tunnel).
+>
+> **A static bearer token is not MCP's OAuth 2.1 authorization flow.** A client
+> that only implements the spec's `401` → resource-metadata → OAuth dance will
+> not authenticate; use one that lets you set a header. And the token
+> authenticates a *deployment*, not a caller: audit records carry no
+> `principal`, which stays [issue #32](https://github.com/plusky/bugwarden/issues/32)'s
+> job.
+
+#### Bugzilla credentials
+
+Each client request carries the Bugzilla API key in an HTTP header (default
+header name: `ApiKey`), so one server can serve multiple users with their own
+keys. This is independent of the bearer gate above: bearer authenticates the
+caller to bugwarden, the API key authenticates bugwarden's request to Bugzilla.
+
+MCP client configuration (exact format varies by client) — both headers are
+required over http, one for each hop:
 
 ```json
 {
@@ -243,12 +326,17 @@ MCP client configuration (exact format varies by client):
     "bugzilla": {
       "url": "http://127.0.0.1:8000/mcp",
       "headers": {
+        "Authorization": "Bearer YOUR_BUGWARDEN_HTTP_TOKEN",
         "ApiKey": "YOUR_BUGZILLA_API_KEY"
       }
     }
   }
 }
 ```
+
+In [server-held key mode](#server-held-key-mode-fleet-deployments) drop the
+`ApiKey` line: the server supplies the Bugzilla key, so `Authorization` is the
+only credential a client holds — which is the point of that mode.
 
 The header name is configurable with `--api-key-header`. For Bugzilla
 instances that reject the `api_key` query parameter and require
@@ -270,6 +358,8 @@ provisioned as a container secret or a systemd credential
 `--api-key-file ${CREDENTIALS_DIRECTORY}/bugzilla-key`):
 
 ```bash
+export BUGWARDEN_HTTP_TOKEN="$(cat /etc/bugwarden/http-token)"
+
 bugwarden \
   --bugzilla-server https://bugzilla.opensuse.org \
   --policy /etc/bugwarden/policy.toml \
@@ -358,21 +448,28 @@ Command-line arguments take precedence over environment variables.
 | `--api-key <KEY>` | `BUGZILLA_API_KEY` | — | Bugzilla API key. **Required** for `--transport stdio` unless `--api-key-file` provides it; with `http` it is ignored with a warning (clients send the key per request — use `--api-key-file` for a server-held key) |
 | `--api-key-file <PATH>` | `BUGZILLA_API_KEY_FILE` | — | Path to a file holding the Bugzilla API key (container secret, systemd `LoadCredential` path). Mutually exclusive with `--api-key`; an empty value counts as unset. Over `http` this selects server-held key mode: every request is served with this key and the per-request header is not consulted |
 | `--use-auth-header` | `BUGZILLA_USE_AUTH_HEADER` | `false` | Authenticate to Bugzilla with `Authorization: Bearer <key>` instead of the `api_key` query parameter. As an environment variable it takes the literal `true` or `false`, exactly like `MCP_READ_ONLY` |
+| `--insecure-no-auth` | — | `false` | Serve the http endpoint with no bearer authentication: every caller reaching the port gets the full write scope. Command line only — no environment variable can turn authentication off. Refuses to start if a token is also set |
+| — | `BUGWARDEN_HTTP_TOKEN` | — | Bearer token granting the **write** scope over http: every tool the policy serves. Environment only (argv is world-readable); at least 32 printable non-space ASCII characters |
+| — | `BUGWARDEN_HTTP_READ_TOKEN` | — | Bearer token granting the **read** scope over http: the read tools only. Same rules, and it must differ from the write token. Either token may be set alone |
 | `--read-only` | `MCP_READ_ONLY` | `false` | Disable all write tools. Tighten-only: ORed with the policy's `global.read_only`; cannot re-enable writes a policy forbids. As an environment variable it takes the literal `true` or `false` — `1`, `yes` and an empty value are a usage error, not a synonym |
 | `--policy <PATH>` | `BUGWARDEN_POLICY` | — | Path to the guard policy TOML. Without it, an allow-all policy applies (with private comments off and the 2 MiB attachment cap still in force) |
 | `--audit-config <PATH>` | `BUGWARDEN_AUDIT_CONFIG` | — | Path to the audit stream configuration TOML (worked example in [`examples/audit.toml`](examples/audit.toml)). Without it, no audit stream is written. Records carry W3C trace ids when the client sends a `traceparent` in the request's `_meta`, enabling correlation with client-side traces |
 | — | `RUST_LOG` | `info` | Tracing filter for the diagnostic log, which always goes to **stderr** — stdout belongs to the stdio transport. An unparsable value falls back to `info` |
 
-An empty value counts as unset for `--api-key`, `--api-key-file` and
-`--allowed-hosts`, so `BUGZILLA_API_KEY_FILE=` in a unit file leaves the two
-key modes unaffected rather than erroring (under stdio it then leaves no key
-source at all, which is a startup error of its own), and `MCP_ALLOWED_HOSTS=`
-names no host, leaving `Host` validation off as if it were never set. An empty
-`BUGWARDEN_POLICY` or `BUGWARDEN_AUDIT_CONFIG` is a usage error.
+An empty value counts as unset for `--api-key`, `--api-key-file`,
+`--allowed-hosts`, `BUGWARDEN_HTTP_TOKEN` and `BUGWARDEN_HTTP_READ_TOKEN`, so
+`BUGZILLA_API_KEY_FILE=` in a unit file leaves the two key modes unaffected
+rather than erroring (under stdio it then leaves no key source at all, which
+is a startup error of its own), `MCP_ALLOWED_HOSTS=` names no host, leaving
+`Host` validation off as if it were never set, and an emptied token variable
+is an unset one — which over http means the deny-by-default refusal, not an
+open port. An empty `BUGWARDEN_POLICY` or `BUGWARDEN_AUDIT_CONFIG` is a usage
+error.
 
-Exit status: `0` on clean shutdown, `1` on a startup or runtime failure (an
-unreadable policy or audit configuration, a key misconfiguration, a Bugzilla
-client or transport error), `2` on a command-line usage error.
+Exit status: `0` on clean shutdown, `1` on a startup or runtime failure (a
+missing or malformed http bearer token, an unreadable policy or audit
+configuration, a key misconfiguration, a Bugzilla client or transport error),
+`2` on a command-line usage error.
 
 ## Policy file reference
 

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -51,6 +51,9 @@ serde_json = "1"
 schemars = { version = "1", features = ["chrono04"] }
 chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.11"
+# Constant-time byte comparison for the HTTP bearer tokens. Already in the
+# lock file through rustls; this makes the dependency the one it is used as.
+subtle = "2.6"
 thiserror = "2"
 toml = "1.1"
 

--- a/crates/bugwarden/completions/_bugwarden
+++ b/crates/bugwarden/completions/_bugwarden
@@ -28,6 +28,7 @@ stdio\:"Stdio transport. The API key comes from \`--api-key\` / \`BUGZILLA_API_K
 '--audit-config=[Path to the audit configuration TOML file (see examples/audit.toml). Environment variable BUGWARDEN_AUDIT_CONFIG can also be used. Without it no audit stream is written]:AUDIT_CONFIG:_files' \
 '--use-auth-header[Use '\''Authorization\: Bearer'\'' header instead of the api_key query parameter (required for some Bugzilla instances). Environment variable BUGZILLA_USE_AUTH_HEADER=true can also be used]' \
 '--read-only[Disables all tools which modify the state of a bug. Environment variable MCP_READ_ONLY=true can also be used. Can only tighten the guard policy, never loosen it]' \
+'--insecure-no-auth[Serve the http transport without bearer authentication. Only for a trusted, isolated network\: every caller that reaches the port gets the full write scope. Command line only, with no environment variable, so no ambient value can turn authentication off. Tokens are never taken from the command line either (argv is world-readable)\: set BUGWARDEN_HTTP_TOKEN / BUGWARDEN_HTTP_READ_TOKEN in the environment]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
 '-V[Print version]' \

--- a/crates/bugwarden/completions/bugwarden.bash
+++ b/crates/bugwarden/completions/bugwarden.bash
@@ -23,7 +23,7 @@ _bugwarden() {
 
     case "${cmd}" in
         bugwarden)
-            opts="-h -V --bugzilla-server --transport --host --port --allowed-hosts --api-key-header --api-key --api-key-file --use-auth-header --read-only --policy --audit-config --help --version"
+            opts="-h -V --bugzilla-server --transport --host --port --allowed-hosts --api-key-header --api-key --api-key-file --use-auth-header --read-only --policy --audit-config --insecure-no-auth --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/bugwarden/completions/bugwarden.fish
+++ b/crates/bugwarden/completions/bugwarden.fish
@@ -11,5 +11,6 @@ complete -c bugwarden -l policy -d 'Path to the guard policy TOML file. Environm
 complete -c bugwarden -l audit-config -d 'Path to the audit configuration TOML file (see examples/audit.toml). Environment variable BUGWARDEN_AUDIT_CONFIG can also be used. Without it no audit stream is written' -r -F
 complete -c bugwarden -l use-auth-header -d 'Use \'Authorization: Bearer\' header instead of the api_key query parameter (required for some Bugzilla instances). Environment variable BUGZILLA_USE_AUTH_HEADER=true can also be used'
 complete -c bugwarden -l read-only -d 'Disables all tools which modify the state of a bug. Environment variable MCP_READ_ONLY=true can also be used. Can only tighten the guard policy, never loosen it'
+complete -c bugwarden -l insecure-no-auth -d 'Serve the http transport without bearer authentication. Only for a trusted, isolated network: every caller that reaches the port gets the full write scope. Command line only, with no environment variable, so no ambient value can turn authentication off. Tokens are never taken from the command line either (argv is world-readable): set BUGWARDEN_HTTP_TOKEN / BUGWARDEN_HTTP_READ_TOKEN in the environment'
 complete -c bugwarden -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c bugwarden -s V -l version -d 'Print version'

--- a/crates/bugwarden/man/bugwarden.1
+++ b/crates/bugwarden/man/bugwarden.1
@@ -17,6 +17,7 @@ bugwarden \- MCP server for Bugzilla with operator\-controlled security guards
 [\fB\-\-read\-only\fR]
 [\fB\-\-policy\fR <POLICY>]
 [\fB\-\-audit\-config\fR <AUDIT_CONFIG>]
+[\fB\-\-insecure\-no\-auth\fR]
 [\fB\-h\fR|\fB\-\-help\fR]
 [\fB\-V\fR|\fB\-\-version\fR]
 .ie \n(.g .ds Aq \(aq
@@ -73,6 +74,9 @@ Path to the guard policy TOML file. Environment variable BUGWARDEN_POLICY can al
 \fB\-\-audit\-config\fR \fI<AUDIT_CONFIG>\fR
 Path to the audit configuration TOML file (see examples/audit.toml). Environment variable BUGWARDEN_AUDIT_CONFIG can also be used. Without it no audit stream is written
 .TP
+\fB\-\-insecure\-no\-auth\fR
+Serve the http transport without bearer authentication. Only for a trusted, isolated network: every caller that reaches the port gets the full write scope. Command line only, with no environment variable, so no ambient value can turn authentication off. Tokens are never taken from the command line either (argv is world\-readable): set BUGWARDEN_HTTP_TOKEN / BUGWARDEN_HTTP_READ_TOKEN in the environment
+.TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)
 .TP
@@ -84,15 +88,18 @@ Print version
 Clean shutdown.
 .TP
 .B 1
-Startup or runtime failure: an unreadable policy or audit configuration, a
-key misconfiguration, a Bugzilla client or transport error.
+Startup or runtime failure: a missing or malformed http bearer token, an
+unreadable policy or audit configuration, a key misconfiguration, a Bugzilla
+client or transport error.
 .TP
 .B 2
 Command\-line usage error.
 .SH ENVIRONMENT
-Each variable is the fallback for one option; a command\-line argument
+Most variables are the fallback for one option; a command\-line argument
 always wins over the environment, and the built\-in default applies when
-neither is given.
+neither is given. The two bearer tokens are the exception: they have no
+option at all and are read from the environment only, because argv is
+world\-readable.
 .TP
 .B BUGZILLA_SERVER
 Fallback for \fB\-\-bugzilla\-server\fR.
@@ -129,6 +136,21 @@ Fallback for \fB\-\-policy\fR.
 .TP
 .B BUGWARDEN_AUDIT_CONFIG
 Fallback for \fB\-\-audit\-config\fR.
+.TP
+.B BUGWARDEN_HTTP_TOKEN
+Bearer token granting the write scope over the http transport: every tool the
+guard policy serves. Environment only \- there is no command\-line flag,
+because argv is world\-readable. At least 32 printable non\-space ASCII
+characters.
+.TP
+.B BUGWARDEN_HTTP_READ_TOKEN
+Bearer token granting the read scope over the http transport: the read tools
+only. Same rules, and it must differ from
+.BR BUGWARDEN_HTTP_TOKEN .
+Either token may be set alone; over http, setting neither is a startup error
+unless
+.B \-\-insecure\-no\-auth
+is given.
 .SH FILES
 .TP
 .I /etc/bugwarden/policy.toml
@@ -163,10 +185,13 @@ bugwarden \-\-transport stdio \e
 .RE
 .PP
 Listen on HTTP (the default transport, 127.0.0.1:8000), each client
-presenting its own key in the API key header:
+presenting a bearer token to this server and its own key in the API key
+header. The token is minted once and kept \- a value generated inline would
+start a server no client could present a credential to:
 .PP
 .RS 4
 .nf
+export BUGWARDEN_HTTP_TOKEN="$(cat /etc/bugwarden/http\-token)"
 bugwarden \-\-bugzilla\-server https://bugzilla.example.com \e
     \-\-policy /etc/bugwarden/policy.toml
 .fi
@@ -174,10 +199,12 @@ bugwarden \-\-bugzilla\-server https://bugzilla.example.com \e
 .PP
 Listen on HTTP with a server\-held key (container secret, systemd
 LoadCredential): every request is served with this key and the per\-request
-key header is not consulted:
+key header is not consulted, so the bearer token is the only thing a client
+presents:
 .PP
 .RS 4
 .nf
+export BUGWARDEN_HTTP_TOKEN="$(cat /etc/bugwarden/http\-token)"
 bugwarden \-\-bugzilla\-server https://bugzilla.example.com \e
     \-\-api\-key\-file /run/secrets/bugzilla\-api\-key \e
     \-\-policy /etc/bugwarden/policy.toml

--- a/crates/bugwarden/src/bin/bugwarden-gen.rs
+++ b/crates/bugwarden/src/bin/bugwarden-gen.rs
@@ -110,13 +110,21 @@ fn render_environment(cmd: &clap::Command, buf: &mut Vec<u8>) -> std::io::Result
     writeln!(buf, ".SH ENVIRONMENT")?;
     writeln!(
         buf,
-        "Each variable is the fallback for one option; a command\\-line argument"
+        "Most variables are the fallback for one option; a command\\-line argument"
     )?;
     writeln!(
         buf,
         "always wins over the environment, and the built\\-in default applies when"
     )?;
-    writeln!(buf, "neither is given.")?;
+    writeln!(
+        buf,
+        "neither is given. The two bearer tokens are the exception: they have no"
+    )?;
+    writeln!(
+        buf,
+        "option at all and are read from the environment only, because argv is"
+    )?;
+    writeln!(buf, "world\\-readable.")?;
     for arg in cmd.get_arguments() {
         let Some(env) = arg.get_env() else { continue };
         let long = arg
@@ -130,8 +138,29 @@ fn render_environment(cmd: &clap::Command, buf: &mut Vec<u8>) -> std::io::Result
             long.replace('-', "\\-")
         )?;
     }
+    // The bearer tokens have no option to be the fallback for — they are
+    // environment-only, because argv is world-readable — so the loop above
+    // cannot see them.
+    buf.write_all(HTTP_TOKEN_ENV.as_bytes())?;
     Ok(())
 }
+
+const HTTP_TOKEN_ENV: &str = r".TP
+.B BUGWARDEN_HTTP_TOKEN
+Bearer token granting the write scope over the http transport: every tool the
+guard policy serves. Environment only \- there is no command\-line flag,
+because argv is world\-readable. At least 32 printable non\-space ASCII
+characters.
+.TP
+.B BUGWARDEN_HTTP_READ_TOKEN
+Bearer token granting the read scope over the http transport: the read tools
+only. Same rules, and it must differ from
+.BR BUGWARDEN_HTTP_TOKEN .
+Either token may be set alone; over http, setting neither is a startup error
+unless
+.B \-\-insecure\-no\-auth
+is given.
+";
 
 const EXIT_STATUS: &str = r".SH EXIT STATUS
 .TP
@@ -139,8 +168,9 @@ const EXIT_STATUS: &str = r".SH EXIT STATUS
 Clean shutdown.
 .TP
 .B 1
-Startup or runtime failure: an unreadable policy or audit configuration, a
-key misconfiguration, a Bugzilla client or transport error.
+Startup or runtime failure: a missing or malformed http bearer token, an
+unreadable policy or audit configuration, a key misconfiguration, a Bugzilla
+client or transport error.
 .TP
 .B 2
 Command\-line usage error.
@@ -168,7 +198,7 @@ or
 no audit stream is written.
 ";
 
-const EXAMPLES: &str = r".SH EXAMPLES
+const EXAMPLES: &str = r#".SH EXAMPLES
 Serve a local MCP client over stdio, the server reading the Bugzilla API
 key from a file:
 .PP
@@ -182,10 +212,13 @@ bugwarden \-\-transport stdio \e
 .RE
 .PP
 Listen on HTTP (the default transport, 127.0.0.1:8000), each client
-presenting its own key in the API key header:
+presenting a bearer token to this server and its own key in the API key
+header. The token is minted once and kept \- a value generated inline would
+start a server no client could present a credential to:
 .PP
 .RS 4
 .nf
+export BUGWARDEN_HTTP_TOKEN="$(cat /etc/bugwarden/http\-token)"
 bugwarden \-\-bugzilla\-server https://bugzilla.example.com \e
     \-\-policy /etc/bugwarden/policy.toml
 .fi
@@ -193,13 +226,15 @@ bugwarden \-\-bugzilla\-server https://bugzilla.example.com \e
 .PP
 Listen on HTTP with a server\-held key (container secret, systemd
 LoadCredential): every request is served with this key and the per\-request
-key header is not consulted:
+key header is not consulted, so the bearer token is the only thing a client
+presents:
 .PP
 .RS 4
 .nf
+export BUGWARDEN_HTTP_TOKEN="$(cat /etc/bugwarden/http\-token)"
 bugwarden \-\-bugzilla\-server https://bugzilla.example.com \e
     \-\-api\-key\-file /run/secrets/bugzilla\-api\-key \e
     \-\-policy /etc/bugwarden/policy.toml
 .fi
 .RE
-";
+"#;

--- a/crates/bugwarden/src/config.rs
+++ b/crates/bugwarden/src/config.rs
@@ -111,6 +111,15 @@ pub struct Cli {
     /// Without it no audit stream is written.
     #[arg(long, env = "BUGWARDEN_AUDIT_CONFIG", value_hint = clap::ValueHint::FilePath)]
     pub audit_config: Option<PathBuf>,
+
+    /// Serve the http transport without bearer authentication. Only for a
+    /// trusted, isolated network: every caller that reaches the port gets the
+    /// full write scope. Command line only, with no environment variable, so
+    /// no ambient value can turn authentication off. Tokens are never taken
+    /// from the command line either (argv is world-readable): set
+    /// BUGWARDEN_HTTP_TOKEN / BUGWARDEN_HTTP_READ_TOKEN in the environment.
+    #[arg(long)]
+    pub insecure_no_auth: bool,
 }
 
 /// Manual impl so the startup key can never reach a log or error through a
@@ -130,6 +139,7 @@ impl std::fmt::Debug for Cli {
             .field("read_only", &self.read_only)
             .field("policy", &self.policy)
             .field("audit_config", &self.audit_config)
+            .field("insecure_no_auth", &self.insecure_no_auth)
             .finish()
     }
 }
@@ -446,16 +456,26 @@ mod tests {
         assert!(msg.contains("--transport stdio requires"), "{msg}");
     }
 
+    /// The one flag that deliberately has no environment fallback. Every
+    /// other knob tightens or is neutral, so an ambient value can only ever
+    /// narrow what is served; `--insecure-no-auth` is the only one that
+    /// LOOSENS — it turns the http bearer gate off — and an environment
+    /// variable able to do that is exactly the loosening default I9 forbids.
+    /// It stays a decision someone typed on the command line.
+    const ENV_LESS_BY_DESIGN: &[&str] = &["insecure_no_auth"];
+
     #[test]
     fn every_flag_declares_an_environment_fallback() {
         // Container deployments configure bugwarden entirely through the
         // environment (issues #31/#32), so a flag without an `env` fallback
-        // is a hole in that contract — this fails the moment one appears.
+        // is a hole in that contract — this fails the moment one appears
+        // that is not the documented exception above.
         let mut cmd = command();
         cmd.build();
         let env_less: Vec<String> = cmd
             .get_arguments()
             .filter(|arg| !matches!(arg.get_id().as_str(), "help" | "version"))
+            .filter(|arg| !ENV_LESS_BY_DESIGN.contains(&arg.get_id().as_str()))
             .filter(|arg| arg.get_env().is_none())
             .map(|arg| arg.get_id().to_string())
             .collect();
@@ -463,6 +483,18 @@ mod tests {
             env_less.is_empty(),
             "every flag needs an environment fallback, these have none: {env_less:?}"
         );
+        // The exception list is not a place to park new flags: every entry
+        // must still name a real, env-less argument.
+        for id in ENV_LESS_BY_DESIGN {
+            let arg = cmd
+                .get_arguments()
+                .find(|arg| arg.get_id().as_str() == *id)
+                .unwrap_or_else(|| panic!("{id} is exempted but does not exist"));
+            assert!(
+                arg.get_env().is_none(),
+                "{id} has an environment fallback and must leave the exception list"
+            );
+        }
         let env_of = |id: &str| {
             cmd.get_arguments()
                 .find(|arg| arg.get_id().as_str() == id)

--- a/crates/bugwarden/src/http_auth.rs
+++ b/crates/bugwarden/src/http_auth.rs
@@ -1,0 +1,833 @@
+//! Who the HTTP caller is, decided before rmcp sees the request (issue #32).
+//!
+//! Key custody (`config.rs`) answers who authenticates to Bugzilla. This
+//! answers the other direction: who is allowed to ask bugwarden anything at
+//! all. It matters only over http. A stdio client already owns the process it
+//! spawned, so the operating system decided the question; an http listener
+//! decides nothing until something here does, and under server-held key
+//! custody "nothing" means handing the deployment's Bugzilla credential to
+//! whoever opened the socket first.
+//!
+//! Two secrets, two answers. One grants the deployment's whole tool surface,
+//! the other only the tools that read. Both arrive as `Authorization: Bearer`,
+//! both are matched without branching on the result, and everything that does
+//! not match gets one response with nothing in it.
+//!
+//! The secrets are taken from the environment and from nowhere else. A
+//! command-line option would publish them through `ps` to every account on the
+//! host, so no option exists — which also means no token can reach a `{:?}` of
+//! [`crate::config::Cli`], because none is stored there. Nothing in this
+//! module derives `Debug` over a secret either (I12).
+//!
+//! The two variable names, the length floor and the refusal shape are chosen
+//! to match the sibling `ruoqa-mcp` deployment so one fleet configuration
+//! serves both. That is a statement about the interface, not about the
+//! implementation below.
+
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::Request;
+use axum::http::header::{HeaderValue, AUTHORIZATION, WWW_AUTHENTICATE};
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::Response;
+use rmcp::service::RequestContext;
+use rmcp::RoleServer;
+use subtle::ConstantTimeEq as _;
+
+use crate::config::Transport;
+
+/// Environment variable carrying the secret that grants the write scope.
+pub const WRITE_TOKEN_VAR: &str = "BUGWARDEN_HTTP_TOKEN";
+
+/// Environment variable carrying the secret that grants the read scope.
+pub const READ_TOKEN_VAR: &str = "BUGWARDEN_HTTP_READ_TOKEN";
+
+/// Fewest characters a usable token may have.
+///
+/// Thirty-two is not a cryptographic threshold; it is the line below which a
+/// value stops looking generated. `openssl rand -hex 32` lands at 64, twice
+/// over, while anything a person typed from memory falls short — and that is
+/// the mistake worth refusing at startup rather than discovering from an
+/// access log.
+const MIN_TOKEN_LEN: usize = 32;
+
+/// The two answers a credential can earn.
+///
+/// Ordered on purpose, least first: [`HttpAuth::scope_for`] takes the maximum
+/// over everything that matched instead of stopping at the first hit.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum Scope {
+    /// Only the tools that read — everything outside
+    /// [`crate::server::WRITE_TOOLS`].
+    Read,
+    /// Whatever this deployment's guard policy still serves after pruning.
+    Write,
+}
+
+/// Which credentials a running listener holds, for the startup log.
+///
+/// Says how the door is locked and never what the key is, so it is safe to
+/// print (I12).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum AuthMode {
+    /// `--insecure-no-auth`: the door is open.
+    Insecure,
+    /// One secret, granting the write scope.
+    Write,
+    /// One secret, granting the read scope.
+    Read,
+    /// Both secrets, and therefore both scopes.
+    WriteAndRead,
+}
+
+impl fmt::Display for AuthMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Insecure => "disabled",
+            Self::Write => "bearer, write scope only",
+            Self::Read => "bearer, read scope only",
+            Self::WriteAndRead => "bearer, write and read scopes",
+        })
+    }
+}
+
+/// What the two variables held when the process started.
+///
+/// A plain struct rather than a direct read of `std::env`, so resolution is a
+/// function of its argument and every test states its own world instead of
+/// mutating the process. No `Debug`: both fields are secret (I12).
+#[derive(Default, Clone)]
+pub struct HttpEnv {
+    /// [`WRITE_TOKEN_VAR`], if it held anything.
+    pub write: Option<String>,
+    /// [`READ_TOKEN_VAR`], if it held anything.
+    pub read: Option<String>,
+}
+
+impl HttpEnv {
+    /// Read both variables out of the process environment.
+    ///
+    /// A variable set to the empty string counts as one that was never set.
+    /// Unit files and container specs clear a variable by emptying it, and
+    /// `--api-key-file` already reads `=` that way; here the convention has
+    /// teeth, because "cleared" must land on the startup refusal rather than
+    /// on an open port.
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self {
+            write: env_token(WRITE_TOKEN_VAR),
+            read: env_token(READ_TOKEN_VAR),
+        }
+    }
+
+    /// Whether the process was started with no token at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.write.is_none() && self.read.is_none()
+    }
+}
+
+/// One environment variable, with the empty string read as absence.
+fn env_token(var: &str) -> Option<String> {
+    match std::env::var(var) {
+        Ok(value) if !value.is_empty() => Some(value),
+        _ => None,
+    }
+}
+
+/// What is wrong with a token the operator configured.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TokenFlaw {
+    /// Under [`MIN_TOKEN_LEN`] characters.
+    TooShort,
+    /// Holds a byte that cannot ride in an `Authorization` header, or a
+    /// space, which usually means a value was pasted with something attached.
+    NotBearerSafe,
+}
+
+/// Why this process must not open an http listener.
+///
+/// Every one of these is fatal and reported before a socket exists. There is
+/// no degraded mode: a deployment that half-configured its credentials is a
+/// deployment whose operator believes it is protected.
+///
+/// The messages name variables, never their contents (I12).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum AuthConfigError {
+    /// No token, and no one said to serve without one.
+    MissingCredential,
+    /// A token and `--insecure-no-auth` together: the operator asked for two
+    /// incompatible things and neither can be assumed to be the real intent.
+    ContradictoryOptOut,
+    /// A configured token could not be used as a bearer credential.
+    UnusableToken {
+        /// The variable it came from.
+        var: &'static str,
+        /// What disqualified it.
+        flaw: TokenFlaw,
+    },
+    /// One string in both variables, which would make the scopes a fiction.
+    IndistinguishableScopes,
+}
+
+impl fmt::Display for AuthConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingCredential => write!(
+                f,
+                "--transport http requires a bearer token: put one in {WRITE_TOKEN_VAR} for \
+                 the write scope or {READ_TOKEN_VAR} for the read scope, or pass \
+                 --insecure-no-auth to serve the endpoint to anyone who reaches it"
+            ),
+            Self::ContradictoryOptOut => write!(
+                f,
+                "--insecure-no-auth conflicts with a configured bearer token \
+                 ({WRITE_TOKEN_VAR} / {READ_TOKEN_VAR}); keep one of the two"
+            ),
+            Self::UnusableToken {
+                var,
+                flaw: TokenFlaw::TooShort,
+            } => write!(
+                f,
+                "{var} holds fewer than {MIN_TOKEN_LEN} characters; generate one with \
+                 `openssl rand -hex 32`"
+            ),
+            Self::UnusableToken {
+                var,
+                flaw: TokenFlaw::NotBearerSafe,
+            } => write!(
+                f,
+                "{var} holds a character a bearer credential cannot carry; use printable \
+                 ASCII, and no spaces"
+            ),
+            Self::IndistinguishableScopes => write!(
+                f,
+                "{WRITE_TOKEN_VAR} and {READ_TOKEN_VAR} hold identical values, which would \
+                 make the two scopes indistinguishable"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AuthConfigError {}
+
+/// A secret that passed startup validation.
+///
+/// Wrapping the `String` is what keeps the two operations that may touch a
+/// token — checking it at startup, matching it per request — in one place, so
+/// neither can be done some other way somewhere else. No `Debug`, no
+/// accessor: nothing can read the bytes back out.
+struct Token(String);
+
+impl Token {
+    /// Accept `raw` as a usable bearer credential, or say why not.
+    ///
+    /// Two things disqualify it. A byte outside printable ASCII cannot be put
+    /// in a header at all, and a space would split the credential from its
+    /// scheme on the wire — both are almost always a paste that picked up a
+    /// newline or a quote. Length comes second, because "it is not a token"
+    /// is a better diagnosis than "it is a short token".
+    fn parse(var: &'static str, raw: &str) -> Result<Self, AuthConfigError> {
+        let flawed = |flaw| AuthConfigError::UnusableToken { var, flaw };
+        if !raw.bytes().all(|byte| byte.is_ascii_graphic()) {
+            return Err(flawed(TokenFlaw::NotBearerSafe));
+        }
+        if raw.len() < MIN_TOKEN_LEN {
+            return Err(flawed(TokenFlaw::TooShort));
+        }
+        Ok(Self(raw.to_owned()))
+    }
+
+    /// Whether `candidate` is this token, compared in constant time.
+    ///
+    /// `subtle` and not `==`: the two agree on every answer and disagree on
+    /// how long they take to give it, and the second is what a caller
+    /// guessing a token measures.
+    fn verifies(&self, candidate: &str) -> bool {
+        self.0.as_bytes().ct_eq(candidate.as_bytes()).into()
+    }
+
+    /// Whether two configured tokens are the same string. Not constant time,
+    /// and it does not need to be: both operands are the operator's own, this
+    /// runs once at startup, and no caller is watching.
+    fn is(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+/// The credentials a listener checks against, and the counter for the ones it
+/// turns away.
+///
+/// No `Debug` impl: it holds secrets, the same reason
+/// [`crate::config::KeyCustody`] has none.
+pub struct HttpAuth {
+    write: Option<Token>,
+    read: Option<Token>,
+    mode: AuthMode,
+    refusals: AtomicU64,
+}
+
+impl HttpAuth {
+    /// Decide what this listener will accept, or refuse to have one.
+    ///
+    /// Validation of each token comes first, so an operator who mistyped one
+    /// is told which variable is at fault rather than being told the pair is
+    /// unusable. What survives that is then read as an intent: two tokens,
+    /// one token, or an explicit request to serve without any.
+    ///
+    /// # Errors
+    ///
+    /// [`AuthConfigError`], every variant of which is fatal.
+    pub fn resolve(env: &HttpEnv, insecure: bool) -> Result<Self, AuthConfigError> {
+        let write = env
+            .write
+            .as_deref()
+            .map(|raw| Token::parse(WRITE_TOKEN_VAR, raw))
+            .transpose()?;
+        let read = env
+            .read
+            .as_deref()
+            .map(|raw| Token::parse(READ_TOKEN_VAR, raw))
+            .transpose()?;
+        if let (Some(write), Some(read)) = (&write, &read) {
+            if write.is(read) {
+                return Err(AuthConfigError::IndistinguishableScopes);
+            }
+        }
+        let mode = match (insecure, write.is_some(), read.is_some()) {
+            (true, false, false) => AuthMode::Insecure,
+            (true, _, _) => return Err(AuthConfigError::ContradictoryOptOut),
+            (false, false, false) => return Err(AuthConfigError::MissingCredential),
+            (false, true, true) => AuthMode::WriteAndRead,
+            (false, true, false) => AuthMode::Write,
+            (false, false, true) => AuthMode::Read,
+        };
+        Ok(Self {
+            write,
+            read,
+            mode,
+            refusals: AtomicU64::new(0),
+        })
+    }
+
+    /// What this listener accepts.
+    #[must_use]
+    pub fn mode(&self) -> AuthMode {
+        self.mode
+    }
+
+    /// Whether this listener checks nothing.
+    #[must_use]
+    pub fn is_insecure(&self) -> bool {
+        self.mode == AuthMode::Insecure
+    }
+
+    /// Announce the mode at startup — the mode, and not one byte of a token
+    /// (I12).
+    ///
+    /// An unauthenticated listener is a `warn!`, because a server with no
+    /// door in front of a Bugzilla credential is not a routine arrangement
+    /// and the operator should see it scroll past.
+    pub fn log_startup_mode(&self) {
+        match self.mode {
+            AuthMode::Insecure => tracing::warn!(
+                "--insecure-no-auth: the http endpoint is served WITHOUT authentication; \
+                 every caller that can reach the port gets the full write scope"
+            ),
+            mode => tracing::info!("http authentication: {mode}"),
+        }
+    }
+
+    /// Each configured credential and the scope it grants.
+    fn credentials(&self) -> impl Iterator<Item = (Scope, &Token)> {
+        [
+            (Scope::Write, self.write.as_ref()),
+            (Scope::Read, self.read.as_ref()),
+        ]
+        .into_iter()
+        .filter_map(|(scope, token)| token.map(|token| (scope, token)))
+    }
+
+    /// What an `Authorization` header value earns, if anything.
+    ///
+    /// `None` covers every way of not being authorized — absent, wrong
+    /// scheme, malformed, or simply a value nobody configured — because the
+    /// caller learns the same thing from all of them.
+    #[must_use]
+    pub fn scope_for(&self, header: Option<&str>) -> Option<Scope> {
+        let candidate = header.and_then(bearer_credential)?;
+        // Folded over every credential rather than returned from the first
+        // hit, and the maximum wins. Leaving early would let a caller time
+        // the reply to learn WHICH of the two secrets a guess collided with,
+        // which is a large step from knowing that it did not.
+        self.credentials()
+            .filter(|(_, token)| token.verifies(candidate))
+            .fold(None, |best, (scope, _)| best.max(Some(scope)))
+    }
+
+    /// Count a refusal, and say so on the first and then at every doubling.
+    ///
+    /// The refusal happens above `call_tool`, where audit records are
+    /// written, so no record can carry it (#32, constraint 5). A log line
+    /// is what is left — and it has to stay cheap, because the people
+    /// triggering it are by definition not authorized to make this process do
+    /// work. Doubling bounds the output at the logarithm of the attempts. The
+    /// line carries a count and nothing else: no token, no header, no path,
+    /// no peer, so it answers no question a stranger might be asking.
+    fn note_refusal(&self) {
+        let total = self.refusals.fetch_add(1, Ordering::Relaxed) + 1;
+        if total.is_power_of_two() {
+            tracing::warn!(
+                refused = total,
+                "http bearer authentication refused a request"
+            );
+        }
+    }
+}
+
+/// The credential out of an `Authorization` value, if it is a bearer one.
+///
+/// The scheme is matched case-insensitively (RFC 9110 says schemes are), the
+/// credential is not. Exactly two whitespace-separated pieces are accepted: a
+/// value with more is not a bearer credential with a suffix, it is something
+/// this server does not understand, and guessing at it is how a parser starts
+/// disagreeing with the proxy in front of it.
+fn bearer_credential(header: &str) -> Option<&str> {
+    let mut pieces = header.split_ascii_whitespace();
+    let scheme = pieces.next()?;
+    let credential = pieces.next()?;
+    match (scheme.eq_ignore_ascii_case("bearer"), pieces.next()) {
+        (true, None) => Some(credential),
+        _ => None,
+    }
+}
+
+/// The gate for `transport`, or `None` where there is nothing to gate.
+///
+/// stdio gets `None` and gets it unconditionally: the client launched this
+/// process, no port is open, and there is no second party for a token to
+/// distinguish. A token sitting in the environment of a stdio run is
+/// therefore ignored outright rather than validated — an unusable value is
+/// not an error for a transport that would not have used a usable one either.
+/// `--insecure-no-auth` is inert there for the same reason.
+///
+/// # Errors
+///
+/// [`AuthConfigError`], for the http transport only.
+pub fn resolve_for(
+    transport: Transport,
+    env: &HttpEnv,
+    insecure: bool,
+) -> Result<Option<HttpAuth>, AuthConfigError> {
+    match transport {
+        Transport::Http => HttpAuth::resolve(env, insecure).map(Some),
+        Transport::Stdio => {
+            if !env.is_empty() || insecure {
+                tracing::debug!(
+                    "http bearer settings are configured but the transport is stdio; ignoring"
+                );
+            }
+            Ok(None)
+        }
+    }
+}
+
+/// Put `auth` in front of `router`.
+///
+/// The one place a guarded router is built, so `main` and every test that
+/// serves one are looking at the same wiring; a test cannot pass against a
+/// gate the deployment does not have.
+///
+/// It wraps the router rather than the `/mcp` route, and that is the point:
+/// an unauthenticated request to a path this server does not serve is refused
+/// exactly like one to a path it does, so probing recovers no map of the
+/// surface (I2).
+pub fn guard_router(router: axum::Router, auth: Arc<HttpAuth>) -> axum::Router {
+    router.layer(axum::middleware::from_fn(move |request, next| {
+        gate(Arc::clone(&auth), request, next)
+    }))
+}
+
+/// Let an authorized request through carrying its scope; turn the rest away.
+async fn gate(auth: Arc<HttpAuth>, mut request: Request, next: Next) -> Response {
+    if auth.is_insecure() {
+        return next.run(request).await;
+    }
+    match auth.scope_for(sole_authorization(&request)) {
+        Some(scope) => {
+            request.extensions_mut().insert(scope);
+            next.run(request).await
+        }
+        None => {
+            auth.note_refusal();
+            unauthorized()
+        }
+    }
+}
+
+/// The request's `Authorization` value, when it has exactly one.
+///
+/// Two of them is not a request with a spare credential, it is a malformed
+/// one (RFC 9110), and resolving it either way is worse than refusing: a
+/// proxy on the path that forwards the last value while this read the first
+/// would authorize a token the operator never saw. Absent and duplicated both
+/// come back `None`, and both end at the same refusal.
+fn sole_authorization(request: &Request) -> Option<&str> {
+    let mut values = request.headers().get_all(AUTHORIZATION).iter();
+    match (values.next(), values.next()) {
+        (Some(only), None) => only.to_str().ok(),
+        _ => None,
+    }
+}
+
+/// The refusal: `401`, `WWW-Authenticate: Bearer`, nothing else.
+///
+/// One response for every way of failing, down to the byte. A caller who
+/// cannot get in is told that and only that — not whether the header was
+/// missing or wrong, and not whether the path they tried exists (I2).
+fn unauthorized() -> Response {
+    let mut response = Response::new(Body::empty());
+    *response.status_mut() = StatusCode::UNAUTHORIZED;
+    response
+        .headers_mut()
+        .insert(WWW_AUTHENTICATE, HeaderValue::from_static("Bearer"));
+    response
+}
+
+/// The scope [`gate`] attached to this request, as the MCP handler sees it.
+///
+/// `None` means no scope was attached, which happens over stdio, under
+/// `--insecure-no-auth`, and — were the listener ever built without the gate
+/// — on a request that skipped it. The caller decides what absence means;
+/// `BugWarden` treats it as "reaches nothing".
+#[must_use]
+pub fn scope_of(context: &RequestContext<RoleServer>) -> Option<Scope> {
+    let parts = context.extensions.get::<Parts>()?;
+    parts.extensions.get::<Scope>().copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WRITE: &str = "0123456789abcdef0123456789abcdef";
+    const READ: &str = "fedcba9876543210fedcba9876543210";
+
+    fn env(write: Option<&str>, read: Option<&str>) -> HttpEnv {
+        HttpEnv {
+            write: write.map(ToOwned::to_owned),
+            read: read.map(ToOwned::to_owned),
+        }
+    }
+
+    fn unusable(var: &'static str, flaw: TokenFlaw) -> Option<AuthConfigError> {
+        Some(AuthConfigError::UnusableToken { var, flaw })
+    }
+
+    #[test]
+    fn http_without_any_token_refuses_to_start() {
+        assert_eq!(
+            HttpAuth::resolve(&HttpEnv::default(), false).err(),
+            Some(AuthConfigError::MissingCredential)
+        );
+    }
+
+    #[test]
+    fn insecure_with_a_token_refuses_to_start() {
+        for e in [env(Some(WRITE), None), env(None, Some(READ))] {
+            assert_eq!(
+                HttpAuth::resolve(&e, true).err(),
+                Some(AuthConfigError::ContradictoryOptOut)
+            );
+        }
+    }
+
+    #[test]
+    fn insecure_without_a_token_starts_with_authentication_off() {
+        let auth = HttpAuth::resolve(&HttpEnv::default(), true).expect("resolve");
+        assert!(auth.is_insecure());
+        assert_eq!(auth.mode(), AuthMode::Insecure);
+        assert_eq!(auth.scope_for(None), None);
+    }
+
+    #[test]
+    fn short_or_unprintable_tokens_refuse_to_start() {
+        // 31 characters: one under the floor, so the boundary itself is
+        // pinned rather than some obviously tiny value.
+        let just_short = &WRITE[..MIN_TOKEN_LEN - 1];
+        assert_eq!(
+            HttpAuth::resolve(&env(Some(just_short), None), false).err(),
+            unusable(WRITE_TOKEN_VAR, TokenFlaw::TooShort)
+        );
+        assert!(HttpAuth::resolve(&env(Some(WRITE), None), false).is_ok());
+        // The read variable is validated on its own terms, and named.
+        assert_eq!(
+            HttpAuth::resolve(&env(None, Some(just_short)), false).err(),
+            unusable(READ_TOKEN_VAR, TokenFlaw::TooShort)
+        );
+        for bad in [
+            "0123456789abcdef 0123456789abcdef",
+            "0123456789abcdef\t0123456789abcdef",
+            "0123456789abcdef\n0123456789abcdef",
+            "0123456789abcdef\u{e9}123456789abcdef",
+        ] {
+            assert_eq!(
+                HttpAuth::resolve(&env(Some(bad), None), false).err(),
+                unusable(WRITE_TOKEN_VAR, TokenFlaw::NotBearerSafe),
+                "{bad:?} must be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn identical_tokens_refuse_to_start() {
+        assert_eq!(
+            HttpAuth::resolve(&env(Some(WRITE), Some(WRITE)), false).err(),
+            Some(AuthConfigError::IndistinguishableScopes)
+        );
+    }
+
+    #[test]
+    fn either_token_may_be_set_alone() {
+        assert_eq!(
+            HttpAuth::resolve(&env(Some(WRITE), None), false)
+                .expect("write alone")
+                .mode(),
+            AuthMode::Write
+        );
+        assert_eq!(
+            HttpAuth::resolve(&env(None, Some(READ)), false)
+                .expect("read alone")
+                .mode(),
+            AuthMode::Read
+        );
+        assert_eq!(
+            HttpAuth::resolve(&env(Some(WRITE), Some(READ)), false)
+                .expect("both")
+                .mode(),
+            AuthMode::WriteAndRead
+        );
+    }
+
+    #[test]
+    fn each_token_grants_exactly_its_own_scope() {
+        let auth = HttpAuth::resolve(&env(Some(WRITE), Some(READ)), false).expect("resolve");
+        assert_eq!(
+            auth.scope_for(Some(&format!("Bearer {WRITE}"))),
+            Some(Scope::Write)
+        );
+        assert_eq!(
+            auth.scope_for(Some(&format!("Bearer {READ}"))),
+            Some(Scope::Read)
+        );
+        // The scheme is case-insensitive (RFC 9110), the credential is not.
+        assert_eq!(
+            auth.scope_for(Some(&format!("bEaReR {WRITE}"))),
+            Some(Scope::Write)
+        );
+        assert_eq!(
+            auth.scope_for(Some(&format!("Bearer {}", WRITE.to_uppercase()))),
+            None
+        );
+    }
+
+    #[test]
+    fn a_read_token_alone_never_grants_write() {
+        let auth = HttpAuth::resolve(&env(None, Some(READ)), false).expect("resolve");
+        assert_eq!(
+            auth.scope_for(Some(&format!("Bearer {READ}"))),
+            Some(Scope::Read)
+        );
+        // An unconfigured slot must not match by being empty on both sides.
+        assert_eq!(auth.scope_for(Some(&format!("Bearer {WRITE}"))), None);
+        assert_eq!(auth.scope_for(Some("Bearer ")), None);
+    }
+
+    #[test]
+    fn missing_or_malformed_headers_grant_nothing() {
+        let auth = HttpAuth::resolve(&env(Some(WRITE), Some(READ)), false).expect("resolve");
+        for header in [
+            None,
+            Some(""),
+            Some("Bearer"),
+            Some("Bearer "),
+            Some(WRITE),
+            Some("Basic dXNlcjpwYXNz"),
+            // A prefix of the real credential, and the real one with a
+            // character added: neither is the credential.
+            Some("Bearer 0123456789abcdef0123456789abcde"),
+            Some("Bearer 0123456789abcdef0123456789abcdef0"),
+            // A valid credential with something after it is not a bearer
+            // credential this server understands.
+            Some("Bearer 0123456789abcdef0123456789abcdef extra"),
+        ] {
+            assert_eq!(
+                auth.scope_for(header),
+                None,
+                "{header:?} must not authorize"
+            );
+        }
+    }
+
+    /// The body of the named function, from its signature to its closing
+    /// brace, with comment lines dropped — the prose around these two
+    /// functions describes the very keywords the checks below look for.
+    fn body_of(src: &'static str, signature: &str) -> String {
+        let tail = src
+            .split(signature)
+            .nth(1)
+            .unwrap_or_else(|| panic!("{signature} must exist"));
+        let end = tail.find("\n    }").unwrap_or(0);
+        tail[..end]
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn token_comparison_is_constant_time_and_unconditional() {
+        // Two properties no behavioural test can reach, because each mutant
+        // returns exactly the same answers and differs only in how long it
+        // takes to return them. The source is the only place to pin them.
+        let src = include_str!("http_auth.rs");
+
+        // 1. The comparison goes through `subtle`. A `==` here is a timing
+        //    oracle on the token.
+        let verifies = body_of(src, "fn verifies(&self, candidate: &str) -> bool {");
+        assert!(
+            verifies.contains("ct_eq"),
+            "the comparison must use ct_eq: {verifies}"
+        );
+        assert!(
+            !verifies.contains("=="),
+            "the comparison must not use ==: {verifies}"
+        );
+
+        // 2. Every configured credential is compared, whatever the earlier
+        //    ones said. Stopping at a hit would let a caller time the reply
+        //    to learn which of the two secrets a guess collided with.
+        let scope_for = body_of(src, "pub fn scope_for(&self, header: Option<&str>)");
+        assert!(
+            scope_for.contains("let candidate"),
+            "scope_for must extract a credential first: {scope_for}"
+        );
+        // Everything after that extraction. The extraction line itself ends
+        // in `?`, an early exit — but it happens before any comparison, so it
+        // reveals nothing about a token.
+        let after_extraction = scope_for
+            .lines()
+            .skip_while(|line| !line.contains("let candidate"))
+            .skip(1)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            after_extraction.contains(".fold("),
+            "scope_for must fold over every credential: {after_extraction}"
+        );
+        assert_eq!(
+            after_extraction.matches("verifies(").count(),
+            1,
+            "one comparison site, applied to every credential: {after_extraction}"
+        );
+        for early_exit in ["return", "break", "if ", "else", "?"] {
+            assert!(
+                !after_extraction.contains(early_exit),
+                "no {early_exit:?} may cut the comparison short: {after_extraction}"
+            );
+        }
+    }
+
+    #[test]
+    fn stdio_ignores_tokens_and_the_insecure_flag() {
+        // Every http startup refusal, offered to a stdio run: all accepted,
+        // and none of them yields a gate. A mutation that resolved the gate
+        // regardless of transport fails on the first of these.
+        for (e, insecure) in [
+            (HttpEnv::default(), false),
+            (env(Some("short"), None), false),
+            (env(Some(WRITE), Some(WRITE)), false),
+            (env(Some(WRITE), None), true),
+            (env(Some("not printable at all"), None), false),
+        ] {
+            let gate = resolve_for(Transport::Stdio, &e, insecure).expect("stdio never refuses");
+            assert!(gate.is_none(), "stdio must resolve no bearer gate");
+        }
+        // The same environment over http is the refusal it should be.
+        assert!(resolve_for(Transport::Http, &HttpEnv::default(), false).is_err());
+    }
+
+    #[test]
+    fn refusal_logging_is_bounded_and_names_no_material() {
+        let auth = HttpAuth::resolve(&env(Some(WRITE), None), false).expect("resolve");
+        let ((), logs) = crate::testlog::capture_logs(|| {
+            for _ in 0..5 {
+                auth.note_refusal();
+            }
+        });
+        // Five refusals, three lines: 1, 2, 4. A mutation that logged every
+        // refusal — an unauthenticated log-volume lever — fails here.
+        assert_eq!(
+            logs.matches("http bearer authentication refused a request")
+                .count(),
+            3,
+            "{logs}"
+        );
+        assert!(logs.contains("refused=4"), "{logs}");
+        assert!(
+            !logs.contains(WRITE),
+            "the log must carry no token (I12): {logs}"
+        );
+    }
+
+    #[test]
+    fn the_startup_mode_line_never_carries_token_material() {
+        for (e, insecure) in [
+            (env(Some(WRITE), Some(READ)), false),
+            (env(Some(WRITE), None), false),
+            (env(None, Some(READ)), false),
+            (HttpEnv::default(), true),
+        ] {
+            let auth = HttpAuth::resolve(&e, insecure).expect("resolve");
+            let ((), logs) = crate::testlog::capture_logs(|| auth.log_startup_mode());
+            // Positive first, so the I12 negative below is evidence and not
+            // just an empty capture passing.
+            assert!(
+                logs.contains("http authentication:") || logs.contains("--insecure-no-auth"),
+                "{logs}"
+            );
+            assert!(!logs.contains(WRITE), "{logs}");
+            assert!(!logs.contains(READ), "{logs}");
+        }
+    }
+
+    #[test]
+    fn config_errors_name_the_variable_and_never_the_token() {
+        let secret = "SUPERSECRETTOKENSUPERSECRETTOKEN";
+        for e in [
+            AuthConfigError::UnusableToken {
+                var: WRITE_TOKEN_VAR,
+                flaw: TokenFlaw::TooShort,
+            },
+            AuthConfigError::UnusableToken {
+                var: READ_TOKEN_VAR,
+                flaw: TokenFlaw::NotBearerSafe,
+            },
+            AuthConfigError::MissingCredential,
+            AuthConfigError::ContradictoryOptOut,
+            AuthConfigError::IndistinguishableScopes,
+        ] {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("BUGWARDEN_HTTP_"),
+                "the message must name a variable: {msg}"
+            );
+            assert!(!msg.contains(secret), "{msg}");
+        }
+    }
+}

--- a/crates/bugwarden/src/lib.rs
+++ b/crates/bugwarden/src/lib.rs
@@ -11,6 +11,8 @@
 /// Operator-facing audit event stream: record schema and JSONL file sink.
 pub mod audit;
 pub mod config;
+/// Bearer authentication for the streamable-HTTP transport.
+pub mod http_auth;
 pub mod server;
 
 #[cfg(test)]

--- a/crates/bugwarden/src/main.rs
+++ b/crates/bugwarden/src/main.rs
@@ -11,6 +11,7 @@ use anyhow::Context;
 use bugwarden::audit::{
     policy_hash_of, AuditConfig, AuditSink, AuditState, FailMode, TransportKind,
 };
+use bugwarden::http_auth::{self, HttpEnv};
 use bugwarden::{config, server};
 use bugwarden_core::{guard::Guard, policy::Policy};
 use clap::Parser;
@@ -37,6 +38,20 @@ async fn main() -> anyhow::Result<()> {
         .with_writer(std::io::stderr)
         .with_ansi(false)
         .init();
+
+    // The http bearer gate, resolved before anything else runs: over http
+    // the port is the access boundary, and a half-configured credential must
+    // never degrade into open access. Ahead of the policy load, the Bugzilla
+    // client, the identity preflight and the audit sink alike, so a token
+    // misconfiguration aborts startup without binding a port, opening a
+    // socket to Bugzilla, or creating or rotating an audit file. `None` for
+    // stdio, where the client owns the process and the tokens are ignored.
+    let http_auth =
+        http_auth::resolve_for(cli.transport, &HttpEnv::from_env(), cli.insecure_no_auth)
+            .map(|auth| auth.map(Arc::new))?;
+    if let Some(auth) = &http_auth {
+        auth.log_startup_mode();
+    }
 
     // Guard policy comes ONLY from the TOML file given at startup (I1);
     // without one the built-in default policy applies.
@@ -111,6 +126,11 @@ async fn main() -> anyhow::Result<()> {
         Some(audit) => server.with_audit(audit),
         None => server,
     };
+    // Per-request scopes exist only where a per-request credential does:
+    // authenticated http. stdio issues none, and --insecure-no-auth issues
+    // none by definition.
+    let server =
+        server.with_scope_enforcement(http_auth.as_ref().is_some_and(|auth| !auth.is_insecure()));
 
     match cfg.transport {
         Transport::Stdio => {
@@ -134,7 +154,14 @@ async fn main() -> anyhow::Result<()> {
                 LocalSessionManager::default().into(),
                 config,
             );
-            let router = axum::Router::new().nest_service("/mcp", service);
+            // `resolve_for` returns the gate for every http start, so the
+            // bail below is unreachable — it exists so a future refactor
+            // that lost the gate fails to serve rather than serving open.
+            let Some(auth) = http_auth else {
+                anyhow::bail!("internal error: the http transport has no resolved bearer gate");
+            };
+            let router =
+                http_auth::guard_router(axum::Router::new().nest_service("/mcp", service), auth);
             let addr = format!("{}:{}", cfg.host, cfg.port);
             tracing::info!("Starting Bugzilla MCP server on {addr}");
             let tcp_listener = tokio::net::TcpListener::bind(&addr)

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -28,6 +28,7 @@ use serde_json::{json, Value};
 
 use crate::audit::{self, AuditCell, AuditState, FailMode, TransportKind, Verdict};
 use crate::config::{Cli, KeyCustody, Transport};
+use crate::http_auth::{self, Scope};
 
 /// The MCP revisions this build actually implements, newest last.
 ///
@@ -432,6 +433,36 @@ fn handshake_required() -> McpError {
         "this server requires the initialize handshake; per-request protocol negotiation is not served",
         None,
     )
+}
+
+/// How much of the tool surface one request's bearer credential reaches.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Reach {
+    /// Every routed tool: scope enforcement is off, or the write scope.
+    Everything,
+    /// The read tools only — the complement of [`WRITE_TOOLS`], which is the
+    /// same set read-only mode removes from the router (I13), so the bearer
+    /// split cannot drift from the policy one.
+    ReadOnly,
+    /// Nothing at all. Only reachable when scopes are enforced and a request
+    /// still carries none, i.e. the gate did not run.
+    Nothing,
+}
+
+/// Whether a read-scope credential reaches `tool`.
+fn read_scope_serves(tool: &str) -> bool {
+    !WRITE_TOOLS.contains(&tool)
+}
+
+/// The refusal for a tool this request's credential does not reach.
+///
+/// Byte-identical to what `ToolRouter` answers for a name it does not route
+/// (rmcp 3.1 `handler/server/router/tool.rs`), so a scope-hidden tool is
+/// indistinguishable from one that does not exist — the same
+/// indistinguishability read-only mode already gives every caller (I13), and
+/// no oracle about which tools the deployment serves (I2).
+fn tool_not_found() -> McpError {
+    McpError::invalid_params("tool not found", None)
 }
 
 /// Total elapsed milliseconds since `started`, saturating.
@@ -1220,6 +1251,10 @@ pub struct BugWarden {
     key_custody: KeyCustody,
     /// Audit wiring; `None` runs the exact pre-audit request path.
     audit: Option<Arc<AuditState>>,
+    /// Whether every request must carry a bearer [`Scope`]. On for
+    /// authenticated http only: stdio has no per-request credential, and
+    /// `--insecure-no-auth` issues none.
+    enforce_scopes: bool,
 }
 
 impl BugWarden {
@@ -1312,6 +1347,7 @@ impl BugWarden {
             tool_router,
             key_custody,
             audit: None,
+            enforce_scopes: false,
         })
     }
 
@@ -1320,6 +1356,20 @@ impl BugWarden {
     /// with auditing off.
     pub fn with_audit(mut self, audit: Arc<AuditState>) -> Self {
         self.audit = Some(audit);
+        self
+    }
+
+    /// Require every request to carry a bearer [`Scope`], and serve a
+    /// read-scope caller the read tools only.
+    ///
+    /// Separate from [`BugWarden::new`] for the same reason
+    /// [`BugWarden::with_audit`] is: whether a request carries a credential
+    /// is a property of the transport it arrives on, not of the policy the
+    /// server enforces. `main` turns it on for an authenticated http
+    /// listener and leaves it off for stdio and for `--insecure-no-auth`.
+    #[must_use]
+    pub fn with_scope_enforcement(mut self, enforce: bool) -> Self {
+        self.enforce_scopes = enforce;
         self
     }
 
@@ -1343,10 +1393,13 @@ impl BugWarden {
     ///   operator bound and named, so that default would refuse every
     ///   deployment not addressed as `localhost`, containers included.
     ///   Disabled deliberately when the operator names no host: the access
-    ///   control here is the network boundary, and per-caller
-    ///   authentication when it lands (issue #32). `--allowed-hosts` /
-    ///   `MCP_ALLOWED_HOSTS` names the authorities this deployment answers
-    ///   to, which only ever narrows what the disabled state serves (I9).
+    ///   control is the bearer gate in front of this service
+    ///   ([`crate::http_auth`]): a rebound browser reaches it with no
+    ///   token and is turned away there, whatever `Host` it sent. That
+    ///   argument lapses under `--insecure-no-auth`, which admits every
+    ///   caller — there `--allowed-hosts` / `MCP_ALLOWED_HOSTS` is how the
+    ///   operator puts the `Host` check back. Naming an authority only
+    ///   ever narrows what the disabled state serves (I9).
     /// * `max_request_body_bytes` is a POST cap with no rmcp 2.2
     ///   equivalent, worth keeping as a memory bound — but it also ceilings
     ///   `add_attachment`, so a fixed value silently overrides the
@@ -1364,7 +1417,8 @@ impl BugWarden {
     /// A body over that cap is refused by rmcp's tower layer with a bare
     /// `413`, which reaches neither `call_tool` nor the guard — so it
     /// leaves NO audit record and names neither the tool nor the caller,
-    /// the same unrecordability as a pre-handler auth refusal (issue #32).
+    /// the same unrecordability as a bearer refusal, which is turned away
+    /// by the layer in front of this service ([`crate::http_auth`]).
     /// An operator diagnosing a 413 therefore has to compare the request
     /// body's size with the cap derived here from
     /// `global.max_attachment_bytes`, since nothing on the server side will
@@ -1521,6 +1575,44 @@ impl BugWarden {
                     )),
                 }
             }
+        }
+    }
+
+    /// What this request's bearer credential reaches.
+    ///
+    /// Fails closed on a missing scope: the gate wraps the whole router, so
+    /// a served request always carries one, and its absence means the
+    /// listener was not wired the way this server was configured. Logged
+    /// once per process rather than per request — the branch is unreachable
+    /// through `main`, and a per-request line would be a log-volume lever if
+    /// it ever became reachable.
+    fn reach(&self, ctx: &RequestContext<RoleServer>) -> Reach {
+        if !self.enforce_scopes {
+            return Reach::Everything;
+        }
+        match http_auth::scope_of(ctx) {
+            Some(Scope::Write) => Reach::Everything,
+            Some(Scope::Read) => Reach::ReadOnly,
+            None => {
+                static WARNED: std::sync::Once = std::sync::Once::new();
+                WARNED.call_once(|| {
+                    tracing::error!(
+                        "a request reached the handler with no bearer scope while scope \
+                         enforcement is on; serving nothing. The http listener is not \
+                         wired through the authentication layer"
+                    );
+                });
+                Reach::Nothing
+            }
+        }
+    }
+
+    /// Whether this request's credential reaches `tool` at all.
+    fn reaches(&self, tool: &str, ctx: &RequestContext<RoleServer>) -> bool {
+        match self.reach(ctx) {
+            Reach::Everything => true,
+            Reach::ReadOnly => read_scope_serves(tool),
+            Reach::Nothing => false,
         }
     }
 
@@ -3255,8 +3347,17 @@ impl ServerHandler for BugWarden {
             }
             return Err(handshake_required());
         }
+        // Bearer scope gate (issue #32): a tool this credential does not
+        // reach is refused as unrouted, so the read scope hides the write
+        // tools exactly the way read-only mode hides them (I13). Decided
+        // here, before dispatch and before any upstream request.
+        let reachable = self.reaches(&request.name, &context);
+
         // Auditing off: byte-identical to the macro-generated dispatch.
         let Some(audit) = self.audit.clone() else {
+            if !reachable {
+                return Err(tool_not_found());
+            }
             return self
                 .tool_router
                 .call(ToolCallContext::new(self, request, context))
@@ -3297,7 +3398,20 @@ impl ServerHandler for BugWarden {
         // the gate exists to stop unaudited work, not to retry its way
         // open. The refusal depends on the tool name alone, never on
         // anything the guard decided (the guard never ran).
-        if audit.sink.failing() && gate_applies(audit.fail_mode, &tool) {
+        // Both guards keep the gate off names the router would not have
+        // dispatched anyway. Without them the gate answers a name with its
+        // own text where a healthy sink answers "tool not found", so sink
+        // health — and, through it, whether the deployment serves a tool at
+        // all — is readable off which refusal comes back: `reachable` covers
+        // a write tool the caller's scope hides, `has_route` an unknown name
+        // and a tool this policy removed (read-only, disabled_tools,
+        // allow_discovery). A name the gate never sees is refused as
+        // unrouted below, identically under every fail mode.
+        if reachable
+            && self.tool_router.has_route(&tool)
+            && audit.sink.failing()
+            && gate_applies(audit.fail_mode, &tool)
+        {
             let event = audit::AuditEventKind::ToolCall(Box::new(audit::ToolCallEvent {
                 client,
                 trace: trace.clone(),
@@ -3328,10 +3442,16 @@ impl ServerHandler for BugWarden {
 
         let cell = Arc::new(AuditCell::default());
         context.extensions.insert(Arc::clone(&cell));
-        let result = self
-            .tool_router
-            .call(ToolCallContext::new(self, request, context))
-            .await;
+        // Recorded like any other call, refused or not: exactly one record,
+        // with no guard verdict and no upstream leg, the same shape an
+        // unknown tool name produces.
+        let result = if reachable {
+            self.tool_router
+                .call(ToolCallContext::new(self, request, context))
+                .await
+        } else {
+            Err(tool_not_found())
+        };
 
         // Exactly one record per call, whatever `result` is — including
         // an unknown tool or another protocol error from the router.
@@ -3409,8 +3529,17 @@ impl ServerHandler for BugWarden {
         if skips_the_handshake(&context) {
             return Err(handshake_required());
         }
+        // Filtered, not listed-then-refused: the write tools are simply not
+        // there for a read-scope credential, which is I13's shape applied to
+        // the caller instead of the deployment.
+        let mut tools = self.tool_router.list_all();
+        match self.reach(&context) {
+            Reach::Everything => {}
+            Reach::ReadOnly => tools.retain(|tool| read_scope_serves(&tool.name)),
+            Reach::Nothing => tools.clear(),
+        }
         Ok(ListToolsResult {
-            tools: self.tool_router.list_all(),
+            tools,
             result_type: Some(ResultType::COMPLETE),
             meta: None,
             next_cursor: None,
@@ -3420,9 +3549,11 @@ impl ServerHandler for BugWarden {
             // add fields to responses no peer asked for. When the
             // revision is adopted, `cache_scope` is `Private` — the
             // listing is pruned per deployment by policy and by
-            // read-only mode (I13), so a shared cache must never serve
-            // one deployment's list to another. `CacheScope::default()`
-            // is `Public`; this field is always written by name.
+            // read-only mode (I13), and per CREDENTIAL by the bearer
+            // scope above, so a shared cache must never serve one
+            // deployment's list to another, nor a write list to a read
+            // token. `CacheScope::default()` is `Public`; this field is
+            // always written by name.
             ttl_ms: None,
             cache_scope: None,
         })
@@ -3997,6 +4128,43 @@ mod tests {
     }
 
     #[test]
+    fn write_tools_agrees_with_every_tool_read_only_hint() {
+        // Two descriptions of the same fact live in this file: `WRITE_TOOLS`,
+        // which read-only mode removes from the router (I13) and which the
+        // bearer read scope hides from one caller (#32), and each tool's own
+        // `read_only_hint` annotation, which is what an MCP client is told.
+        // They must agree tool for tool, or a tool added to one and forgotten
+        // in the other would be advertised read-only while the read scope
+        // still refuses it — or, worse, hidden from the annotation and served
+        // to a read token.
+        let (cfg, guard, bz) = parts("[global]\nallow_discovery = true\n");
+        let server = BugWarden::new(cfg, guard, bz).expect("server builds");
+        for tool in server.tool_router.list_all() {
+            let hinted_read_only = tool
+                .annotations
+                .as_ref()
+                .and_then(|a| a.read_only_hint)
+                .unwrap_or(false);
+            assert_eq!(
+                read_scope_serves(&tool.name),
+                hinted_read_only,
+                "{} is in WRITE_TOOLS xor annotated read_only_hint = true",
+                tool.name
+            );
+        }
+    }
+
+    #[test]
+    fn read_scope_serves_exactly_the_non_write_tools() {
+        for name in WRITE_TOOLS {
+            assert!(!read_scope_serves(name), "{name}");
+        }
+        for name in ["bug_info", "bugs_quicksearch", "bug_url", "mcp_server_info"] {
+            assert!(read_scope_serves(name), "{name}");
+        }
+    }
+
+    #[test]
     fn discovery_tools_absent_by_default_present_when_enabled_i16() {
         let (cfg, guard, bz) = parts("");
         let server = BugWarden::new(cfg, guard, bz).expect("server builds");
@@ -4532,6 +4700,101 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn scope_enforcement_without_a_scope_serves_nothing() {
+        // Defense in depth for the one branch `main` cannot reach: scopes
+        // enforced, but the request carries none because it arrived over a
+        // transport with no HTTP request behind it. Fail closed — an empty
+        // listing and no reachable tool — rather than assume the listener was
+        // wired the way this server was configured.
+        // No upstream fixture: nothing may reach Bugzilla, and the call
+        // below is refused before any tool body runs.
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz)
+            .expect("server must build")
+            .with_scope_enforcement(true);
+        let (client_io, server_io) = tokio::io::duplex(1 << 16);
+        tokio::spawn(async move {
+            if let Ok(running) = server.serve(server_io).await {
+                let _ = running.waiting().await;
+            }
+        });
+        let client: RunningService<RoleClient, ()> =
+            ().serve(client_io)
+                .await
+                .expect("MCP handshake must succeed");
+
+        assert!(
+            client
+                .list_all_tools()
+                .await
+                .expect("tools/list must succeed")
+                .is_empty(),
+            "a request with no scope must be offered nothing"
+        );
+        let refused = client
+            .call_tool(
+                CallToolRequestParams::new("bug_info".to_string()).with_arguments(
+                    json!({ "bug_ids": [7] })
+                        .as_object()
+                        .expect("object")
+                        .clone(),
+                ),
+            )
+            .await
+            .expect_err("a request with no scope must reach no tool");
+        let unknown = client
+            .call_tool(CallToolRequestParams::new(
+                "no_such_tool_at_all".to_string(),
+            ))
+            .await
+            .expect_err("an unknown tool is an error");
+        assert_eq!(refused.to_string(), unknown.to_string());
+    }
+
+    #[tokio::test]
+    async fn a_scope_refused_call_is_recorded_like_an_unknown_tool() {
+        // Rejection at the transport layer cannot be audited (issue #32
+        // constraint 5), but a scope refusal happens inside `call_tool` and
+        // therefore can be: exactly ONE record, no guard verdict, no upstream
+        // leg — the same shape an unknown tool name produces.
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz)
+            .expect("server must build")
+            .with_audit(audit)
+            .with_scope_enforcement(true);
+        let (client_io, server_io) = tokio::io::duplex(1 << 16);
+        tokio::spawn(async move {
+            if let Ok(running) = server.serve(server_io).await {
+                let _ = running.waiting().await;
+            }
+        });
+        let client: RunningService<RoleClient, ()> =
+            ().serve(client_io)
+                .await
+                .expect("MCP handshake must succeed");
+
+        client
+            .call_tool(CallToolRequestParams::new("add_comment".to_string()))
+            .await
+            .expect_err("the call must be refused");
+        drop(client);
+
+        let events = read_audit_events(&audit_path);
+        let calls = tool_calls(&events);
+        assert_eq!(calls.len(), 1, "exactly one record: {events:?}");
+        assert_eq!(calls[0].request.tool, "add_comment");
+        assert_eq!(calls[0].guard, None, "the guard never ran");
+        assert_eq!(calls[0].upstream, None, "Bugzilla was never contacted");
+        assert_eq!(calls[0].outcome.class, audit::OutcomeClass::Error);
+        assert_eq!(
+            calls[0].client.principal, None,
+            "a deployment credential is not a caller (#32)"
+        );
+    }
+
+    #[tokio::test]
     async fn traceparent_in_meta_lands_in_the_tool_record() {
         let mock = MockServer::start().await;
         mount_bug7(&mock).await;
@@ -4664,6 +4927,105 @@ mod tests {
         let guard = calls[0].guard.as_ref().expect("the gate records a guard");
         assert_eq!(guard.verdict, Verdict::Refused);
         assert_trace_is_canonical(calls[0].trace.as_ref());
+    }
+
+    /// A `RequestContext` carrying the HTTP request parts a served request
+    /// would carry, with `scope` attached the way the bearer layer attaches
+    /// it. The only way to reach [`Reach::ReadOnly`] without a live listener.
+    fn context_with_scope(
+        peer: rmcp::service::Peer<RoleServer>,
+        scope: Option<Scope>,
+    ) -> RequestContext<RoleServer> {
+        let (mut parts, ()) = axum::http::Request::new(()).into_parts();
+        if let Some(scope) = scope {
+            parts.extensions.insert(scope);
+        }
+        let mut context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer);
+        context.extensions.insert(parts);
+        context
+    }
+
+    /// A peer for a hand-built context, minted by serving a clone over a
+    /// duplex (the SDK exposes no other constructor). No tool call flows
+    /// through that session.
+    async fn peer_of(server: &BugWarden) -> rmcp::service::Peer<RoleServer> {
+        let (client_io, server_io) = tokio::io::duplex(1 << 16);
+        let serving = server.clone();
+        let task = tokio::spawn(async move { serving.serve(server_io).await });
+        let _client = ().serve(client_io).await.expect("MCP handshake must succeed");
+        task.await
+            .expect("serve task must not panic")
+            .expect("server must serve")
+            .peer()
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn a_failing_sink_never_tells_a_read_scope_which_names_this_build_routes() {
+        // The audit gate answers a refused call with that TOOL's own failure
+        // text. Reached for a name the router would not have dispatched, it
+        // becomes an existence oracle that opens only while the sink is
+        // failing: a scope-hidden write tool, an unrouted-by-policy tool and
+        // an unknown name must all answer exactly as they do with a healthy
+        // sink. Driven under ClosedAll, which gates everything and is the
+        // http transport's default fail mode.
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, _path) = audit_state(dir.path(), FailMode::ClosedAll);
+        // Discovery off (the default), so `bugzilla_products` is a KNOWN
+        // name this deployment does not route — the sibling of the scope
+        // case, and reachable by the read scope.
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz)
+            .expect("server must build")
+            .with_audit(Arc::clone(&audit))
+            .with_scope_enforcement(true);
+        let peer = peer_of(&server).await;
+
+        let answer = |name: &'static str| {
+            let server = server.clone();
+            let peer = peer.clone();
+            async move {
+                let context = context_with_scope(peer, Some(Scope::Read));
+                let params = CallToolRequestParams::new(name.to_string());
+                match ServerHandler::call_tool(&server, params, context).await {
+                    Ok(ok) => format!("ok {ok:?}"),
+                    Err(e) => format!("err {e}"),
+                }
+            }
+        };
+
+        let healthy = (
+            answer("add_comment").await,
+            answer("bugzilla_products").await,
+            answer("no_such_tool_at_all").await,
+        );
+        assert_eq!(healthy.0, healthy.1, "healthy sink: {healthy:?}");
+        assert_eq!(healthy.1, healthy.2, "healthy sink: {healthy:?}");
+
+        audit.sink.set_fail_writes(true);
+        // `failing()` turns true only after a record is actually dropped, so
+        // prime it: without this the first probe below still meets a
+        // not-yet-failing sink and the gate is skipped for the wrong reason.
+        let _ = answer("bug_url").await;
+        assert!(audit.sink.failing(), "the sink must be in failure");
+        let failing = (
+            answer("add_comment").await,
+            answer("bugzilla_products").await,
+            answer("no_such_tool_at_all").await,
+        );
+        assert_eq!(
+            failing.0, failing.2,
+            "a scope-hidden write tool must answer like an unknown name whatever \
+             the sink is doing"
+        );
+        assert_eq!(
+            failing.1, failing.2,
+            "a tool this policy does not route must answer like an unknown name too"
+        );
+        assert_eq!(
+            healthy, failing,
+            "sink health must not be readable off any of the three refusals"
+        );
     }
 
     #[tokio::test]

--- a/crates/bugwarden/tests/http_auth_wiremock.rs
+++ b/crates/bugwarden/tests/http_auth_wiremock.rs
@@ -1,0 +1,783 @@
+//! End-to-end tests of the HTTP bearer gate over REAL streamable HTTP
+//! (issue #32).
+//!
+//! Two layers, both needed. The wire layer serves a [`BugWarden`] through the
+//! same `http_auth::guard_router` `main` uses, over an actual TCP listener,
+//! and drives it with raw reqwest (for the refusal shape, which is not an MCP
+//! message at all) and with an rmcp client (for the per-credential tool
+//! surface). The process layer spawns the shipped binary, because "refuses to
+//! start before binding the port" is a claim about `main`'s ordering that no
+//! in-process test can make.
+//!
+//! Coverage contract (each of these mutations must fail at least one test):
+//! - resolving the bearer gate after the listener is bound, or after the
+//!   audit sink is opened;
+//! - accepting a request with no `Authorization` header, the wrong token, or
+//!   a non-Bearer scheme;
+//! - varying the refusal between those cases (status, headers or body), or
+//!   answering `404` for an unrouted path instead of the same refusal;
+//! - granting the write scope to the read token, or leaving the write tools
+//!   in a read-scope `tools/list`;
+//! - letting a read-scope write call reach Bugzilla, or answering it with
+//!   anything other than the router's own unknown-tool error;
+//! - moving the gate behind rmcp's POST body cap, which would let an
+//!   unauthenticated caller probe the cap for the policy value it derives;
+//! - dropping any of the five startup refusals;
+//! - refusing a stdio start over a token in the environment.
+
+use std::net::SocketAddr;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bugwarden::config::Cli;
+use bugwarden::http_auth::{self, HttpAuth, HttpEnv};
+use bugwarden::server::{BugWarden, USER_AGENT, WRITE_TOOLS};
+use bugwarden_core::client::BugzillaClient;
+use bugwarden_core::guard::Guard;
+use bugwarden_core::policy::Policy;
+use clap::Parser as _;
+use rmcp::model::CallToolRequestParams;
+use rmcp::service::{RoleClient, RunningService};
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::streamable_http_server::{
+    session::local::LocalSessionManager, StreamableHttpService,
+};
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::ServiceExt as _;
+use serde_json::{json, Value};
+use wiremock::matchers::{any, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// 32 printable non-space characters each, and distinct.
+const WRITE_TOKEN: &str = "0123456789abcdef0123456789abcdef";
+const READ_TOKEN: &str = "fedcba9876543210fedcba9876543210";
+
+/// Bounded so a binary that never exits fails this test rather than hanging
+/// the suite until CI's own timeout kills it.
+const EXIT_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Every environment variable the binary reads, cleared before each spawn:
+/// an ambient value would change exactly what is under test.
+const AMBIENT_VARS: &[&str] = &[
+    "BUGZILLA_SERVER",
+    "BUGZILLA_API_KEY",
+    "BUGZILLA_API_KEY_FILE",
+    "BUGWARDEN_POLICY",
+    "BUGWARDEN_AUDIT_CONFIG",
+    "BUGWARDEN_HTTP_TOKEN",
+    "BUGWARDEN_HTTP_READ_TOKEN",
+    "BUGZILLA_USE_AUTH_HEADER",
+    "MCP_TRANSPORT",
+    "MCP_HOST",
+    "MCP_PORT",
+    "MCP_ALLOWED_HOSTS",
+    "MCP_READ_ONLY",
+    "MCP_API_KEY_HEADER",
+    "RUST_LOG",
+];
+
+/// The scrub list is only as good as its coverage of `Cli`; a flag added
+/// with an `env` fallback would otherwise reach the spawned binary from the
+/// runner's environment and change what these tests measure. The two bearer
+/// tokens are not clap arguments, so they are checked by name.
+#[test]
+fn the_scrub_list_covers_every_environment_fallback() {
+    let mut cmd = bugwarden::config::command();
+    cmd.build();
+    let unscrubbed: Vec<String> = cmd
+        .get_arguments()
+        .filter_map(clap::Arg::get_env)
+        .map(|env| env.to_string_lossy().into_owned())
+        .filter(|env| !AMBIENT_VARS.contains(&env.as_str()))
+        .collect();
+    assert!(
+        unscrubbed.is_empty(),
+        "these environment fallbacks reach the spawned binary: {unscrubbed:?}"
+    );
+    for var in [
+        bugwarden::http_auth::WRITE_TOKEN_VAR,
+        bugwarden::http_auth::READ_TOKEN_VAR,
+    ] {
+        assert!(AMBIENT_VARS.contains(&var), "{var} must be scrubbed");
+    }
+}
+
+// ---------- wire-level harness ----------
+
+/// Serve a [`BugWarden`] over a real TCP listener behind the bearer gate
+/// `env`/`insecure` resolve to, and return the bound address.
+///
+/// The router is assembled by `http_auth::guard_router`, the one `main`
+/// calls, and scope enforcement is switched the way `main` switches it — so
+/// no test can exercise a differently-guarded server than the deployment
+/// serves.
+async fn serve_guarded(mock: &MockServer, env: &HttpEnv, insecure: bool) -> SocketAddr {
+    let mut cli = Cli::parse_from([
+        "bugwarden",
+        "--bugzilla-server",
+        &mock.uri(),
+        "--transport",
+        "http",
+    ]);
+    // Both key fields explicitly cleared, so the ambient environment cannot
+    // leak into what these tests resolve; the tests send the key per request.
+    cli.api_key = None;
+    cli.api_key_file = None;
+    let guard = Arc::new(Guard {
+        policy: Policy::default(),
+    });
+    let bz =
+        Arc::new(BugzillaClient::new(&mock.uri(), false, USER_AGENT).expect("client must build"));
+    let auth = Arc::new(HttpAuth::resolve(env, insecure).expect("the test gate must resolve"));
+    let server = BugWarden::new(Arc::new(cli), guard, bz)
+        .expect("server must build")
+        .with_scope_enforcement(!auth.is_insecure());
+
+    let config = server.http_server_config();
+    let service = StreamableHttpService::new(
+        move || Ok(server.clone()),
+        LocalSessionManager::default().into(),
+        config,
+    );
+    let router = http_auth::guard_router(
+        axum::Router::new().nest_service("/mcp", service),
+        Arc::clone(&auth),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind an ephemeral port");
+    let addr = listener.local_addr().expect("bound address");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    addr
+}
+
+/// Both tokens configured.
+fn both_tokens() -> HttpEnv {
+    HttpEnv {
+        write: Some(WRITE_TOKEN.to_owned()),
+        read: Some(READ_TOKEN.to_owned()),
+    }
+}
+
+/// Connect an MCP client that presents `token` as its bearer credential and
+/// `test-key` as the per-request Bugzilla key.
+async fn connect(addr: SocketAddr, token: Option<&str>) -> RunningService<RoleClient, ()> {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert("ApiKey", "test-key".parse().expect("header value"));
+    if let Some(token) = token {
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {token}").parse().expect("header value"),
+        );
+    }
+    let client = reqwest::Client::builder()
+        .default_headers(headers)
+        .build()
+        .expect("reqwest client");
+    let transport = StreamableHttpClientTransport::with_client(
+        client,
+        StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp")),
+    );
+    ().serve(transport)
+        .await
+        .expect("MCP handshake must succeed")
+}
+
+/// The tool names this credential is offered.
+async fn listed_tools(client: &RunningService<RoleClient, ()>) -> Vec<String> {
+    client
+        .list_all_tools()
+        .await
+        .expect("tools/list must succeed")
+        .into_iter()
+        .map(|tool| tool.name.to_string())
+        .collect()
+}
+
+/// A classification response for one world-readable bug.
+fn world_readable_bug(id: u64) -> Value {
+    json!({
+        "id": id,
+        "summary": "a plain bug",
+        "product": "openSUSE",
+        "component": "Kernel",
+        "status": "NEW",
+        "severity": "normal",
+        "priority": "P3",
+        "keywords": [],
+        "groups": [],
+        "whiteboard": "",
+        "creation_time": "2020-01-01T00:00:00Z",
+    })
+}
+
+/// Mount the fetches a served `bug_info` call needs.
+async fn mount_bug(mock: &MockServer, id: u64) {
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", id.to_string()))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "bugs": [world_readable_bug(id)] })),
+        )
+        .mount(mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .mount(mock)
+        .await;
+}
+
+// ---------- the refusal, and its uniformity (I2) ----------
+
+/// One raw HTTP exchange, reduced to what a caller can actually observe.
+#[derive(Debug, PartialEq, Eq)]
+struct Observed {
+    status: u16,
+    www_authenticate: Option<String>,
+    body: Vec<u8>,
+}
+
+async fn probe(client: &reqwest::Client, url: &str, authorization: &[&str]) -> Observed {
+    let mut request = client.post(url).json(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}
+    }));
+    // Appended, not replaced: passing two values is how a duplicate
+    // `Authorization` reaches the server.
+    for value in authorization {
+        request = request.header(reqwest::header::AUTHORIZATION, *value);
+    }
+    let response = request.send().await.expect("the server must answer");
+    Observed {
+        status: response.status().as_u16(),
+        www_authenticate: response
+            .headers()
+            .get(reqwest::header::WWW_AUTHENTICATE)
+            .map(|v| v.to_str().expect("ascii header").to_owned()),
+        body: response.bytes().await.expect("body").to_vec(),
+    }
+}
+
+#[tokio::test]
+async fn every_unauthenticated_request_gets_one_byte_identical_refusal() {
+    let mock = MockServer::start().await;
+    // Nothing may reach Bugzilla: a refused request never gets that far.
+    Mock::given(any())
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .named("a refused request must make no upstream request")
+        .mount(&mock)
+        .await;
+    let addr = serve_guarded(&mock, &both_tokens(), false).await;
+    let http = reqwest::Client::new();
+    let mcp = format!("http://{addr}/mcp");
+
+    let baseline = probe(&http, &mcp, &[]).await;
+    assert_eq!(baseline.status, 401);
+    assert_eq!(baseline.www_authenticate.as_deref(), Some("Bearer"));
+    assert!(baseline.body.is_empty(), "{baseline:?}");
+
+    let good = format!("Bearer {WRITE_TOKEN}");
+    let good_read = format!("Bearer {READ_TOKEN}");
+    for authorization in [
+        // Wrong token, a prefix of the right one, the right token as some
+        // other scheme, a bare scheme, and a scheme-less value.
+        vec!["Bearer 11111111111111111111111111111111"],
+        vec!["Bearer 0123456789abcdef0123456789abcde"],
+        vec![&*format!("Basic {WRITE_TOKEN}")],
+        vec!["Bearer"],
+        vec![WRITE_TOKEN],
+        vec![""],
+        // Two credentials in one request. RFC 9110 makes that malformed, and
+        // a proxy on the path forwarding last-wins where the server reads
+        // first-wins would authorize the other one — so BOTH orders are
+        // refused, including two copies of a token that would be accepted
+        // alone.
+        vec![&*good, &*good_read],
+        vec![&*good_read, &*good],
+        vec![&*good, &*good],
+        vec![&*good, "Bearer 11111111111111111111111111111111"],
+        vec!["Bearer 11111111111111111111111111111111", &*good],
+    ] {
+        assert_eq!(
+            probe(&http, &mcp, &authorization).await,
+            baseline,
+            "{authorization:?} must be refused exactly like a missing header"
+        );
+    }
+    // The same single credential, alone, is served — so the refusals above
+    // are about the duplication and not about the value.
+    assert_ne!(probe(&http, &mcp, &[&good]).await.status, 401);
+
+    // Path knowledge is part of the same uniformity: an unrouted path is
+    // refused identically, so probing cannot map the surface either.
+    for url in [
+        format!("http://{addr}/"),
+        format!("http://{addr}/mcp/nope"),
+        format!("http://{addr}/.well-known/oauth-protected-resource"),
+    ] {
+        assert_eq!(
+            probe(&http, &url, &[]).await,
+            baseline,
+            "{url} must be refused exactly like /mcp"
+        );
+        assert_ne!(
+            probe(&http, &url, &[&good]).await.status,
+            401,
+            "an authenticated caller gets the router's own answer, not the gate's"
+        );
+    }
+}
+
+#[tokio::test]
+async fn an_oversized_body_from_a_stranger_is_refused_by_the_gate_not_the_cap() {
+    // The gate is a layer in FRONT of rmcp, so an unauthenticated caller
+    // never reaches the POST body cap and cannot binary-search it. DESIGN.md
+    // rests the 413-observability argument on exactly this.
+    let mock = MockServer::start().await;
+    let addr = serve_guarded(&mock, &both_tokens(), false).await;
+    let http = reqwest::Client::new();
+    let url = format!("http://{addr}/mcp");
+    // Past the 4 MiB floor the default policy derives.
+    let oversized = "x".repeat(5 * 1024 * 1024);
+
+    let anonymous = http
+        .post(&url)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(oversized.clone())
+        .send()
+        .await
+        .expect("the server must answer");
+    assert_eq!(anonymous.status().as_u16(), 401, "the gate answers first");
+
+    let authenticated = http
+        .post(&url)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .header(
+            reqwest::header::ACCEPT,
+            "application/json, text/event-stream",
+        )
+        .header(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {WRITE_TOKEN}"),
+        )
+        .body(oversized)
+        .send()
+        .await
+        .expect("the server must answer");
+    assert_eq!(
+        authenticated.status().as_u16(),
+        413,
+        "a credentialed caller reaches the cap, and only then"
+    );
+
+    // The READ scope reaches it too: the cap is a transport limit and the
+    // scope gate sits above it in the handler, so a credential that may not
+    // upload at all still sees the boundary. DESIGN.md's #52 disclosure note
+    // says so; this is what makes that sentence true.
+    let read_scope = http
+        .post(&url)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .header(
+            reqwest::header::ACCEPT,
+            "application/json, text/event-stream",
+        )
+        .header(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {READ_TOKEN}"),
+        )
+        .body("y".repeat(5 * 1024 * 1024))
+        .send()
+        .await
+        .expect("the server must answer");
+    assert_eq!(read_scope.status().as_u16(), 413);
+}
+
+// ---------- the two scopes ----------
+
+#[tokio::test]
+async fn the_write_token_reaches_the_whole_tool_surface() {
+    let mock = MockServer::start().await;
+    mount_bug(&mock, 7).await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug/7/comment"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": 99 })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    let addr = serve_guarded(&mock, &both_tokens(), false).await;
+    let client = connect(addr, Some(WRITE_TOKEN)).await;
+
+    let listed = listed_tools(&client).await;
+    for name in WRITE_TOOLS {
+        assert!(
+            listed.iter().any(|t| t == name),
+            "the write scope must be offered {name}: {listed:?}"
+        );
+    }
+    assert!(listed.iter().any(|t| t == "bug_info"), "{listed:?}");
+
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("add_comment".to_owned()).with_arguments(
+                json!({ "bug_id": 7, "comment": "hello" })
+                    .as_object()
+                    .expect("object")
+                    .clone(),
+            ),
+        )
+        .await
+        .expect("the write scope must reach a write tool");
+    assert_ne!(result.is_error, Some(true), "{result:?}");
+}
+
+#[tokio::test]
+async fn the_read_token_is_offered_only_the_read_tools() {
+    let mock = MockServer::start().await;
+    let addr = serve_guarded(&mock, &both_tokens(), false).await;
+
+    let read = listed_tools(&connect(addr, Some(READ_TOKEN)).await).await;
+    let write = listed_tools(&connect(addr, Some(WRITE_TOKEN)).await).await;
+
+    for name in WRITE_TOOLS {
+        assert!(
+            !read.iter().any(|t| t == name),
+            "the read scope must not be offered {name}: {read:?}"
+        );
+    }
+    // The listing is FILTERED, not emptied: every non-write tool the write
+    // scope sees is still there.
+    let expected: Vec<&String> = write
+        .iter()
+        .filter(|t| !WRITE_TOOLS.contains(&t.as_str()))
+        .collect();
+    assert_eq!(
+        read.iter().collect::<Vec<_>>(),
+        expected,
+        "the read listing must be the write listing minus the write tools"
+    );
+    assert!(!expected.is_empty(), "the fixture must offer read tools");
+}
+
+#[tokio::test]
+async fn a_read_scope_write_call_is_refused_as_unrouted_and_reaches_no_bugzilla() {
+    let mock = MockServer::start().await;
+    // The read tool below is the only thing allowed upstream; anything a
+    // refused write call would send falls through to this and fails the test.
+    mount_bug(&mock, 7).await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .named("a scope-refused write call must POST nothing")
+        .mount(&mock)
+        .await;
+    let addr = serve_guarded(&mock, &both_tokens(), false).await;
+    let client = connect(addr, Some(READ_TOKEN)).await;
+
+    // A read tool still works, so the refusal below is about the scope and
+    // not about the session being broken.
+    let served = client
+        .call_tool(
+            CallToolRequestParams::new("bug_info".to_owned()).with_arguments(
+                json!({ "bug_ids": [7] })
+                    .as_object()
+                    .expect("object")
+                    .clone(),
+            ),
+        )
+        .await
+        .expect("the read scope must reach a read tool");
+    assert_ne!(served.is_error, Some(true), "{served:?}");
+
+    let refused = client
+        .call_tool(
+            CallToolRequestParams::new("add_comment".to_owned()).with_arguments(
+                json!({ "bug_id": 7, "comment": "hello" })
+                    .as_object()
+                    .expect("object")
+                    .clone(),
+            ),
+        )
+        .await
+        .expect_err("the read scope must not reach a write tool");
+
+    // Compared against the router's OWN answer for a name it does not route,
+    // not against a literal: a scope-hidden tool must be indistinguishable
+    // from one that does not exist, and this stays true across rmcp bumps.
+    let unknown = client
+        .call_tool(CallToolRequestParams::new("no_such_tool_at_all".to_owned()))
+        .await
+        .expect_err("an unknown tool is an error");
+    assert_eq!(
+        refused.to_string(),
+        unknown.to_string(),
+        "a write tool must look exactly like a tool that does not exist"
+    );
+}
+
+#[tokio::test]
+async fn insecure_no_auth_serves_every_caller_the_full_surface() {
+    let mock = MockServer::start().await;
+    let addr = serve_guarded(&mock, &HttpEnv::default(), true).await;
+    let listed = listed_tools(&connect(addr, None).await).await;
+    for name in WRITE_TOOLS {
+        assert!(
+            listed.iter().any(|t| t == name),
+            "--insecure-no-auth grants the full write scope: {listed:?}"
+        );
+    }
+}
+
+// ---------- startup: the process, not the library ----------
+
+/// Run the shipped binary with `args` and `env`, and return
+/// `(exit code, stderr)`.
+async fn run_binary(args: &[&str], env: &[(&str, &str)]) -> (Option<i32>, String) {
+    let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_bugwarden"));
+    cmd.args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    for var in AMBIENT_VARS {
+        cmd.env_remove(var);
+    }
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+    let child = cmd.spawn().expect("the built binary must start");
+    let output = tokio::time::timeout(EXIT_TIMEOUT, child.wait_with_output())
+        .await
+        .expect("the binary must exit rather than serve")
+        .expect("the binary must be waitable");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[tokio::test]
+async fn every_startup_misconfiguration_refuses_before_the_port_is_bound() {
+    // The port is already taken by this test. A start that bound before
+    // checking its credentials would fail with a bind error instead of the
+    // token error each case asserts — which is what makes this an ordering
+    // test and not just a validation test.
+    let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = occupied.local_addr().expect("addr").port().to_string();
+    let base: Vec<&str> = vec![
+        "--bugzilla-server",
+        "https://bugzilla.example.invalid",
+        "--port",
+        &port,
+    ];
+    let secret = "SUPERSECRETTOKENSUPERSECRETTOKEN0";
+
+    /// One refusal case: extra flags, environment, and the phrase the
+    /// diagnostic must carry.
+    struct Case<'a> {
+        flags: Vec<&'a str>,
+        env: Vec<(&'a str, &'a str)>,
+        expected: &'a str,
+    }
+    let case = |flags: Vec<&'static str>, env, expected| Case {
+        flags,
+        env,
+        expected,
+    };
+    let cases = vec![
+        // 1. http (the DEFAULT transport) with no token and no opt-out.
+        case(vec![], vec![], "requires a bearer token"),
+        // 2. --insecure-no-auth together with a token.
+        case(
+            vec!["--insecure-no-auth"],
+            vec![("BUGWARDEN_HTTP_TOKEN", secret)],
+            "conflicts with a configured bearer token",
+        ),
+        // 3. too short.
+        case(
+            vec![],
+            vec![("BUGWARDEN_HTTP_TOKEN", "tooshort")],
+            "holds fewer than 32 characters",
+        ),
+        // 4. not printable ASCII.
+        case(
+            vec![],
+            vec![(
+                "BUGWARDEN_HTTP_READ_TOKEN",
+                "0123456789abcdef 0123456789abcdef",
+            )],
+            "use printable ASCII, and no spaces",
+        ),
+        // 5. the read token IS the write token.
+        case(
+            vec![],
+            vec![
+                ("BUGWARDEN_HTTP_TOKEN", secret),
+                ("BUGWARDEN_HTTP_READ_TOKEN", secret),
+            ],
+            "identical",
+        ),
+    ];
+
+    for Case {
+        flags,
+        env,
+        expected,
+    } in cases
+    {
+        let args: Vec<&str> = base.iter().copied().chain(flags.iter().copied()).collect();
+        let (code, stderr) = run_binary(&args, &env).await;
+        assert_eq!(code, Some(1), "{expected}: {stderr}");
+        assert!(
+            stderr.contains(expected),
+            "expected {expected:?} in: {stderr}"
+        );
+        assert!(
+            !stderr.contains("failed to bind"),
+            "the refusal must come before the bind: {stderr}"
+        );
+        // I12: the diagnostic names the variable, never what it held.
+        for (var, value) in &env {
+            assert!(
+                stderr.contains(var) || expected == "requires a bearer token",
+                "{stderr}"
+            );
+            assert!(
+                !stderr.contains(value),
+                "the error must not echo the token: {stderr}"
+            );
+        }
+    }
+
+    drop(occupied);
+}
+
+/// A port to hand the child, chosen by binding and releasing an ephemeral
+/// one. Racy in principle; the child's readiness poll below is what turns a
+/// lost race into a test failure rather than a hang.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind")
+        .local_addr()
+        .expect("addr")
+        .port()
+}
+
+#[tokio::test]
+async fn the_shipped_binary_wires_the_read_token_to_the_read_surface() {
+    // `main` is the only place scope enforcement is switched on, and every
+    // other test in this file builds the server itself — so deleting that
+    // one call leaves them all green while every deployed read token gets
+    // the write surface. This drives the REAL executable end to end.
+    let mock = MockServer::start().await;
+    let port = free_port();
+    let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_bugwarden"));
+    cmd.args(["--bugzilla-server", &mock.uri()])
+        .args(["--host", "127.0.0.1", "--port", &port.to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    for var in AMBIENT_VARS {
+        cmd.env_remove(var);
+    }
+    cmd.env("BUGWARDEN_HTTP_TOKEN", WRITE_TOKEN)
+        .env("BUGWARDEN_HTTP_READ_TOKEN", READ_TOKEN);
+    cmd.kill_on_drop(true);
+    let mut child = cmd.spawn().expect("the built binary must start");
+
+    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
+    let ready = tokio::time::timeout(EXIT_TIMEOUT, async {
+        loop {
+            if tokio::net::TcpStream::connect(addr).await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await;
+    assert!(ready.is_ok(), "the binary must start serving");
+
+    let read = listed_tools(&connect(addr, Some(READ_TOKEN)).await).await;
+    let write = listed_tools(&connect(addr, Some(WRITE_TOKEN)).await).await;
+    for name in WRITE_TOOLS {
+        assert!(
+            write.iter().any(|t| t == name),
+            "the deployed write token must reach {name}: {write:?}"
+        );
+        assert!(
+            !read.iter().any(|t| t == name),
+            "the deployed read token must NOT reach {name}: {read:?}"
+        );
+    }
+    assert!(!read.is_empty(), "the read token must still see read tools");
+    let _ = child.kill().await;
+}
+
+#[tokio::test]
+async fn a_token_refusal_precedes_the_audit_sink() {
+    // The gate is resolved ahead of every other startup effect, and the audit
+    // sink is the one with a side effect on disk: a refused start must not
+    // have created (or rotated) the operator's audit file. Same ordering
+    // rationale key custody already has.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let audit_path = dir.path().join("audit.jsonl");
+    let config_path = dir.path().join("audit.toml");
+    std::fs::write(
+        &config_path,
+        format!("path = {:?}\n", audit_path.to_str().expect("utf-8 path")),
+    )
+    .expect("write the audit config");
+
+    let (code, stderr) = run_binary(
+        &[
+            "--bugzilla-server",
+            "https://bugzilla.example.invalid",
+            "--audit-config",
+            config_path.to_str().expect("utf-8 path"),
+        ],
+        &[],
+    )
+    .await;
+    assert_eq!(code, Some(1), "{stderr}");
+    assert!(stderr.contains("requires a bearer token"), "{stderr}");
+    assert!(
+        !audit_path.exists(),
+        "a refused start must not have opened the audit sink"
+    );
+}
+
+#[tokio::test]
+async fn a_stdio_start_ignores_the_bearer_tokens() {
+    // Every http refusal condition, handed to a stdio run that has no key
+    // source: it must fail on the key, which is the error a stdio start
+    // without a token already had, and never on the tokens.
+    for env in [
+        vec![("BUGWARDEN_HTTP_TOKEN", "tooshort")],
+        vec![
+            ("BUGWARDEN_HTTP_TOKEN", "0123456789abcdef0123456789abcdef"),
+            (
+                "BUGWARDEN_HTTP_READ_TOKEN",
+                "0123456789abcdef0123456789abcdef",
+            ),
+        ],
+    ] {
+        let (code, stderr) = run_binary(
+            &[
+                "--bugzilla-server",
+                "https://bugzilla.example.invalid",
+                "--transport",
+                "stdio",
+            ],
+            &env,
+        )
+        .await;
+        assert_eq!(code, Some(1), "{stderr}");
+        assert!(
+            stderr.contains("--transport stdio requires"),
+            "a stdio start must fail on its key, not on the tokens: {stderr}"
+        );
+    }
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -832,6 +832,124 @@ units and container specs). Decisions, all deliberate:
   file's write-bit warning). The startup log line states mode and source
   only — never key material (I12).
 
+### HTTP bearer authentication (crates/bugwarden/src/http_auth.rs)
+
+Key custody above answers "who authenticates to Bugzilla". This answers the
+other half — who authenticates to bugwarden — for the http transport only.
+Partial delivery of issue #32, deliberately scoped: it authenticates a
+DEPLOYMENT, not a caller, so `ClientInfo.principal` stays `None` and #32 stays
+open until a verified caller identity fills it.
+
+Over stdio the client launched the process and is its only principal. Over http
+the port was the whole access control, and under server-held key custody that
+means anyone reaching the port is served with the deployment's Bugzilla
+credential. So http is **deny-by-default**: two tokens, read from the
+environment only.
+
+The *contract* — the two variable names, the 32-character printable-ASCII
+floor, the five startup refusals, the `Authorization: Bearer` wire shape and
+the read/write scope split — is deliberately the one `ruoqa-mcp` serves, so a
+fleet configures both from one set of variables (#32). That is an agreement
+about the interface; the implementation is this repository's own.
+
+| variable | scope | reaches |
+|---|---|---|
+| `BUGWARDEN_HTTP_TOKEN` | write | every tool the policy serves |
+| `BUGWARDEN_HTTP_READ_TOKEN` | read | the non-`WRITE_TOOLS` tools only |
+
+`main` calls `http_auth::resolve_for`, which delegates to `HttpAuth::resolve`
+for the http transport and returns `None` for stdio. That call comes BEFORE
+the policy load, the Bugzilla client, the identity preflight and the audit
+sink — so a misconfiguration binds no port, opens no socket and neither
+creates nor rotates an audit file, the same ordering rationale key custody
+already has. It refuses to start on five conditions:
+
+- http with neither token set and no `--insecure-no-auth` — including the bare
+  `bugwarden --bugzilla-server …` that worked before this landed, since http is
+  the DEFAULT transport. Breaking, and chosen: the alternative is a port that
+  keeps serving a Bugzilla credential to anyone who can reach it;
+- `--insecure-no-auth` together with either token (contradictory intent);
+- a token shorter than 32 characters;
+- a token containing anything but printable non-space ASCII (it has to survive
+  an HTTP header, and whitespace hides transcription errors);
+- the read token equal to the write token, which would make the scopes
+  meaningless.
+
+Decisions, all deliberate:
+
+- **Environment only, no flag.** argv is world-readable through `ps`, so no CLI
+  option carries token material. The value never enters `Cli` at all, so I12's
+  "never in a log or error" is structural here rather than a redacting `Debug`
+  impl: there is nothing to redact. `HttpEnv` and `HttpAuth` have no `Debug`
+  impl for the same reason `KeyCustody` has none. An empty value counts as
+  unset, matching `--api-key` / `--api-key-file`.
+- **`--insecure-no-auth` has no environment variable**, and is the only flag
+  that has none — every other one gained a fallback with #31/#32, and a unit
+  test holds them to it with this single named exception. It is also the only
+  flag that LOOSENS: I9 says CLI and env may only tighten, and an ambient
+  `BUGWARDEN_*` able to switch authentication off is precisely the loosening
+  default I9 exists to forbid. On the command line it stays a per-run decision
+  someone typed. It warns at startup.
+- **The gate is an axum layer wrapping the WHOLE router**, not the `/mcp`
+  route, and it runs before rmcp sees the request. So an unauthenticated
+  caller reaches no MCP handling at all, and an unrouted path is refused
+  identically instead of answering `404` — the refusal discloses no path
+  knowledge, no tool, no policy and no bug (I2). One response for every
+  failure: empty `401` with `WWW-Authenticate: Bearer`, byte-identical whether
+  the header was missing, wrong-schemed, or carried a wrong token.
+- **Constant-time comparison** (`subtle::ConstantTimeEq`), and BOTH tokens are
+  always compared: returning early on a write-token match would leak by timing
+  which credential a guess matched.
+- **The read scope is the complement of `WRITE_TOOLS`** — the same constant
+  read-only mode removes from the router (I13) — so the per-caller split cannot
+  drift from the per-deployment one. A unit test additionally pins
+  `WRITE_TOOLS` against every tool's own `read_only_hint` annotation, so a tool
+  added to one and forgotten in the other fails to build a passing test run.
+- **A read-scope caller is served a FILTERED listing, not a listing plus
+  errors** — I13's shape applied to the credential instead of the deployment.
+  Calling a hidden write tool anyway is answered with `ToolRouter`'s own
+  unknown-tool error, byte for byte, so a write tool is indistinguishable from
+  a tool that does not exist: nothing tells a read credential whether the
+  deployment even serves writes. No Bugzilla request is made, because the
+  refusal is decided before dispatch.
+- **Fail closed on a missing scope.** With enforcement on, a request carrying
+  no scope reaches nothing — an empty listing and the same unknown-tool
+  refusal for every name. Unreachable through `main` (the layer wraps the
+  router), so it is defense in depth against a future rewiring, and it logs
+  once per process rather than per request.
+- **Refusals are logged, not audited.** Rejection happens in the layer, before
+  `call_tool`, which is where audit records are written — so #32's "refusals
+  must be recorded" cannot be met by the audit stream without a new event kind,
+  and the schema's event set is #34's to decide. What lands instead is a
+  counter logged on the first refusal and then at every power of two: bounded,
+  so an unauthenticated client cannot drive log volume, and carrying no token,
+  header, path or peer, so it is no oracle. A read-scope caller's refused write
+  call IS audited, as one ordinary `tool_call` record with no guard verdict and
+  no upstream leg — the same shape an unknown tool name produces.
+- **Scope enforcement is a transport property, not a policy one.**
+  `BugWarden::with_scope_enforcement` is switched on by `main` for an
+  authenticated http listener only: stdio issues no per-request credential and
+  `--insecure-no-auth` issues none by definition. It never widens what the
+  guard policy allows — a write token reaches exactly the router the policy
+  already pruned (I1, I9).
+- **`server/discover` closes with everything else.** #32 listed it open —
+  whether a mandatory *unauthenticated* pre-request surface should survive the
+  arrival of auth. It does not: the gate wraps the whole router, so
+  `server/discover` needs a token like any other request. Decided rather than
+  inherited, and the cheap direction — no revision this build serves defines
+  that surface (`2026-07-28` is unadopted, #34), so nothing needs it today,
+  and opening a pre-request identity surface ahead of the revision that gives
+  it a purpose would hand out the deployed version to strangers for nothing.
+  Reopening it is a one-line route exemption if #34 ever needs one.
+- **What this deliberately does NOT do.** No caller identity: `principal` stays
+  `None`, and a deployment credential must never fill it (#32). No per-caller
+  policy: one operator policy per process (I1) is unchanged, and a token
+  narrows the tool surface without touching a single guard decision. No RRID or
+  work-context binding. No token rotation without a restart, and no revocation
+  list. The wire shape — `Authorization: Bearer <token>` — is the one #32's end
+  state uses, so what changes when per-caller tokens arrive is the validator,
+  not the request shape, the refusal path or the audit fields.
+
 ### Identity preflight (`BugWarden::preflight`)
 
 `Guard::resolve_caller` maps every `whoami` failure to `None`, and I4 then
@@ -992,12 +1110,17 @@ clap derive `Cli`, with env fallbacks:
 | --read-only | MCP_READ_ONLY | false | tighten-only (I9) |
 | --policy | BUGWARDEN_POLICY | — | path to guard policy TOML |
 | --audit-config | BUGWARDEN_AUDIT_CONFIG | — | path to audit configuration TOML; without it no audit stream is written |
+| --insecure-no-auth | — (deliberately) | false | serve http with no bearer gate; refuses to start together with a token (see HTTP bearer authentication) |
+| — | BUGWARDEN_HTTP_TOKEN | — | bearer token, write scope; environment only, never a flag |
+| — | BUGWARDEN_HTTP_READ_TOKEN | — | bearer token, read scope; environment only, never a flag |
 
 Startup validation: key custody is resolved by `Cli::resolve_key_custody`
 inside `BugWarden::new` (see Key custody) — --api-key together with
 --api-key-file, stdio without any key source, and an empty or unreadable
 key file all exit with an error (the key-file errors name the path only,
-I12); http with api_key => tracing::warn (ignored). main.rs adds: http
+I12); http with api_key => tracing::warn (ignored). main.rs adds: the http
+bearer gate, resolved FIRST of all (see HTTP bearer authentication) so a
+token misconfiguration precedes every other startup effect; and http
 without audit_config => tracing::warn (remote tool calls leave no audit
 record).
 
@@ -1265,10 +1388,12 @@ wired, `server.rs` and `main.rs` are the reference.
   placeholder `client_info` in the `_meta`-shape trap below, in the other
   direction: the SDK's build environment is not this build's identity
   (issue #53). `server/discover` is the second place a peer reads it, and
-  it is answered with no handshake — so until #32 lands, anything that can
-  open the port learns the exact deployed version, unauthenticated and
-  unrecorded. Accepted deliberately: `serverInfo` is a required field of
-  `InitializeResult`, so withholding it is not protocol-legal, and the
+  it is answered with no handshake — so anything that gets past the http
+  bearer gate learns the exact deployed version without a handshake and
+  without an audit record, and over stdio or behind `--insecure-no-auth`
+  anything that reaches the process at all does. Accepted deliberately:
+  `serverInfo` is a required field of `InitializeResult`, so withholding it
+  is not protocol-legal, and the
   value being replaced was rmcp's own exact release — a dependency
   fingerprint, which is not the smaller disclosure. The same trap has a
   non-MCP twin, and it is not rmcp's: the `User-Agent` sent to Bugzilla
@@ -1319,8 +1444,16 @@ wired, `server.rs` and `main.rs` are the reference.
   `allowed_hosts` is a DNS-rebinding defence for MCP servers a browser can
   reach on localhost, and its default would refuse every deployment not
   addressed as `localhost`, containers included; bugwarden disables it
-  deliberately, since its access control is the network boundary and, when it
-  lands, per-caller authentication (#32). `max_request_body_bytes` is a POST
+  deliberately, because with the gate on the rebinding attack is already
+  answered a layer earlier — the rebound browser carries no bearer token and
+  is turned away with the same `401` as any other stranger, whatever `Host`
+  it sent (see "HTTP bearer authentication"). That argument lapses under
+  `--insecure-no-auth`, which admits every caller by design: there
+  `--allowed-hosts` / `MCP_ALLOWED_HOSTS` is how the operator puts the `Host`
+  check back, and a deployment that turns the gate off should name its
+  authorities. ruoqa-mcp keeps its `Host` allowlist alongside its own gate for
+  the same reason — the two defences are independent, and only one of them is
+  optional here. `max_request_body_bytes` is a POST
   cap with no rmcp 2.2 equivalent: kept as a memory bound, but it also
   ceilings `add_attachment`, so a fixed value silently overrides the
   operator's `global.max_attachment_bytes` — at the SDK's 4 MiB, base64
@@ -1349,9 +1482,10 @@ wired, `server.rs` and `main.rs` are the reference.
   decoded is not honored over HTTP. A body over the cap is refused by rmcp's
   tower layer with a bare `413` that reaches neither `call_tool` nor the
   guard, so it is **unrecordable** in the audit stream — the same class as a
-  pre-handler auth refusal (#32), and accepted on the same terms; an operator
-  diagnosing a 413 compares the body size against the derived cap, because
-  nothing server-side recorded the attempt.
+  bearer refusal, which the layer in front of the service turns away and
+  which is likewise only counted in the log, and accepted on the same terms;
+  an operator diagnosing a 413 compares the body size against the derived
+  cap, because nothing server-side recorded the attempt.
 
   That boundary is also observable to an unauthenticated client, which is
   **ACCEPTED**: whenever the derivation exceeds the floor (a decoded cap above
@@ -1365,13 +1499,20 @@ wired, `server.rs` and `main.rs` are the reference.
   bug's existence or content, so I1's "the policy file is never readable
   through MCP" and I2/I3 are untouched — this is the one policy-derived
   number a transport-level limit inherently exposes, in exchange for the
-  operator's configured limit actually working. And the probing itself needs
-  network reach, which is the access control until per-caller authentication
-  lands (#32); a caller who can binary-search POST sizes can already call
-  tools. If #32 changes that calculus, revisit here and at the add_attachment
-  row together. The `cancellation_token` is named so ctrl_c tears the live
-  transport down with the process instead of leaving it to outlive the
-  shutdown.
+  operator's configured limit actually working. And the probing itself now
+  needs a valid bearer token, since the gate turns an unauthenticated caller
+  away before rmcp measures the body at all: whoever can binary-search POST
+  sizes can already call tools. The audience did narrow rather than vanish —
+  a READ-scope caller still reaches the 413 boundary, because the cap is a
+  transport limit and the scope gate sits above it in the handler, so the
+  figure is legible to a credential that may not upload at all. Accepted on
+  the same terms: it is a memory-tuning number, not bug data, and the holder
+  is someone the operator issued a token to. `--insecure-no-auth` restores
+  the older, wider exposure to everyone — one more thing that flag hands
+  out. If a per-caller identity (#32) changes this calculus, revisit here
+  and at the add_attachment row together. The `cancellation_token` is named so ctrl_c
+  tears the live transport down with the process instead of leaving it to
+  outlive the shutdown.
 
   An operator who does know the authorities their deployment answers to names
   them with a repeated `--allowed-hosts`, or with `MCP_ALLOWED_HOSTS` as one
@@ -1388,10 +1529,14 @@ wired, `server.rs` and `main.rs` are the reference.
   which would refuse every `Host`.
 
   `allowed_origins` is the browser-facing sibling of `allowed_hosts`, and the
-  #32 argument covers it identically. It is inherited rather than named because
-  the empty default IS the disabled state — `origin_is_allowed` returns true on
-  an empty list, exactly what `disable_allowed_origins()` would produce — so
-  naming it would assert nothing the default does not already say. The
+  bearer-gate argument covers it identically — including the lapse: under
+  `--insecure-no-auth` nothing stands in front of a browser-originated
+  request, and rmcp offers no operator-facing knob here the way
+  `--allowed-hosts` covers the other row. It is inherited rather than named
+  because the empty default IS the disabled state — `origin_is_allowed`
+  returns true on an empty list, exactly what `disable_allowed_origins()`
+  would produce — so naming it would assert nothing the default does not
+  already say. The
   asymmetry with `allowed_hosts` is real and not an oversight: the host default
   refuses ordinary requests from this build's clients, whereas Origin is only
   checked when the header is present and a non-browser MCP client does not send
@@ -1828,5 +1973,40 @@ wired, `server.rs` and `main.rs` are the reference.
   constructor, so a per-mode identity would send nothing at all in the
   other — and a blank or non-header-value identity fails at construction
   rather than going out anonymously.
+- HTTP bearer tests (#[cfg(test)] in crates/bugwarden/src/http_auth.rs and
+  crates/bugwarden/src/server.rs; crates/bugwarden/tests/
+  http_auth_wiremock.rs): resolution — each of the five startup refusals,
+  the 31/32-character boundary either side, each token alone and both
+  together, and the error naming the VARIABLE and never its value; the wire —
+  a request with no header, the wrong token, a token prefix, a non-Bearer
+  scheme, a bare scheme and an unrouted path all get one BYTE-IDENTICAL empty
+  `401`, compared as (status, `WWW-Authenticate`, body) against the
+  no-header baseline, while the same paths with a valid token get the
+  router's own answer; the scopes — the write token is offered and reaches
+  every `WRITE_TOOLS` entry, the read listing is exactly the write listing
+  minus them (so a mutation that empties it fails too), a read-scope write
+  call is refused with the router's OWN unknown-tool error (read back from
+  the live router rather than pinned as a literal, so an rmcp bump cannot
+  make the two diverge silently) while a wiremock catch-all proves nothing
+  was POSTed, and a read tool on the same session still serves; an oversized
+  POST from a stranger is answered `401` by the gate and `413` only for a
+  credentialed caller, which is what the 413-observability argument under
+  "rmcp 3.1 usage notes" rests on; a scope-refused call leaves exactly ONE
+  audit record, with no guard verdict, no upstream leg and no `principal`;
+  scopes
+  enforced with NO scope on the request serves an empty listing and refuses
+  every name, the fail-closed branch `main` cannot reach; the constant-time
+  comparison is pinned by source, since `ct_eq` and `==` are behaviorally
+  identical and only the instruction sequence differs; refusal logging is
+  bounded (five refusals, three lines) and carries no token; and the SHIPPED
+  BINARY is spawned for the startup half, on a port this test already holds,
+  so a `main` that bound before checking its credentials would fail with a
+  bind error instead of the token error each case asserts, and a refused start
+  with an `--audit-config` leaves no audit file on disk, pinning the other half
+  of the ordering — with the same spawn proving a stdio start ignores tokens
+  that would refuse an http one.
+  `WRITE_TOOLS` is additionally pinned against every tool's own
+  `read_only_hint` annotation, so the read scope cannot drift from what
+  clients are told.
 - CI: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
   `cargo test --workspace --locked`, `cargo deny check`.


### PR DESCRIPTION
Ruoqa-mcp-compatible scoped bearer authentication for the HTTP transport (#32, fleet alignment). **BREAKING**: http (the default transport) now refuses to start without `BUGWARDEN_HTTP_TOKEN` (write scope) or `BUGWARDEN_HTTP_READ_TOKEN` (read scope); `--insecure-no-auth` is the explicit escape hatch (CLI-only — I9).

Contract: env-only tokens (argv is ps-readable), ≥32 printable non-space ASCII, read≠write, deny-by-default resolved before any port binds or audit file exists, constant-time comparison with both tokens always compared, one byte-identical empty 401 + `WWW-Authenticate: Bearer` for every refusal cause including unrouted paths and duplicate Authorization headers (I2). Read scope reuses I13's WRITE_TOOLS set: filtered `tools/list`, and a refused write call answers the router's own "tool not found" with zero upstream requests — a hidden tool is indistinguishable from a nonexistent one, now also under a failing audit sink (the refusal gate checks routing first; this closed a pre-existing sibling leak for policy-removed discovery tools). stdio ignores tokens. `principal` stays `None` — a deployment credential is not a caller; #32 remains open for (caller, RRID).

## Adversarial review before opening
Security lens: 29 bypass probes all byte-identical 401s; no session-scope escalation; I12 clean under RUST_LOG=trace. Its two proven findings — an oracle under failing-sink+closed_all and the `main.rs` scope wiring being unpinned (deleting it left 463 tests green) — are fixed, each with a killing test. Docs lens: falsified man-page preamble, unqualified allowed-hosts rationale (in three places), unrunnable examples, stale MCP client config — all corrected; the gate's closing of `server/discover` is now a recorded DESIGN.md decision.

The auth core was rewritten independently after review flagged verbatim overlap with ruoqa-mcp's GPL source: 0 identical doc-comment lines, 0 identical function bodies remain (mechanical difflib check); the compatible part is the wire contract, not the code.

## Verification
Rebased on current main. All five AGENTS.md commands independently re-run: fmt/clippy×2 clean, **471 passed / 0 failed**, cargo deny fully green. 24/24 mutations killed. Assets regenerated byte-stable.