### PR TITLE
build(release): ship x86_64 deb and rpm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,10 +79,146 @@ jobs:
             ${{ env.DIST }}.tar.gz.sha256
           if-no-files-found: error
 
+  package:
+    # Distribution packages, x86_64 only: they mirror the one Linux triple the
+    # `build` matrix ships, and the openSUSE packages come from OBS anyway
+    # (devel:tools), which builds every tier-1 arch from the source tarball.
+    # Sibling of `build`, not downstream of it — the two share no output, and
+    # `release` waits for both.
+    name: package (deb, rpm)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
+        with:
+          # Keep in sync with rust-toolchain.toml.
+          toolchain: "1.98.0"
+      # No cargo cache, same hermetic-release rule as `build` above.
+
+      - name: Verify tag matches workspace version
+        shell: bash
+        run: |
+          pkg="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
+          if [ "$pkg" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::tag '$GITHUB_REF_NAME' != workspace version '$pkg'"
+            exit 1
+          fi
+
+      - name: Install packaging tools
+        # Pinned exactly and --locked: the packagers' own lockfiles decide
+        # their dependencies, so a release cannot change shape because an
+        # unrelated crate published that morning.
+        run: |
+          cargo install cargo-deb --locked --version 3.7.0
+          cargo install cargo-generate-rpm --locked --version 0.16.1
+
+      - name: Build release binary
+        run: cargo build --release --locked -p bugwarden
+
+      - name: Strip the packaged binary
+        # cargo-deb strips by default and cargo-generate-rpm cannot at all, so
+        # strip once here and tell cargo-deb not to: both packages then ship a
+        # byte-identical binary. The tarballs keep their symbols (unchanged).
+        run: strip target/release/bugwarden
+
+      - name: Build packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Note the asymmetry: cargo-deb's -p takes a PACKAGE NAME,
+          # cargo-generate-rpm's a MANIFEST DIRECTORY. Both read their
+          # metadata from crates/bugwarden/Cargo.toml and write under the
+          # workspace target dir.
+          cargo deb -p bugwarden --no-build --no-strip
+          # An RPM Version may not contain '-'. cargo-deb rewrites a semver
+          # pre-release to '~' itself; cargo-generate-rpm passes it through,
+          # producing an illegal Version that also sorts NEWER than the final
+          # release. Convert here. No-op for a plain 0.2.0 tag.
+          rpmver="$(printf '%s' "$GITHUB_REF_NAME" | tr -- - '~')"
+          # --auto-req on the CLI, not in Cargo.toml: the metadata key silently
+          # ignores every value but "no"/"disabled", which would leave the
+          # dependency set up to whichever find-requires the runner has.
+          cargo generate-rpm -p crates/bugwarden --auto-req builtin \
+            -s "version = \"${rpmver}\""
+
+      - name: Check the packages before they can be released
+        shell: bash
+        run: |
+          set -euo pipefail
+          deb="$(echo target/debian/*.deb)"
+          rpm="$(echo target/generate-rpm/*.rpm)"
+
+          # Both packagers exit 0 on an empty dependency set, and a package that
+          # installs on a too-old glibc and then dies at exec is worse than one
+          # that fails to build. `release` needs us, so failing here costs a tag
+          # and no more.
+          dpkg-deb -f "$deb" Depends | grep -q libc6 \
+            || { echo "::error::deb has no libc6 dependency"; exit 1; }
+          rpm -qp --requires "$rpm" | grep -q '^libc\.so' \
+            || { echo "::error::rpm has no libc.so dependency"; exit 1; }
+
+          # Every asset actually landed. The two lists differ by one entry on
+          # purpose: cargo-deb gzips man pages, cargo-generate-rpm does not.
+          rpmfiles="$(rpm -qpl "$rpm")"
+          for want in /usr/bin/bugwarden /etc/bugwarden/policy.toml \
+                      /etc/bugwarden/audit.toml /usr/share/man/man1/bugwarden.1; do
+            grep -qxF "$want" <<<"$rpmfiles" \
+              || { echo "::error::rpm is missing $want"; exit 1; }
+          done
+          debfiles="$(dpkg-deb -c "$deb" | awk '{print $NF}')"
+          for want in ./usr/bin/bugwarden ./etc/bugwarden/policy.toml \
+                      ./etc/bugwarden/audit.toml ./usr/share/man/man1/bugwarden.1.gz; do
+            grep -qxF "$want" <<<"$debfiles" \
+              || { echo "::error::deb is missing $want"; exit 1; }
+          done
+
+          # /etc/bugwarden is rpm-owned, so erasing the package does not orphan
+          # it. dpkg tracks its own directories and needs no equivalent.
+          rpm -qp --qf '[%{FILENAMES}|%{FILEMODES:octal}\n]' "$rpm" \
+            | grep -qxF '/etc/bugwarden|40755' \
+            || { echo "::error::rpm does not own /etc/bugwarden"; exit 1; }
+
+          # I1: the shipped policy must not be loaded implicitly. A package that
+          # made /etc/bugwarden/policy.toml take effect on install would hand
+          # every fresh install a policy nobody chose.
+          test "$(rpm -qp --qf '%{PREIN}%{POSTIN}%{PREUN}%{POSTUN}' "$rpm")" = "(none)(none)(none)(none)" \
+            || { echo "::error::rpm gained a scriptlet"; exit 1; }
+
+      - name: Collect packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir dist
+          cp target/debian/*.deb target/generate-rpm/*.rpm dist/
+          cd dist
+          # A release asset name is rewritten by GitHub to [A-Za-z0-9._-], which
+          # a pre-release deb's '~' trips. Rename first, so the .sha256 does not
+          # end up naming a file that never arrives.
+          for f in *.deb *.rpm; do
+            safe="$(printf '%s' "$f" | tr -c 'A-Za-z0-9._-' '.')"
+            [ "$safe" = "$f" ] || mv -- "$f" "$safe"
+          done
+          for f in *.deb *.rpm; do
+            sha256sum "$f" >"${f}.sha256"
+          done
+          ls -l
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: packages
+          path: dist/*
+          if-no-files-found: error
+
   release:
-    # Publish only after every platform built successfully, so a release never
-    # ships a partial artifact set.
-    needs: build
+    # Publish only after every tarball AND both distro packages are built and
+    # checked, so a release never ships a partial artifact set. That does mean a
+    # packaging fault now blocks the crates.io publish and the container image.
+    needs: [build, package]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,15 +153,39 @@ are never a justification for undoing them.
 
 A release is one push of an annotated tag; nothing is released by hand.
 
-- The tag is the bare version, no `v` prefix (`0.1.0`, `0.2.0rc1`), and must
-  equal `[workspace.package] version` — the workflow refuses to build a tag
-  that disagrees with the manifest. Bump the version in a normal PR first,
-  then tag the merge commit on `main`.
+- The tag is the bare version, no `v` prefix (`0.1.0`, `0.2.0-rc.1`; a
+  pre-release must be hyphenated semver, Cargo rejects `0.2.0rc1`), and
+  must equal `[workspace.package] version` — the workflow refuses to build
+  a tag that disagrees with the manifest. Bump the version in a normal PR
+  first, then tag the merge commit on `main`.
 - `.github/workflows/release.yml` then does everything: hermetic builds for
-  x86_64-unknown-linux-gnu and aarch64-apple-darwin, a GitHub release with
-  both tarballs and their `.sha256` files, and finally the crates.io publish
-  — `bugwarden-core` before `bugwarden`, because the binary crate resolves
-  its dependency from the index and cannot be packaged before core is there.
+  x86_64-unknown-linux-gnu and aarch64-apple-darwin, an x86_64 `.deb` and
+  `.rpm`, a GitHub release with all of those and their `.sha256` files, and
+  finally the crates.io publish — `bugwarden-core` before `bugwarden`,
+  because the binary crate resolves its dependency from the index and cannot
+  be packaged before core is there.
+- The `.deb`/`.rpm` come from `cargo-deb` and `cargo-generate-rpm`, both
+  pinned to an exact version and installed `--locked`, reading
+  `[package.metadata.deb]` / `[package.metadata.generate-rpm]` in
+  `crates/bugwarden/Cargo.toml`. That layout deliberately mirrors the
+  openSUSE spec in `devel:tools` — same binary, config, man and completion
+  paths, same two example configs under `/etc/bugwarden/` marked noreplace
+  in all three — so the packagings do not disagree about where a file
+  lives. Two documented exceptions: the spec's `%doc` resolves to
+  `/usr/share/doc/packages/bugwarden` on SUSE while these use the
+  Fedora/Debian `/usr/share/doc/bugwarden`, and cargo-generate-rpm 0.16.1
+  cannot emit rpm's `%license` flag. A new installed file is added to both
+  metadata blocks AND to the spec. x86_64 only: OBS builds every tier-1
+  arch from the source tarball, so these cover the distributions OBS does
+  not, rather than replacing it.
+- Two cargo-generate-rpm traps the workflow works around, both of which
+  fail silently if reintroduced: `auto-req` must be passed on the CLI,
+  because in metadata every value but `no`/`disabled` is discarded; and the
+  RPM `Version` is overridden with the `-`→`~` form of the tag, because RPM
+  forbids `-` there and, unlike cargo-deb, cargo-generate-rpm will not
+  convert it — leaving a pre-release that sorts *newer* than its own GA.
+  The `package` job re-checks both, plus dependency discovery and the asset
+  list, before `release` may run.
 - Publishing uses crates.io Trusted Publishing over the workflow's OIDC
   token, so the repository stores no registry credential. Both crates must
   have this repository, workflow `release.yml`, and no environment

--- a/README.md
+++ b/README.md
@@ -133,6 +133,30 @@ one is named via `--policy` / `BUGWARDEN_POLICY`, and an audit configuration
 only via `--audit-config` / `BUGWARDEN_AUDIT_CONFIG`, so installing the
 package does not by itself activate anything.
 
+### .deb / .rpm from the release page
+
+Every [release](https://github.com/plusky/bugwarden/releases) carries an
+x86_64 `.deb` and `.rpm` next to the tarballs, each with a `.sha256`:
+
+```bash
+sudo apt install ./bugwarden_<version>-1_amd64.deb   # Debian, Ubuntu
+sudo dnf install ./bugwarden-<version>-1.x86_64.rpm  # Fedora, RHEL
+```
+
+`apt`/`dnf` rather than `dpkg -i`/`rpm -i` because neither of the latter
+resolves dependencies. Both packages are built on current Ubuntu and link
+the system glibc, so they need a comparably recent one (2.38+ as of
+writing; the package's own `Depends`/`Requires` is authoritative). On an
+older enterprise base such as RHEL 9 or Debian 12 the install will refuse
+— use the container image or build from source there.
+
+Same layout as the openSUSE package above, including both
+`/etc/bugwarden/*.toml` example configs marked noreplace — so an upgrade
+keeps local edits, and installing still activates nothing on its own. On
+openSUSE prefer the OBS package: these two are x86_64 only and would
+conflict with its completion subpackages, while OBS covers every tier-1
+architecture.
+
 ### Container image
 
 ```bash

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -96,3 +96,82 @@ tokio = { version = "1", features = [
     "time",
 ] }
 wiremock = "0.6"
+
+# Distribution packages for the GitHub release (x86_64 Linux only, matching
+# the only Linux tarball target). Layout mirrors the openSUSE spec in
+# devel:tools so the two packagings do not disagree about where things go;
+# the completions are NOT split into subpackages here, which neither tool
+# can express.
+#
+# Neither example config is read implicitly — the server loads a policy only
+# via --policy / BUGWARDEN_POLICY and an audit config only via
+# --audit-config / BUGWARDEN_AUDIT_CONFIG — so installing a package activates
+# nothing. Both are conffiles: an operator's edits survive an upgrade.
+
+[package.metadata.deb]
+maintainer = "Martin Pluskal <martin@pluskal.org>"
+copyright = "2026 Martin Pluskal"
+license-file = ["LICENSE", "0"]
+extended-description = """\
+bugwarden exposes Bugzilla to MCP (Model Context Protocol) clients through a \
+guard policy that the client can neither read nor change. The policy is a \
+TOML file read once at startup and decides, per bug, which capabilities a \
+client is granted, so an operator can expose a Bugzilla instance to an LLM \
+client while keeping undisclosed security bugs, private comments and write \
+access out of reach."""
+section = "utils"
+priority = "optional"
+assets = [
+    ["target/release/bugwarden", "usr/bin/", "755"],
+    ["../../examples/policy.toml", "etc/bugwarden/policy.toml", "644"],
+    ["../../examples/audit.toml", "etc/bugwarden/audit.toml", "644"],
+    ["man/bugwarden.1", "usr/share/man/man1/", "644"],
+    ["completions/bugwarden.bash", "usr/share/bash-completion/completions/bugwarden", "644"],
+    ["completions/_bugwarden", "usr/share/zsh/site-functions/_bugwarden", "644"],
+    ["completions/bugwarden.fish", "usr/share/fish/vendor_completions.d/bugwarden.fish", "644"],
+    ["README.md", "usr/share/doc/bugwarden/README.md", "644"],
+    ["../../docs/DESIGN.md", "usr/share/doc/bugwarden/DESIGN.md", "644"],
+]
+conf-files = ["/etc/bugwarden/policy.toml", "/etc/bugwarden/audit.toml"]
+
+[package.metadata.generate-rpm]
+summary = "MCP server for Bugzilla with operator-controlled security guards"
+description = """\
+bugwarden exposes Bugzilla to MCP (Model Context Protocol) clients through a \
+guard policy that the client can neither read nor change. The policy is a \
+TOML file read once at startup and decides, per bug, which capabilities a \
+client is granted, so an operator can expose a Bugzilla instance to an LLM \
+client while keeping undisclosed security bugs, private comments and write \
+access out of reach."""
+# NOTE: there is deliberately no `auto-req` key here. cargo-generate-rpm 0.16.1
+# honours only "no"/"disabled" in metadata and silently discards every other
+# value, so `auto-req = "builtin"` would be indistinguishable from a typo and
+# the dependency set would fall back to whatever find-requires the runner
+# happens to have. The workflow passes --auto-req builtin on the CLI instead,
+# where an unrecognised value is a hard error.
+# Sources resolve CWD-first, manifest-dir second (unlike cargo-deb, which is
+# manifest-relative only), so these paths assume CWD == workspace root.
+# LICENSE and README.md here are the workspace-root files; the crate-level ones
+# are symlinks to them, so either resolution order yields the same bytes.
+assets = [
+    { source = "target/release/bugwarden", dest = "/usr/bin/bugwarden", mode = "755" },
+    # rpm owns the directories it creates, matching %dir in the openSUSE spec;
+    # without these, erasing the package orphans them. 40755 = S_IFDIR | 0755,
+    # and the type bits are what make it a directory entry. `source` is ignored
+    # for those but must still name a readable regular file, hence the reuse.
+    { source = "../../examples/policy.toml", dest = "/etc/bugwarden", mode = "40755" },
+    { source = "../../examples/policy.toml", dest = "/usr/share/doc/bugwarden", mode = "40755" },
+    { source = "../../examples/policy.toml", dest = "/usr/share/licenses/bugwarden", mode = "40755" },
+    { source = "../../examples/policy.toml", dest = "/etc/bugwarden/policy.toml", mode = "644", config = "noreplace" },
+    { source = "../../examples/audit.toml", dest = "/etc/bugwarden/audit.toml", mode = "644", config = "noreplace" },
+    { source = "man/bugwarden.1", dest = "/usr/share/man/man1/bugwarden.1", mode = "644", doc = true },
+    { source = "completions/bugwarden.bash", dest = "/usr/share/bash-completion/completions/bugwarden", mode = "644" },
+    { source = "completions/_bugwarden", dest = "/usr/share/zsh/site-functions/_bugwarden", mode = "644" },
+    { source = "completions/bugwarden.fish", dest = "/usr/share/fish/vendor_completions.d/bugwarden.fish", mode = "644" },
+    # doc, not rpm's %license flag: 0.16.1 cannot emit the latter, so
+    # `rpm --excludedocs` drops the licence text. Path is still the one rpm
+    # expects, so a future version only has to change the flag.
+    { source = "LICENSE", dest = "/usr/share/licenses/bugwarden/LICENSE", mode = "644", doc = true },
+    { source = "README.md", dest = "/usr/share/doc/bugwarden/README.md", mode = "644", doc = true },
+    { source = "../../docs/DESIGN.md", dest = "/usr/share/doc/bugwarden/DESIGN.md", mode = "644", doc = true },
+]


### PR DESCRIPTION
## What

Adds a `package` job to `release.yml` that builds an x86_64 `.deb` and `.rpm`
with `cargo-deb` and `cargo-generate-rpm`, checks them, and uploads them
alongside the existing tarballs. `release` now needs `[build, package]`.

Installed layout mirrors the openSUSE spec in `devel:tools` — same binary,
config, man and completion paths, both example configs under `/etc/bugwarden`
marked noreplace. Neither config is read implicitly, so installing activates
nothing. x86_64 only: OBS already builds every tier-1 arch from the source
tarball, so this covers the distributions OBS does not.

## Why not just the tarballs

Anyone outside OBS's reach had to unpack a tarball by hand and place the man
page, completions and example configs themselves.

## Adversarial review

Reviewed against `docs/DESIGN.md` before opening. No guard, policy, client or
server code is touched — this is workflow plus packaging metadata plus docs —
so no invariant changes behaviour. The one invariant in scope is **I1** (policy
comes only from the operator, at startup): the packages ship `policy.toml` as an
inert example, nothing reads it implicitly, and the check step asserts the RPM
carries no scriptlets, so an install cannot start activating one.

Findings addressed:

1. **`auto-req = "builtin"` in `Cargo.toml` was a silent no-op.**
   cargo-generate-rpm 0.16.1 honours only `no`/`disabled` in metadata and
   discards everything else, so it was indistinguishable from a typo — verified
   locally: metadata `builtin`, `bogus-value` and the default all produce the
   identical 10 `libc.so.6` requires. The dependency set would have been decided
   by whichever `find-requires` the runner happened to have. Moved to
   `--auto-req builtin` on the CLI, where an unrecognised value exits 1.
2. **A valid pre-release tag produced a poisoned RPM.** `0.5.0-rc.1` is legal
   semver, passes the tag/manifest check, and cargo-generate-rpm wrote the
   hyphen straight into the RPM `Version` — illegal there, and
   `rpmdev-vercmp` confirms `0:0.5.0-rc.1-1 > 0:0.5.0-1`, so an rc install would
   never be offered the GA. cargo-deb does the `~` conversion itself; the
   workflow now does it for the RPM. Verified end-to-end: `V=0.5.0~rc.1`,
   `labelCompare` = -1.
3. **The RPM owned no directories**, orphaning `/etc/bugwarden` on erase where
   the spec has `%dir`. Added `S_IFDIR` asset entries; asserted in the check
   step. dpkg tracks its own directories and needs no equivalent.
4. **The job's first run would have been a tag push.** Added a check step
   between build and upload — libc dependency present, expected files present,
   directory ownership, no scriptlets — so a silent packaging regression costs a
   tag rather than shipping. While writing it I caught a real bug in my own
   assertion: cargo-deb gzips the man page to `bugwarden.1.gz` and
   cargo-generate-rpm does not, so a shared file list would have failed every
   release. The two lists are now separate and commented.
5. **README overstated coverage.** `dpkg -i`/`rpm -i` do not resolve
   dependencies; switched to `apt install ./…`/`dnf install ./…`, added the
   glibc floor, and pointed openSUSE at OBS (these would file-conflict with its
   completion subpackages).
6. **"Same paths" was not literally true.** The spec's `%doc` resolves to
   `/usr/share/doc/packages/bugwarden` on SUSE; these use the Fedora/Debian
   `/usr/share/doc/bugwarden`. Recorded in AGENTS.md as a known divergence
   rather than papered over.

Accepted, not fixed:

- **`cargo-deb`'s dependency tree is not covered by `cargo deny`.** Both tools
  are version-pinned and `--locked`, and crates.io versions are immutable and
  checksummed, so this is effectively content-pinning — consistent with how the
  repo SHA-pins actions. But `deny.toml` only sees the workspace graph.
- **No PR-time packaging leg.** Adding one to `ci.yml` is a separate concern.
  The failure mode is bounded: `release` needs `package`, so a fault costs a
  version number and a fix-forward, never a bad artifact.
- **`%license` cannot be expressed** by cargo-generate-rpm 0.16.1, so the
  licence is flagged `doc` and `rpm --excludedocs` drops it. Path is already the
  one rpm expects; noted in a comment so it is not read as an oversight.

Also corrected: AGENTS.md gave `0.2.0rc1` as an example pre-release tag, which
Cargo refuses to parse — the hyphenated form is the only one that can occur,
which is exactly the case finding 2 covers.

## Verification

All five commands pass on the single commit (no Rust changed; `Cargo.lock`
untouched). `typos` clean. Both packages built locally and inspected: assets
byte-identical to their sources, `conffiles` and `FILEFLAGS 17` on both tomls,
identical stripped binary in each. Every assertion in the new check step was run
against the real packages (the `dpkg-deb` Depends check excepted — no dpkg on
this host; it fails closed if the runner lacks `dpkg-shlibdeps`). Pre-release
path dry-run end-to-end, including the asset-name sanitisation and
`sha256sum -c`.
