### PR TITLE
ci: pin Swatinem/rust-cache to the v2.9.2 release commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,19 @@ updates:
 
   # GitHub Actions used by the workflows. Keeps the SHA-pinned actions in
   # ci.yml / release.yml current so they cannot silently rot.
+  #
+  # Pin every action to a commit a version tag points at, and name that
+  # release in the trailing `# vX.Y.Z` comment. This file cannot enforce it:
+  # the github-actions ecosystem has no "releases only" setting, and the
+  # property lives in the SHA in the workflow, not here. Dependabot follows
+  # version tags for a SHA pin only while the pinned commit is itself
+  # tagged; for an untagged SHA it falls back to the head of the branch
+  # containing that commit and keeps it there, so one bump onto an untagged
+  # commit converts a release pin into branch-tracking, and preserves it
+  # once there. Swatinem/rust-cache was pinned to an untagged commit from
+  # the start, so it never left branch-tracking (#102). A tagged pin
+  # re-arms release-following on its own; what catches a relapse is
+  # checking a bumped SHA against the `# vX.Y.Z` comment it claims.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         # Tag runs re-verify a release: keep them off restored build state;
         # PR/main runs keep the cache.
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3  # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           workspaces: . -> target
       - name: Format
@@ -70,7 +70,7 @@ jobs:
         # Tag runs re-verify a release: keep them off restored build state;
         # PR/main runs keep the cache.
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3  # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           workspaces: . -> target
       - name: Clippy
@@ -96,7 +96,7 @@ jobs:
           components: clippy
       - name: Cache cargo
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3  # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           workspaces: . -> target
       - name: Clippy (beta)
@@ -137,7 +137,7 @@ jobs:
           toolchain: "1.88"
       - name: Cache cargo
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3  # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           workspaces: . -> target
       - name: Build (MSRV)
@@ -159,7 +159,7 @@ jobs:
           toolchain: "1.97.1"
       - name: Cache cargo
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3  # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           workspaces: . -> target
       - name: Regenerate man page + completions


### PR DESCRIPTION
Closes #102. Pins 6323deb1 — verified as the commit v2.9.2's annotated tag dereferences to (the issue's own '49a0bdc7' was the tag object, not a commit). Reviewer verified dependabot-core source: a tagged pin permanently flips the updater to release-following, and v2.9.2 being the newest tag means no immediate re-bump. The dependabot.yml comment records the true history (every pin this repo ever had was untagged — branch-tracking from the first hand-written pin). **Deliberate 3-commit downgrade**: drops upstream #377 (cleanup-timestamp pruning fix), cache-efficiency only, release artifacts never touch this action; v2.9.3 will arrive via dependabot. Supersedes closed #108. Adversarially reviewed (MERGE-SAFE).