### PR TITLE
feat(audit): record response_bytes in the tool_call outcome

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,8 +863,23 @@ Every record carries `v`, a millisecond-precision UTC `ts`, a per-process
 monotonic `seq` (the ordering authority — file order equals `seq` order),
 and a `session` naming the transport, the session id and, over http, the
 peer address. A `tool_call` adds the client, the request (tool name, request
-id, parameters), the outcome class and duration, and — for the tools that
-consult the guard — a `guard` object:
+id, parameters), the `outcome` — class, duration and, when there was a
+result to measure, `response_bytes`: the serialized size of the content
+the server produced — the compact JSON of the result's content array,
+block framing included, so more than the length of the text inside it and
+independent of the negotiated protocol revision. It is absent, never zero,
+where no result exists (a protocol error, or a call the pre-dispatch audit
+gate turned away before building its refusal), so an operator aggregating
+payload size per tool does not average errors in. It measures the payload
+and the verdict does not bound it: `denied` is the *worst* verdict of a
+call, not a claim that nothing was served, so a multi-bug read with one
+denied id records `denied` over an envelope holding the bugs it did serve.
+Only where the whole response is a single uniform denial does the size
+reduce to a function of the id the caller asked about. Produced, not
+necessarily delivered: an audit failure after the record was written can
+swap the response for a refusal, and the record keeps describing the call
+rather than the wire — the same caveat `class` and `verdict` carry. And — for the
+tools that consult the guard — a `guard` object:
 
 | `guard` field | Meaning |
 |---------------|---------|
@@ -887,8 +902,11 @@ Bugzilla-side timings; nothing emits it yet, so do not build on it.
 
 The schema is closed — fixed structs, fixed vocabularies — and it has no
 field for the Bugzilla API key, for request headers, or for free-text bug
-content. Nothing fetched *from* Bugzilla is written: a tool result is not a
-parameter. The one open field is the request's `params`, and it is fed
+content. No *content* fetched from Bugzilla is written: a tool result is
+not a parameter. The one thing a record says about a result is its size —
+`outcome.response_bytes`, a byte count and never a byte — which is the
+same presence-and-size treatment `params` gives a blob. The one open field
+is the request's `params`, and it is fed
 through an allowlist of client-authored keys: allowlisted values are
 recorded verbatim (strings truncated at 1024 characters), and every other
 parameter — `comment`, `summary`, `description`, `url`, `whiteboard`,
@@ -896,7 +914,7 @@ parameter — `comment`, `summary`, `description`, `url`, `whiteboard`,
 presence and size but never its content.
 
 ```json
-{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":7,"session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"event":"tool_call","client":{"name":"example-agent","version":"1.4.2"},"request":{"tool":"bugs_quicksearch","id":"3","params":{"limit":50,"offset":0,"query":"kernel panic","status":"ALL"}},"guard":{"verdict":"served_filtered","policy_hash":"sha256:58013baa090cf77630373ab50cc5eaf2d679ec5a06e8a336600fc89b23bb8604","suppressed_count":2,"suppressed_ids":[1290040,1290041],"redacted_fields":[],"scan":{"scanned":50,"dropped":2}},"outcome":{"class":"ok","duration_ms":52}}
+{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":7,"session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"event":"tool_call","client":{"name":"example-agent","version":"1.4.2"},"request":{"tool":"bugs_quicksearch","id":"3","params":{"limit":50,"offset":0,"query":"kernel panic","status":"ALL"}},"guard":{"verdict":"served_filtered","policy_hash":"sha256:58013baa090cf77630373ab50cc5eaf2d679ec5a06e8a336600fc89b23bb8604","suppressed_count":2,"suppressed_ids":[1290040,1290041],"redacted_fields":[],"scan":{"scanned":50,"dropped":2}},"outcome":{"class":"ok","duration_ms":52,"response_bytes":6218}}
 ```
 
 A reader of the file should skip empty lines and tolerate at most one
@@ -935,7 +953,9 @@ What goes over the wire:
   sink — so nothing extra is added.
   Attributes lift the fields worth querying on out of the body:
   `bugwarden.event`, `.seq`, `.transport`, `.session.id` and, on a tool
