### PR TITLE
build(deps): update chacha20 past the yanked 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,9 +287,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",


### PR DESCRIPTION
## What

`cargo update -p chacha20` — 0.10.1 → 0.10.2, lockfile only.

## Why

chacha20 0.10.1 (rand 0.10.2 → rmcp 3.1.4) was yanked from crates.io after the rmcp bump landed on main, so every PR opened since fails the required `rust-deny` check on the inherited lockfile. Unrelated to those PRs' changes; split out per the one-logical-change rule.

## Verification

`cargo fmt --check`, both clippy invocations, `cargo test --workspace --all-targets --locked` (17 suites ok), `cargo deny check` — all green locally with the current advisory db.