### PR TITLE
chore: release 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "bugwarden"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "bugwarden-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Martin Pluskal <martin@pluskal.org>"]

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -34,7 +34,7 @@ gen = ["dep:clap_complete", "dep:clap_mangen"]
 workspace = true
 
 [dependencies]
-bugwarden-core = { path = "../bugwarden-core", version = "0.4.0" }
+bugwarden-core = { path = "../bugwarden-core", version = "0.5.0" }
 
 rmcp = { version = "3.1", features = [
     "server",

--- a/crates/bugwarden/man/bugwarden.1
+++ b/crates/bugwarden/man/bugwarden.1
@@ -1,4 +1,4 @@
-.TH bugwarden 1 "" "bugwarden 0.4.0" "General Commands Manual"
+.TH bugwarden 1 "" "bugwarden 0.5.0" "General Commands Manual"
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SH NAME


### PR DESCRIPTION
Version bump for the 0.5.0 release. Per AGENTS.md the bump lands as a normal PR first; the annotated tag then goes on the merge commit and `release.yml` does the rest (binaries, GitHub release, GHCR image, crates.io).

## Why 0.5.0 and not 0.4.1

26 commits since `0.4.0` (2026-08-12), and one of them changes behaviour an operator can be broken by: **#105 / #32** makes the http transport deny-by-default — no bearer token and no `--insecure-no-auth` is a startup refusal *before the port is bound*. A 0.4.0 http deployment with no token will not come up. Pre-1.0, that belongs in the minor position.

## What's in the cycle

**Features**
- HTTP bearer gate: `BUGWARDEN_HTTP_TOKEN` / `BUGWARDEN_HTTP_READ_TOKEN`, deny-by-default, write vs read scope (#105 / #32)
- `MCP_ALLOWED_HOSTS` and `BUGZILLA_USE_AUTH_HEADER` from the environment (#104)
- audit / diagnostics export to an OTLP collector; a configured collector is load-bearing (#121 / #31)
- published container image `ghcr.io/plusky/bugwarden` (multi-arch, distroless) (#106)

**Fixes**
- unparsable `--allowed-hosts` is a startup error; `::1` is a matchable authority (#125 / #117)
- SIGTERM so `docker stop` is a graceful shutdown (#122 / #114)
- tool schemas normalized for Gemini/Vertex clients, including nested draft-2020-12 positions (#119, #126)
- I12 transport tests no longer aim at recycled ports (#124)

**Docs / test / build**
- I12 refuse address recorded as `127.0.0.1:1` (#128)
- toolchain pin 1.97.1; Alpine rust image matching it
- h2 0.4.16 (RUSTSEC-2026-0258)
- rust-cache pinned to the v2.9.2 release commit

## What this PR touches

| File | Change |
|---|---|
| `Cargo.toml` | `[workspace.package] version` → `0.5.0` |
| `crates/bugwarden/Cargo.toml` | the `bugwarden-core` dependency pins `version` as well as `path`, so it moves in lockstep |
| `Cargo.lock` | both workspace crates |
| `crates/bugwarden/man/bugwarden.1` | regenerated — the man page embeds the version |

The completions carry no version string and are unchanged, which `rust-assets-drift` confirms.

The `bugwarden-core` version requirement is still not single-sourced; it has to be bumped by hand every release. It fails the build loudly rather than silently resolving a stale core.

## Verification

`cargo fmt --check`, both clippy invocations, `cargo test --workspace --all-targets --locked` (**550 passed, 0 failed**), and `cargo deny check` all pass. Assets regenerated from the clap CLI and re-diffed.

After merge: annotated tag `0.5.0` on the merge commit (no `v` prefix). First GHCR push will be **private**; visibility has to be flipped to public once in Package settings (Danger Zone) — that is a one-way UI step, not part of this PR.