-  call, `.tool`, `.verdict` and `.rule`. The record's `trace_id` and
+  call, `.tool`, `.verdict`, `.rule` and `.response_bytes` — the last
+  absent, never zero, on a call that produced nothing to measure, so a
+  size aggregation does not average errors in. The record's `trace_id` and
   `span_id` are the ones the client sent in its `traceparent`, so a guard
   decision joins the client trace that caused it. Severity follows the
   record *kind*: `audit_gap` is an error, everything else is info — the

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -741,6 +741,28 @@ pub struct OutcomeInfo {
     pub class: OutcomeClass,
     /// Total request handling time, in milliseconds.
     pub duration_ms: u64,
+    /// Serialized size of the payload the server produced, in bytes: the
+    /// compact JSON of the result's content array, not just the text it
+    /// carries and not the enclosing result object, whose `resultType`
+    /// depends on the negotiated revision (issue #145). Absent when no
+    /// result exists to measure — a protocol error, or a refusal the audit
+    /// gate records before it is built.
+    ///
+    /// Produced, not necessarily delivered: a record whose write survived
+    /// but whose `record_event` still failed can be followed by a fail-mode
+    /// swap, leaving this sizing a payload the client never received.
+    /// [`OutcomeInfo::class`] and [`GuardInfo::verdict`] have the same
+    /// property; the record describes the call, not the wire.
+    ///
+    /// It sizes the PAYLOAD, and the verdict does not bound it. `denied` is
+    /// the *worst* verdict of the call, not a claim that nothing was
+    /// served: a multi-bug `bug_info` with one denied id records `denied`
+    /// over an envelope carrying the bugs it did serve, so that record's
+    /// size tracks those bodies. Only where the whole payload is one
+    /// uniform denial does the size reduce to a function of the caller's
+    /// own id width. Reading this as "how big was the refusal" is wrong.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_bytes: Option<u64>,
 }
 
 /// Coarse outcome of a tool call. Note that a guard denial is `ok` here:
@@ -1717,6 +1739,7 @@ mod tests {
             outcome: OutcomeInfo {
                 class: OutcomeClass::Ok,
                 duration_ms: 52,
+                response_bytes: Some(1462),
             },
         }))
     }
@@ -1819,6 +1842,23 @@ mod tests {
         r#""suppressed_count":2,"suppressed_ids":[1290040,1290041],"redacted_fields":["cc","flags"],"#,
         r#""scan":{"scanned":200,"dropped":2}},"#,
         r#""upstream":{"requests":1,"status":200,"latency_ms":48},"#,
+        r#""outcome":{"class":"ok","duration_ms":52,"response_bytes":1462}}"#,
+    );
+
+    /// [`GOLDEN_TOOL_CALL`] as records looked before `outcome.response_bytes`
+    /// existed (issue #145) — byte-identical to the golden before that field,
+    /// same additive-optional shape as the pre-#29 pin below.
+    const GOLDEN_TOOL_CALL_PRE_RESPONSE_BYTES: &str = concat!(
+        r#"{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":7,"#,
+        r#""session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"#,
+        r#""event":"tool_call","#,
+        r#""client":{"name":"example-agent","version":"1.4.2","principal":"alice@example.org"},"#,
+        r#""trace":{"trace_id":"0af7651916cd43dd8448eb211c80319c","span_id":"b7ad6b7169203331"},"#,
+        r#""request":{"tool":"bug_info","id":"3","params":{"id":1290042,"include_private":false}},"#,
+        r#""guard":{"verdict":"served_filtered","rule":"group-restricted","policy_hash":"2b6e8f5d1c9a4e70","#,
+        r#""suppressed_count":2,"suppressed_ids":[1290040,1290041],"redacted_fields":["cc","flags"],"#,
+        r#""scan":{"scanned":200,"dropped":2}},"#,
+        r#""upstream":{"requests":1,"status":200,"latency_ms":48},"#,
         r#""outcome":{"class":"ok","duration_ms":52}}"#,
     );
 
