### PR TITLE
build: bump the pinned toolchain to 1.97.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
           # Keep in sync with rust-toolchain.toml.
-          toolchain: "1.97.0"
+          toolchain: "1.97.1"
           components: rustfmt, clippy
       - name: Cache cargo
         # Tag runs re-verify a release: keep them off restored build state;
@@ -64,7 +64,7 @@ jobs:
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
           # Keep in sync with rust-toolchain.toml.
-          toolchain: "1.97.0"
+          toolchain: "1.97.1"
           components: clippy
       - name: Cache cargo
         # Tag runs re-verify a release: keep them off restored build state;
@@ -156,7 +156,7 @@ jobs:
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
           # Keep in sync with rust-toolchain.toml.
-          toolchain: "1.97.0"
+          toolchain: "1.97.1"
       - name: Cache cargo
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3  # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
           # Keep in sync with rust-toolchain.toml.
-          toolchain: "1.97.0"
+          toolchain: "1.97.1"
       # No cargo cache here: releases are built hermetically so restored
       # build state can never influence published artifacts.
 
@@ -228,7 +228,7 @@ jobs:
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
           # Keep in sync with rust-toolchain.toml.
-          toolchain: "1.97.0"
+          toolchain: "1.97.1"
 
       - name: Authenticate to crates.io
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18  # v1.0.5

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # toolchain input in .github/workflows/ci.yml; the workspace MSRV
 # (rust-version in Cargo.toml) is a separate, lower bound.
 [toolchain]
-channel = "1.97.0"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Completes the coordinated bump #107 started: Dockerfile went to 1.97.1 there; this moves `rust-toolchain.toml` and the six CI/release toolchain pins to match, restoring the bump-both-together contract the Dockerfile documents.

Verification: fmt/clippy/test (471/0)/deny all green locally — under the host's distro 1.97.0 (no rustup on this box), so the authoritative 1.97.1 compile is this PR's own CI, where dtolnay/rust-toolchain installs the pinned version.