### PR TITLE
feat(server): serialize tool responses as compact JSON

### DIFF
--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -143,9 +143,13 @@ pub const WRITE_TOOLS: &[&str] = &[
 /// from the router unless `global.allow_discovery = true` (I13, I16).
 pub const DISCOVERY_TOOLS: &[&str] = &["bugzilla_products", "bug_fields"];
 
-/// Success result: ONE text block containing pretty-printed JSON.
+/// Success result: ONE text block containing compact JSON.
+///
+/// Compact, not pretty-printed: the block is parsed as JSON by clients, and
+/// the whitespace difference is ~15-25% of a bug payload's size — context
+/// the model pays for on every call.
 fn ok_json(value: Value) -> CallToolResult {
-    let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
+    let text = serde_json::to_string(&value).unwrap_or_else(|_| value.to_string());
     CallToolResult::success(vec![ContentBlock::text(text)])
 }
 
@@ -3112,7 +3116,7 @@ impl BugWarden {
             })
         };
         Ok(CallToolResult::success(vec![
-            ContentBlock::text(serde_json::to_string_pretty(&summary).unwrap_or_default()),
+            ContentBlock::text(serde_json::to_string(&summary).unwrap_or_default()),
             content,
         ]))
     }
@@ -3332,8 +3336,7 @@ impl BugWarden {
             }
         }
         let comments = Guard::scrub_duplicate_markers(comments, &disclosable);
-        let comments_json =
-            serde_json::to_string_pretty(&comments).unwrap_or_else(|_| "[]".to_string());
+        let comments_json = serde_json::to_string(&comments).unwrap_or_else(|_| "[]".to_string());
         let prompt = format!(
             "You are an expert in summarizing bugzilla comments.\n\
              Rules to follow:\n\

--- a/crates/bugwarden/tests/tools_wiremock.rs
+++ b/crates/bugwarden/tests/tools_wiremock.rs
@@ -404,8 +404,14 @@ async fn create_scoped_rule_files_bugs_without_hiding_reads_issue_26() {
         "search must succeed: {}",
         text_of(&search)
     );
+    // Parse rather than string-match: the wire format is compact JSON, so
+    // `"id": 7` with a space is not the shape to assert on.
+    let search_json: Value = serde_json::from_str(&text_of(&search)).expect("search returns JSON");
     assert!(
-        text_of(&search).contains("\"id\": 7"),
+        search_json
+            .get("bugs")
+            .and_then(Value::as_array)
+            .is_some_and(|bugs| bugs.iter().any(|b| b.get("id") == Some(&json!(7)))),
         "the existing bug must not vanish from search: {}",
         text_of(&search)
     );

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -778,7 +778,8 @@ where every other criterion describes bug content. Decisions, all deliberate:
 ## MCP tool surface (crates/bugwarden/src/server.rs)
 
 Result convention: success => `CallToolResult::success` with ONE text block of
-pretty-printed JSON. The sole exception is `download_attachment`, which
+compact JSON (whitespace is not MCP API; pretty-printing costs the model
+~15-25% of every payload for nothing). The sole exception is `download_attachment`, which
 returns a JSON summary text block PLUS one image or blob-resource block. Guard refusals and input-validation failures =>
 `CallToolResult::error` with a text block (NOT a protocol error). Protocol
 issues (missing API key header in per-request custody) =>


### PR DESCRIPTION
## What

`ok_json` (server.rs:147) pretty-printed every tool response; switches to `serde_json::to_string`. Also flips the two stray `to_string_pretty` sites (`download_attachment`'s summary block, `summarize_bug`'s embedded comments_json) and updates the DESIGN.md result convention.

Closes #139.

## Why

Whitespace is not MCP API — clients parse the text block as JSON. Measured against apibugzilla.suse.com (read-only probes):

- `bugs_quicksearch` limit 25: 12659 → 9422 B (−26%)
- `bug_info` single bug: 1682 → 1412 B (−16%)
- `bug_history` (12 entries): 3101 → 2048 B (−34%)
- `bug_comments` heavy bug: −1% (text-dominated; windowing is #141)

## Adversarial review (DESIGN.md invariants)

- **I2**: denials are plain strings via `err_text`, never `ok_json` — all denial sites verified.
- **I15**: byte-identity covers auditing on/off/failing, not serialization format; the audit record never stores the payload.
- **I3/I14**: same `Value`, same content and key order, different whitespace.

Finding addressed in the PR: one test asserted pretty-printed spacing (`"id": 7`); it now parses the text block as JSON instead of string-matching — fixed the test, not the guard (AGENTS.md).

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo clippy -p bugwarden --features gen --all-targets -- -D warnings`, `cargo test --workspace --all-targets --locked`, `cargo deny check` — all green.