@@ -1865,6 +1905,20 @@ mod tests {
     fn golden_audit_gap_json() {
         let event = envelope(9, session_stdio(), sample_gap());
         assert_eq!(serde_json::to_string(&event).unwrap(), GOLDEN_AUDIT_GAP);
+    }
+
+    #[test]
+    fn tool_call_line_without_response_bytes_still_deserializes() {
+        // A pre-#145 record has no `outcome.response_bytes` bytes at all;
+        // it must parse with the size simply unknown, not defaulted to 0 —
+        // "not measured" and "measured as empty" are different facts.
+        let event: AuditEvent = serde_json::from_str(GOLDEN_TOOL_CALL_PRE_RESPONSE_BYTES)
+            .expect("an old line must parse");
+        let AuditEventKind::ToolCall(tc) = &event.kind else {
+            panic!("expected a tool_call event");
+        };
+        assert_eq!(tc.outcome.response_bytes, None, "absent means unknown");
+        assert_eq!(tc.outcome.duration_ms, 52, "the rest is read unchanged");
     }
 
     #[test]

--- a/crates/bugwarden/src/otel.rs
+++ b/crates/bugwarden/src/otel.rs
@@ -502,7 +502,7 @@ fn now_unix_nano() -> u64 {
 /// newline; it becomes the record body unchanged (I12: the exported
 /// payload carries exactly what the file carries).
 fn audit_entry(event: &AuditEvent, line: &[u8]) -> LogEntry {
-    let mut attrs: Vec<(&'static str, AttrValue)> = Vec::with_capacity(8);
+    let mut attrs: Vec<(&'static str, AttrValue)> = Vec::with_capacity(10);
     attrs.push(("bugwarden.stream", AttrValue::Str("audit".to_owned())));
     let (kind, severity) = match &event.kind {
         AuditEventKind::ToolCall(_) => ("tool_call", Severity::Info),
@@ -539,6 +539,15 @@ fn audit_entry(event: &AuditEvent, line: &[u8]) -> LogEntry {
             if let Some(rule) = &guard.rule {
                 attrs.push(("bugwarden.rule", AttrValue::Str(rule.clone())));
             }
+        }
+        // Projected out of the body so a collector can aggregate response
+        // size per tool without parsing every record (issue #145). Left off
+        // when the record carries no size, rather than exported as zero.
+        if let Some(bytes) = call.outcome.response_bytes {
+            attrs.push((
+                "bugwarden.response_bytes",
+                AttrValue::Int(i64::try_from(bytes).unwrap_or(i64::MAX)),
+            ));
         }
         // Correlation ids the client claimed; unauthenticated, exactly as
         // the audit record documents them. Anything that does not decode
@@ -1600,6 +1609,7 @@ mod tests {
             outcome: OutcomeInfo {
                 class: OutcomeClass::Ok,
                 duration_ms: 3,
+                response_bytes: Some(87),
             },
         }))
     }
@@ -1661,6 +1671,23 @@ mod tests {
             attr(&entry, "bugwarden.rule"),
             Some(&AttrValue::Str("embargo".to_owned()))
         );
+        assert_eq!(
+            attr(&entry, "bugwarden.response_bytes"),
+            Some(&AttrValue::Int(87))
+        );
+    }
+
+    #[test]
+    fn an_unmeasured_response_exports_no_size_attribute() {
+        // Absent, not zero: a collector averaging response size must not
+        // see a refusal the gate never sized pulled into the mean.
+        let mut kind = tool_call(None);
+        let AuditEventKind::ToolCall(call) = &mut kind else {
+            unreachable!()
+        };
+        call.outcome.response_bytes = None;
+        let entry = audit_entry(&event(kind), b"{}");
+        assert_eq!(attr(&entry, "bugwarden.response_bytes"), None);
     }
 
     #[test]

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -483,6 +483,60 @@ fn elapsed_ms(started: Instant) -> u64 {
     u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
 }
 
+/// A `Write` that keeps the length and throws the bytes away.
+///
+/// `download_attachment` can serialize megabytes here, on the async worker,
+/// purely to be measured — buffering that would be a multi-MB alloc and copy
+/// per call for a number.
+struct ByteCounter(u64);
+
+impl std::io::Write for ByteCounter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0 += buf.len() as u64;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Serialized size of the payload the client is shown, in bytes (issue #145):
+/// the compact JSON of the result's `content` array — block framing included,
+/// so it is more than the length of the text inside.
+///
+/// The array, NOT the whole `CallToolResult`: `resultType` is cleared
+/// downstream for peers on an older revision, so sizing the enclosing object
+/// would make the number move with the negotiated protocol version instead of
+/// with the payload, and the point of the field is to compare payload sizes
+/// across calls. `isError` is excluded with it — a constant, carrying nothing.
+///
+/// `None` where there is nothing to measure: a protocol error is a JSON-RPC
+/// `error`, not a result, and the response variants this build does not serve
+/// carry no completed result at all. Also `None` if serialization fails, which
+/// it cannot for a `ContentBlock` — no float, no non-string key — but an
+/// unmeasured record is the right answer if that ever changes.
+///
+/// Counts rather than buffers, so the cost is the serialize alone and no
+/// allocation, and it is paid only when auditing is on.
+fn response_bytes(result: &Result<CallToolResponse, McpError>) -> Option<u64> {
+    let Ok(CallToolResponse::Complete(complete)) = result else {
+        return None;
+    };
+    // Structured output would be part of the payload — and for a client that
+    // prefers it, the whole of it — so measuring `content` alone would
+    // under-report. Nothing returns `Json<T>` today; this is the tripwire for
+    // the first tool that does.
+    debug_assert!(
+        complete.structured_content.is_none(),
+        "response_bytes measures `content` only: teach it structuredContent first"
+    );
+    let mut counter = ByteCounter(0);
+    serde_json::to_writer(&mut counter, &complete.content)
+        .ok()
+        .map(|()| counter.0)
+}
+
 /// Persist one audit record without blocking the async worker: the sink
 /// is synchronous by design (that is what makes "persisted before the
 /// response is returned" a guarantee), so the write moves to the blocking
@@ -3966,6 +4020,8 @@ impl ServerHandler for BugWarden {
                     outcome: audit::OutcomeInfo {
                         class: audit::OutcomeClass::Error,
                         duration_ms: elapsed_ms(started),
+                        // A protocol error, so no result to size.
+                        response_bytes: None,
                     },
                 }));
                 let session = self.session_info(&context, &audit);
@@ -4060,6 +4116,10 @@ impl ServerHandler for BugWarden {
                 outcome: audit::OutcomeInfo {
                     class: audit::OutcomeClass::Refused,
                     duration_ms: elapsed_ms(started),
+                    // The refusal is built below, after this record: the
+                    // gate must not spend a serialization to size a text
+                    // whose length is fixed by `audit_refusal` anyway.
+                    response_bytes: None,
                 },
             }));
             let _ = record_event(&audit, event, session).await;
