### PR TITLE
build: sync the pinned toolchain to 1.98.0 and guard against drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
           # Keep in sync with rust-toolchain.toml.
-          toolchain: "1.97.1"
+          toolchain: "1.98.0"
           components: rustfmt, clippy
       - name: Cache cargo
         # Tag runs re-verify a release: keep them off restored build state;
@@ -64,7 +64,7 @@ jobs:
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
           # Keep in sync with rust-toolchain.toml.
-          toolchain: "1.97.1"
+          toolchain: "1.98.0"
           components: clippy
       - name: Cache cargo
         # Tag runs re-verify a release: keep them off restored build state;
@@ -156,7 +156,7 @@ jobs:
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
           # Keep in sync with rust-toolchain.toml.
-          toolchain: "1.97.1"
+          toolchain: "1.98.0"
       - name: Cache cargo
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,39 @@ jobs:
             exit 1
           fi
 
+  toolchain-drift:
+    # The image build stage never COPYs rust-toolchain.toml, so a base-image
+    # bump can move the container's rustc off the pinned channel with nothing
+    # failing. Deliberately not behind the `changes` paths filter: the check
+    # is two sed calls, and paths-filter would skip it on a tag push.
+    # release.yml is a separate workflow this job cannot hold back, so on a
+    # tag it only reports the mismatch that shipped; the PR run is where it
+    # flags a bump before it lands.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Compare Dockerfile rust tags with rust-toolchain.toml channel
+        shell: bash
+        run: |
+          set -euo pipefail
+          tags="$(sed -n 's/^FROM rust:\([0-9][0-9.]*\)-alpine.*/\1/p' Dockerfile)"
+          channel="$(sed -n 's/^channel = "\([^"]*\)".*/\1/p' rust-toolchain.toml)"
+          if [ -z "$tags" ] || [ -z "$channel" ]; then
+            echo "::error::cannot read the Rust version: Dockerfile FROM tags '$tags', rust-toolchain.toml channel '$channel'"
+            exit 1
+          fi
+          # Check every rust stage, so a second one cannot drift past the guard.
+          while IFS= read -r tag; do
+            if [ "$tag" != "$channel" ]; then
+              echo "::error::toolchain drift: Dockerfile builds on rust:$tag but rust-toolchain.toml pins channel $channel -- bump both together"
+              exit 1
+            fi
+          done <<< "$tags"
+          echo "in sync: Dockerfile rust:$channel == rust-toolchain.toml channel $channel"
+
   changes:
     # Gate for the docker job: a full image build on every PR would be the
     # slowest leg in CI for changes that cannot affect it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
           # Keep in sync with rust-toolchain.toml.
-          toolchain: "1.97.1"
+          toolchain: "1.98.0"
       # No cargo cache here: releases are built hermetically so restored
       # build state can never influence published artifacts.
 
@@ -228,7 +228,7 @@ jobs:
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
           # Keep in sync with rust-toolchain.toml.
-          toolchain: "1.97.1"
+          toolchain: "1.98.0"
 
       - name: Authenticate to crates.io
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18  # v1.0.5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,10 @@ cargo deny check
 ```
 
 Use the toolchain pinned in `rust-toolchain.toml` (repo root, currently
-`1.97.0`). The workspace MSRV is declared once in `Cargo.toml`
+`1.98.0`). That pin, the `toolchain:` inputs in `.github/workflows/`, and
+the `FROM rust:` tag in the `Dockerfile` all name the same version and move
+together; the `rust-msrv` and `rust-beta` inputs are deliberate exceptions.
+The workspace MSRV is declared once in `Cargo.toml`
 (`rust-version = "1.88"`); do not introduce APIs or dependencies which
 require a newer compiler without deliberately updating both the pin and the
 MSRV policy. CI and reproducible local checks use the committed

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 
 # Pinned to the channel in rust-toolchain.toml, which this stage never COPYs —
 # so a floating `rust:1` would silently build releases with an unpinned
-# compiler. Bump this tag and rust-toolchain.toml together.
+# compiler. Bump this tag and rust-toolchain.toml together; ci.yml's
+# toolchain-drift job fails when they disagree.
 FROM rust:1.98.0-alpine@sha256:a10e64dd139b7387337c7fbe8aca31b959b57b2fd4c8ae20a02cf1d6ea424dce AS build
 # gcc and musl-dev are already in the base; aws-lc-sys (the rustls crypto
 # provider) compiles C from source and needs cmake plus a make generator.

--- a/crates/bugwarden/src/config.rs
+++ b/crates/bugwarden/src/config.rs
@@ -381,8 +381,6 @@ fn read_key_file(path: &Path) -> anyhow::Result<String> {
 mod tests {
     use std::io::Write as _;
 
-    use clap::Parser as _;
-
     use super::*;
 
     /// A `Cli` for `transport` with both key sources explicitly cleared, so

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,7 @@
 # Pinned toolchain for reproducible local checks. Keep in sync with the CI
-# toolchain input in .github/workflows/ci.yml; the workspace MSRV
-# (rust-version in Cargo.toml) is a separate, lower bound.
+# toolchain inputs in .github/workflows/ and with the Dockerfile's rust tag,
+# which ci.yml's toolchain-drift job compares against this channel; the
+# workspace MSRV (rust-version in Cargo.toml) is a separate, lower bound.
 [toolchain]
 channel = "1.98.0"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # toolchain input in .github/workflows/ci.yml; the workspace MSRV
 # (rust-version in Cargo.toml) is a separate, lower bound.
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Closes #134.

Two commits, each independently green:

- **`build: bump the pinned toolchain to 1.98.0`** — `rust-toolchain.toml`
  and all five CI `toolchain:` inputs move to 1.98.0, matching the
  Dockerfile tag that #130 already bumped. Includes the deletion of the
  redundant `use clap::Parser as _;` in `config.rs`'s test module, without
  which 1.98's sharpened `unused_imports` lint fails the required
  `-D warnings` clippy gate, plus the stale AGENTS.md toolchain
  parenthetical.
- **`ci: fail when the Dockerfile rust tag and the pinned channel
  disagree`** — a dependency-free shell guard so the next dependabot base
  image bump cannot silently reopen the desync.

## Why the desync mattered

The build stage never copies `rust-toolchain.toml`, so the image's rustc
governed only the `docker` CI job and the release container legs. A
release therefore shipped a container binary compiled by a rustc no
clippy or test gate had ever run, with container and tarball binaries of
the same version built by different compilers — and nothing failed
loudly, because the container build has no `-D warnings`.

## Adversarial review before opening

Three lenses over the uncommitted diff; the documentation lens returned
NOT MERGE-SAFE and its blocking finding was fixed before this PR existed.
Independent verification then re-derived everything from scratch rather
than trusting the author or the reviewers:

- Both commits pass all five AGENTS.md commands **on their own** under a
  scratch rustup 1.98.0 (550 tests, 0 failures; deny clean) — required
  because main takes rebase merges.
- Seven Rust version pins now hold one value; MSRV (1.88) and `Cargo.lock`
  are untouched.
- The guard was extracted from `ci.yml` with a YAML parser and run
  directly: in-sync passes, desync fails with a message naming both
  values, and seven adversarial probes (second rust stage drifting or in
  sync, pin moved instead of the tag, rust stage deleted, non-alpine base,
  `rust:1.98-alpine`, floating `rust:1-alpine`) all fail closed with no
  fail-open path.

## Non-blocking findings, filed separately rather than smuggled in here

The reviews surfaced two things this PR deliberately does not fix: the
new `toolchain-drift` job is not in main's required status contexts (a
repo-settings change no PR can make), and the `rust-msrv` job's
`toolchain:` input is inert because `rust-toolchain.toml` outranks
`rustup default` — so that job has not been testing the MSRV. Both
pre-date this change.