@@ -4112,6 +4172,13 @@ impl ServerHandler for BugWarden {
             outcome: audit::OutcomeInfo {
                 class,
                 duration_ms: elapsed_ms(started),
+                // Sizes the DISPATCHED result. A record that persisted but
+                // whose `record_event` still failed (fsync, or an export
+                // refusal after the file write) can be followed by a
+                // fail-mode arm below swapping the response for a refusal,
+                // leaving this describing the result the client did not
+                // get — exactly as `class` above already does.
+                response_bytes: response_bytes(&result),
             },
         }));
         match record_event(&audit, event, session).await {

--- a/crates/bugwarden/tests/audit_wiremock.rs
+++ b/crates/bugwarden/tests/audit_wiremock.rs
@@ -2108,3 +2108,217 @@ async fn bug_comments_window_with_nothing_omitted_records_no_redaction() {
         "nothing omitted, nothing capped: no redaction is recorded: {guard:?}"
     );
 }
+
+// ---------- outcome.response_bytes (issue #145) ----------
+
+/// Serialized length of the content the client actually received.
+///
+/// Computed from the client's own view of the result, so the assertion is
+/// end to end: if `response_bytes` were measured off anything but the
+/// payload that reached the client, this would not match. Deliberately
+/// sizes `content` alone — the enclosing `CallToolResult` carries
+/// `resultType`, which the SDK clears per negotiated revision.
+fn content_len(result: &CallToolResult) -> u64 {
+    serde_json::to_vec(&result.content)
+        .expect("served content must serialize")
+        .len() as u64
+}
+
+#[tokio::test]
+async fn response_bytes_is_the_served_payload_length() {
+    let mock = MockServer::start().await;
+    mount_fixture(&mock).await;
+    let audited = audited_client_for("", &mock, "test-key").await;
+
+    let result = call(&audited.client, "bug_info", json!({ "bug_ids": [7] })).await;
+    assert_ne!(result.is_error, Some(true), "bug 7 is served");
+
+    let events = read_events(&audited.audit_path);
+    let tc = last_tool_call(&events);
+    assert_eq!(
+        tc.outcome.response_bytes,
+        Some(content_len(&result)),
+        "the record sizes the content the client received"
+    );
+    // Block framing is real: the array is strictly larger than the text
+    // it wraps, so this is not silently measuring the text alone.
+    let text = match result.content.first() {
+        Some(block) => block.as_text().expect("one text block").text.clone(),
+        None => panic!("a served bug_info carries content"),
+    };
+    let bytes = tc.outcome.response_bytes.expect("measured");
+    assert!(
+        bytes > text.len() as u64,
+        "{bytes} must exceed the {} bytes of text it wraps",
+        text.len()
+    );
+}
+
+#[tokio::test]
+async fn a_wholly_denied_call_is_sized_by_its_id_width_and_nothing_else() {
+    // WHOLLY denied — the qualifier is the point. `denied` is the WORST
+    // verdict of a call, not a claim that nothing was served, so this
+    // property holds only where the entire payload is the uniform denial
+    // (contrast `a_partial_denial_is_sized_by_what_was_served`).
+    //
+    // Where it does hold: the denial text (I2) interpolates the id the
+    // CALLER asked for — `Bug {id} is not accessible through this server`
+    // — so its length is fixed by that id's decimal width and by nothing
+    // about the bug. Both halves are pinned: two same-width ids over
+    // wildly different upstream bugs must size identically (nothing about
+    // the bug leaks into the size), and a wider id must cost exactly the
+    // extra digits (nothing else varies). The id itself is not a
+    // disclosure — the caller supplied it and `request.params` already
+    // records it verbatim — and the stream reaches no MCP surface (I15).
+    let policy = concat!(
+        "[[rule]]\nname = \"hide-secret\"\naction = \"deny\"\n",
+        "[rule.match]\nproducts = [\"Secret*\"]\n",
+    );
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .mount(&mock)
+        .await;
+    // 7 and 8 are the same width; 4242424 is six digits wider. Bug 8 is
+    // deliberately bulky where bug 7 is minimal.
+    for id in [7_u64, 8, 4_242_424] {
+        let mut secret = world_bug(id);
+        secret["product"] = json!("SecretSauce");
+        if id == 8 {
+            secret["summary"] = json!("x".repeat(4096));
+            secret["whiteboard"] = json!("y".repeat(512));
+            secret["keywords"] = json!(["alpha", "beta", "gamma"]);
+        }
+        Mock::given(method("GET"))
+            .and(path("/rest/bug"))
+            .and(query_param("id", id.to_string()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [secret] })))
+            .mount(&mock)
+            .await;
+    }
+    let audited = audited_client_for(policy, &mock, "test-key").await;
+
+    let mut sizes = Vec::new();
+    for id in [7_u64, 8, 4_242_424] {
+        let denied = call(&audited.client, "bug_history", json!({ "id": id })).await;
+        assert_eq!(denied.is_error, Some(true), "bug {id} is denied");
+        let events = read_events(&audited.audit_path);
+        let tc = last_tool_call(&events);
+        assert_eq!(
+            tc.guard.as_ref().expect("the guard ran").verdict,
+            Verdict::Denied
+        );
+        let bytes = tc
+            .outcome
+            .response_bytes
+            .expect("a denial is still content");
+        assert_eq!(
+            bytes,
+            content_len(&denied),
+            "a denial is sized like any other served content"
+        );
+        sizes.push(bytes);
+    }
+    assert_eq!(
+        sizes[0], sizes[1],
+        "a 4KiB bug and a minimal one deny at the same size: the bug does not \
+         reach the denial"
+    );
+    assert_eq!(
+        sizes[2] - sizes[0],
+        6,
+        "4242424 is six digits wider than 7, and that is the whole difference"
+    );
+}
+
+#[tokio::test]
+async fn a_partial_denial_is_sized_by_what_was_served() {
+    // The counterexample to reading `response_bytes` as "how big was the
+    // refusal". `bug_info` puts served bugs and denied ones in ONE
+    // envelope, and the record takes the WORST verdict of the call, so a
+    // record can read `denied` over a payload carrying a full bug body.
+    // Pinned because the field is easy to misread the other way: the size
+    // tracks the payload, and no verdict bounds it.
+    let policy = concat!(
+        "[[rule]]\nname = \"hide-secret\"\naction = \"deny\"\n",
+        "[rule.match]\nproducts = [\"Secret*\"]\n",
+    );
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "7"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [world_bug(7)] })))
+        .mount(&mock)
+        .await;
+    let mut secret = world_bug(8);
+    secret["product"] = json!("SecretSauce");
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "8"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [secret] })))
+        .mount(&mock)
+        .await;
+    let audited = audited_client_for(policy, &mock, "test-key").await;
+
+    let whole = call(&audited.client, "bug_info", json!({ "bug_ids": [8] })).await;
+    let events = read_events(&audited.audit_path);
+    let denied_only = last_tool_call(&events)
+        .outcome
+        .response_bytes
+        .expect("measured");
+    drop(whole);
+
+    let partial = call(&audited.client, "bug_info", json!({ "bug_ids": [7, 8] })).await;
+    assert_ne!(
+        partial.is_error,
+        Some(true),
+        "bug 7 is still served alongside the denial"
+    );
+    let events = read_events(&audited.audit_path);
+    let tc = last_tool_call(&events);
+    assert_eq!(
+        tc.guard.as_ref().expect("the guard ran").verdict,
+        Verdict::Denied,
+        "worst-wins: one denied id stamps the whole record"
+    );
+    let bytes = tc.outcome.response_bytes.expect("measured");
+    assert_eq!(
+        bytes,
+        content_len(&partial),
+        "the record sizes the envelope"
+    );
+    assert!(
+        bytes > denied_only,
+        "{bytes} carries bug 7's body on top of the same denial ({denied_only}): a \
+         `denied` record is not bounded by the refusal's width"
+    );
+}
+
+#[tokio::test]
+async fn a_protocol_error_records_no_response_size() {
+    // No result exists, so the field is absent rather than zero: an
+    // operator averaging payload size must not see errors pulled in.
+    let mock = MockServer::start().await;
+    mount_fixture(&mock).await;
+    let audited = audited_client_for("", &mock, "test-key").await;
+
+    let err = audited
+        .client
+        .call_tool(CallToolRequestParams::new("no_such_tool".to_string()))
+        .await
+        .expect_err("an unknown tool is a protocol error");
+    drop(err);
+
+    let events = read_events(&audited.audit_path);
+    let tc = last_tool_call(&events);
+    assert_eq!(tc.outcome.class, OutcomeClass::Error);
+    assert_eq!(tc.outcome.response_bytes, None, "absent, not zero");
+}

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -624,6 +624,9 @@ async fn a_handshake_free_call_is_refused_and_never_names_a_client() {
         calls[0].guard.is_none(),
         "the guard never ran, so no verdict may be recorded"
     );
+    // Nothing was dispatched, so there is no payload — absent, not zero, or
+    // a size aggregation averages in a call that returned nothing (#145).
+    assert_eq!(calls[0].outcome.response_bytes, None);
 }
 
 #[tokio::test]

--- a/crates/bugwarden/tests/otel_wiremock.rs
+++ b/crates/bugwarden/tests/otel_wiremock.rs
@@ -637,6 +637,27 @@ async fn a_mid_serve_collector_death_gates_uniformly_and_recovery_clears() {
             .any(|l| l.contains("\"event\":\"audit_gap\"") && l.contains("\"write_error\"")),
         "the undelivered window must be accounted in an audit_gap: {lines:?}"
     );
+
+    // The pre-dispatch gate's own records (issue #145). They are written
+    // before the refusal exists, so they carry no size — and this is the
+    // one path where such a record reaches the FILE, because the write
+    // succeeds and only the export refuses. Absent, never zero: a zero
+    // would drag every average over the gated window down.
+    let gated: Vec<_> = lines
+        .iter()
+        .filter(|l| l.contains("\"event\":\"tool_call\"") && l.contains("\"class\":\"refused\""))
+        .collect();
+    assert!(!gated.is_empty(), "the gated window is recorded: {lines:?}");
+    for line in gated {
+        // A substring test, and deliberately: it pins the WIRE shape, so it
+        // catches `response_bytes: Some(0)` at the gate site and a dropped
+        // `skip_serializing_if` (which would emit `"response_bytes":null`)
+        // alike. Rewriting it to parse the field would reopen the second.
+        assert!(
+            !line.contains("response_bytes"),
+            "a gate refusal has nothing to size: {line}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1208,6 +1208,46 @@ Decisions, all deliberate:
   are deliberately not stored: the schema has no field for either,
   `tracestate` is client free text, and `baggage` is unbounded client
   key/values — revisit under #34.
+- **Response size accounting (issue #145).** `outcome.response_bytes`
+  carries the serialized size of the result's `content` array, so the
+  operator stream can quantify a compression win — or a bloat
+  regression — per tool without reading payloads it must never hold. The
+  array, NOT the enclosing `CallToolResult`: the SDK clears `resultType`
+  for peers on an older revision, so sizing the object would make the
+  number move with the negotiated protocol version rather than with the
+  payload, and comparing sizes across calls is the entire point.
+  `Option<u64>`, absent rather than zero where nothing was produced — a
+  protocol error, and the pre-dispatch audit gate, which records its
+  refusal before building it and must not spend a serialization sizing a
+  fixed text. "Not measured" and "measured as empty" are different facts
+  and the reader must be able to tell them apart. Optional and
+  absent-when-unset, so the schema stays v1 (the #29 shape); pre-#145
+  lines are pinned as `GOLDEN_TOOL_CALL_PRE_RESPONSE_BYTES` and must keep
+  deserializing. Backward only: `deny_unknown_fields` means a reader built
+  before #145 REJECTS a post-#145 line outright, so "the schema stays v1"
+  buys old files new readers, not old readers new files — the issue's
+  "older readers ignore it" is wrong about this codebase's own parser.
+  THE ISSUE'S SAFETY PREMISE IS ALSO WRONG and the docs must not repeat
+  it. It claims "denial responses have constant size by construction". They
+  do not, on two counts. The uniform text interpolates the caller's id
+  (`Bug {id} is not accessible through this server`), so its length tracks
+  that id's decimal width — harmless, the id is the caller's own and
+  `request.params` already records it verbatim. More importantly the
+  verdict does not bound the payload at all: `denied` is the WORST verdict
+  of the call (worst-wins merge), so a multi-bug `bug_info` naming one
+  denied id records `denied` over an envelope holding the bugs it did
+  serve, and that record's size tracks those bodies. `download_attachment`
+  refuses in three different texts, whose lengths do not all agree. So the
+  honest statement is the simple one: the field sizes whatever was served,
+  and no verdict makes it constant. That is acceptable because it is a count and
+  never a byte of content, because the stream already carries
+  `suppressed_count`, `scan` and the ids, and because it reaches no MCP
+  surface (I15) — the response itself is byte-identical with the field on
+  or off (I3). It is, though, the first payload-derived value in the
+  stream, so a deployment shipping records to a lower-trust tier should
+  treat a size as it treats a count. Exported as the OTLP attribute
+  `bugwarden.response_bytes` beside the verdict, absent when unmeasured,
+  so a collector aggregates size per tool without parsing every body.
 - **Search-window drop accounting (issue #29).** A `bugs_quicksearch`
   record carries `guard.scan = {scanned, dropped}`: how many upstream rows
   the window scan examined and how many it dropped by verdict — without
@@ -2358,7 +2398,25 @@ wired, `server.rs` and `main.rs` are the reference.
   policy granting by NAME, and once beside an I5-dropped private comment,
   where the guard's own upgrade must clear the rule and the window beside
   it must not put it back. That pair pins the note ordering in the
-  handler as much as the notes themselves.
+  handler as much as the notes themselves. Response size accounting
+  (issue #145) is pinned on all four of its arms: a served `bug_info`
+  records exactly the length of the content the CLIENT received
+  (recomputed from the client's own copy, so measuring anything but the
+  served payload fails) and strictly more than the text inside it, so a
+  regression to the text alone or to the whole `CallToolResult` fails on
+  a byte count; a wholly denied call sizes by the caller's id width and
+  nothing else — two same-width ids over a 4 KiB bug and a minimal one
+  are EQUAL, a six-digit-wider id costs exactly six — while a partial
+  denial, verdict `denied` over an envelope that still carries a served
+  body, is strictly larger than the same denial alone, pinning that the
+  verdict does not bound the size; and the three unmeasured sites record
+  the field ABSENT rather than zero — the protocol error, the
+  handshake-skip refusal, and the pre-dispatch gate, whose line is
+  asserted not to contain the key at all, so `Some(0)` and a dropped
+  `skip_serializing_if` (a `null`) fail alike. On the export side the
+  attribute is asserted present as an Int and absent when the record
+  carries no size, and a pre-#145 line without `response_bytes`
+  deserializes with it `None` against the pinned pre-change golden.
 - Identity tests (#[cfg(test)] in crates/bugwarden/src/server.rs and
   crates/bugwarden-core/src/client.rs; crates/bugwarden/tests/
   http_transport_wiremock.rs, crates/bugwarden/tests/binary_user_agent.rs

--- a/examples/otel-collector.yaml
+++ b/examples/otel-collector.yaml
@@ -187,6 +187,12 @@ receivers:
         if: 'attributes?.guard?.rule != nil'
         from: attributes.guard.rule
         to: attributes["bugwarden.rule"]
+      # Absent on a call that produced nothing to measure, so a mean over
+      # this attribute is a mean over calls that returned something.
+      - type: move
+        if: 'attributes?.outcome?.response_bytes != nil'
+        from: attributes.outcome.response_bytes
+        to: attributes["bugwarden.response_bytes"]
 
       # The W3C ids the client stamped on the call (issue #28). Promoting
       # them to the record's own trace context is what makes a guard


### PR DESCRIPTION
Closes #145.

`outcome.response_bytes` — the serialized size of what a tool call
produced — plus the matching OTLP attribute, so an operator can quantify a
compression win or a bloat regression per tool without the audit stream
ever holding a payload.

## Two deliberate deviations from the issue text

**It sizes `content`, not the whole `CallToolResult`.** rmcp's
`strip_result_type_for_legacy_peer` clears `resultType` downstream of
`ServerHandler::call_tool` for any peer below the `2026-07-28` revision, so
sizing the enclosing object bolts on `"resultType":"complete",` — 24 bytes
that vanish depending on the negotiated version. The same payload would
then measure differently on two clients, which is exactly what the field
exists to compare. `isError` goes with it: a constant, carrying nothing.

**The issue's two premises are both false, and the docs say so instead of
repeating them.**

1. *"Denial responses have constant size by construction."* They are not.
   The uniform text interpolates the caller's id (`Bug {id} is not
   accessible through this server`), so its length tracks that id's decimal
   width — harmless, the id is the caller's own and `request.params`
   already records it verbatim. The bigger reason: `denied` is the *worst*
   verdict of a call, not a claim that nothing was served. A multi-bug
   `bug_info` naming one denied id records `denied` over an envelope
   holding the bugs it did serve, and the size tracks those bodies. The
   honest property — the field sizes whatever was served, and no verdict
   bounds it — is what README, DESIGN and the rustdoc now state, and it is
   pinned by `a_partial_denial_is_sized_by_what_was_served`.
2. *"Older readers ignore it."* Not this codebase's parser: `OutcomeInfo`
   carries `deny_unknown_fields`, so a pre-#145 reader **rejects** a
   post-#145 line. Staying at v1 buys old files new readers, not old
   readers new files. Noted in DESIGN.

## Coordination

#145 asks to land in step with #34 and #118 "rather than as three
independent schema edits". Overridden deliberately: this is purely
additive and spends no `SCHEMA_VERSION` revision (optional, absent when
unset, with the pre-change byte sequence pinned as
`GOLDEN_TOOL_CALL_PRE_RESPONSE_BYTES` and a test proving old lines still
deserialize), while #34 needs v2. Bundling would make a v1-compatible
change wait on a v2 one, against AGENTS.md's one-logical-change rule.

## Invariants

No MCP surface changes: the response is byte-identical with the field on
or off (I3), and the number reaches only the audit stream (I15). It is the
first payload-*derived* value in the stream, though — a count, never a
byte of content — so DESIGN records that a deployment shipping records to
a lower-trust tier should treat a size as it treats a count.

## Cost

Counted through a discarding `io::Write` rather than buffered. An audited
`download_attachment` would otherwise allocate and memcpy the whole
~2.8 MB base64 block on the async worker purely to be measured
(`max_attachment_bytes = 0` means no cap at all). Paid only when auditing
is on — the audit-off path early-returns before the helper.

## Adversarial review

Two independent reviews before this PR: one against the DESIGN.md
invariants, one against correctness. Both ran mutation testing.

Addressed:

- **The safety claim was still too strong** even after the id-width
  correction — partial denials and `download_attachment`'s three refusal
  texts both break it. Rewrote the claim in three places and added
  `a_partial_denial_is_sized_by_what_was_served`.
- **README's "nothing fetched from Bugzilla is written"** became false the
  moment a result-derived number entered the stream. Now: no *content* is
  written, and the one thing a record says about a result is its size.
- **DESIGN's "nothing new enters the stream"** overclaimed the same way;
  now states this is the first payload-derived value and why that is
  acceptable.
- **Three unmeasured sites had no coverage.** `Some(0)` at the
  pre-dispatch gate and at the handshake-skip site each survived the whole
  suite. Both are now pinned — the gate by a wire-shape substring
  assertion that also catches a dropped `skip_serializing_if` (which would
  emit `"response_bytes":null`), the handshake site in the http transport
  test that already had the record in hand.
- **`structured_content` is silently unmeasured.** Correct today (no tool
  returns `Json<T>`), silently wrong the first time one does. Now a
  `debug_assert!` tripwire.
- **The buffered `to_vec`** became the counting writer described above.
- **"the payload the client was shown"** was an unqualified client-facing
  claim the implementation site correctly qualifies: an audit failure
  after the record is written can swap the response for a refusal. Both
  the rustdoc and README now say *produced*, with the caveat `class` and
  `verdict` already carry.
- **DESIGN's "Testing" list** was not updated, breaking the #29 precedent
  this change models itself on. Added.
- Nits: dead `usize`→`u64` saturation removed, `Vec::with_capacity` bumped
  for the extra attribute, the unreachable-serialization-error case
  documented, the unpinned attachment-text length claim softened to what
  is actually true.

Not taken: projecting `outcome.class` and `duration_ms` as OTLP attributes
too. Real asymmetry, but beyond this issue — the body already carries them
verbatim, and widening the projection set is its own change.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D
warnings`, `cargo clippy -p bugwarden --features gen --all-targets -- -D
warnings`, `cargo test --workspace --all-targets --locked` (632 tests) and
`cargo deny check` all green.
