### PR TITLE
ci: save the cargo cache only on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,16 @@ jobs:
           toolchain: "1.98.0"
           components: rustfmt, clippy
       - name: Cache cargo
-        # Tag runs re-verify a release: keep them off restored build state;
-        # PR/main runs keep the cache.
+        # Tag runs re-verify a release: keep them off restored build state.
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           workspaces: . -> target
+          # A PR-written cache is invisible to main and evicts main's own by
+          # LRU once the repo is over quota; PRs restore main's entry either
+          # way, since nothing ref-specific enters the key. So: main writes,
+          # PRs only read.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Format
         run: cargo fmt --check
       - name: Clippy
@@ -67,12 +71,12 @@ jobs:
           toolchain: "1.98.0"
           components: clippy
       - name: Cache cargo
-        # Tag runs re-verify a release: keep them off restored build state;
-        # PR/main runs keep the cache.
+        # Tag runs re-verify a release: keep them off restored build state.
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           workspaces: . -> target
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Clippy
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - name: Test
@@ -99,6 +103,12 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           workspaces: . -> target
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # This leg is expected to fail sometimes (that is what it is for),
+          # and the save otherwise needs a green one. With main the only
+          # writer, a beta break would freeze this cache — right when a
+          # toolchain bump has invalidated the key and PRs need it rebuilt.
+          cache-on-failure: true
       - name: Clippy (beta)
         run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Test (beta)
@@ -140,6 +150,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           workspaces: . -> target
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build (MSRV)
         run: cargo build --workspace --locked
 
@@ -162,6 +173,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           workspaces: . -> target
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Regenerate man page + completions
         # Start from empty directories so an asset the generator no longer
         # emits surfaces as a deletion in the drift diff instead of shipping


### PR DESCRIPTION
The `save-if` half of openSUSE/mtui#511, which is the only part of that PR
bugwarden does not already have. The rest of it — `Swatinem/rust-cache` on
every compiling job, pinned to the same SHA — has been here for months, and
mtui's registry-only tier for its cheaper jobs would be a downgrade against
what we run.

## Why

The repo is over its cache quota and losing the cache it pays for:

```
active_caches_size_in_bytes: 11875472318   # 11.87 GB against a 10 GB cap
refs/heads/main         16 entries   4.91 GB
refs/pull/*/merge       22 entries   6.96 GB   (all five PRs already merged)
```

Cache scoping is one-way: a PR ref reads its own entries plus the default
branch's, while `main` reads only its own. So every byte under
`refs/pull/*` is dead weight from main's point of view — and being over the
cap evicts main's entries by LRU. That is not theoretical: three refs
independently wrote the byte-identical key
`v0-rust-rust-Linux-x64-0b9fd15e-60cf92f2` within eight minutes, which can
only happen if none of them could read the others'. Main's four Linux
entries for the 08-24 lock hash are gone while its macos entry survives,
and PR #146 correspondingly rebuilt cold: `rust` 194s, `rust-beta` 195s,
`rust-msrv` 109s, against a steady-state 89s / 91s / 39s.

## What PRs lose

Nothing ref-specific enters rust-cache's key — prefix, job id, os/arch, a
hash of rustc+env, a hash of the manifests — so a PR still gets an exact or
prefix hit on main's entry. What it gives up is the warm-up between pushes
to *the same branch*, and only on a push that changes a manifest, since an
exact key hit never re-saves. Measured on PR #151's two runs: **~10s of
critical path**, against the ~105s an eviction-induced cold build costs.

## `cache-on-failure` on the beta leg

`rust-beta` carries `continue-on-error: true` because it is expected to
fail — that is the job's purpose. The save is gated on `success()`, so with
main as the only writer a beta break would freeze that cache indefinitely,
and the beta key is invalidated by every toolchain bump. Exactly the moment
PRs need it rebuilt. `cache-on-failure: true` keeps main writing it.

## Not in this change

Merging this stops the bleeding but reclaims nothing: GitHub does not reap
a PR's caches when it merges, and its over-quota eviction is lazy, so the
6.96 GB stays until it ages out. Swept manually alongside this PR rather
than folded in.

Steady state afterwards is main-only at ~1.5 GB per manifest change, so the
repo will still read near quota — that is fine, since LRU then evicts
main's own oldest generation, which nothing needs.

## Adversarial review

Reviewed against the action's source at the pinned commit before opening.

- **Verified, not assumed:** `save-if` is read only by `save.ts`; `restore.ts`
  never consults it, so restore stays unconditional. The key composition
  carries nothing ref-derived. `cache-on-failure` reaches `post-if` through
  an exported `CACHE_ON_FAILURE`, so the mitigation above actually works.
  The step-level tag guard and the input are independent — tag runs are
  unchanged. rust-cache is 100% of the repo's cache footprint: the docker
  job sets no `cache-from`/`cache-to`, CodeQL builds with `build-mode: none`,
  and all 38 active caches are `v0-rust-*`.
- **Fixed after review:** the first draft's comment claimed "~300 MB per
  push" and "every PR's first build missed". Both wrong — a save only
  happens when the key changes (12 main runs on 08-28 produced 3 cache
  generations, matching the 3 manifest-touching commits exactly), and PR
  #151 and #155 both got prefix hits on their first run. The numbers moved
  to the commit body where they belong, and the comment now states only the
  durable invariant.
- **Fixed after review:** two existing comments said "PR/main runs keep the
  cache", which this change makes false.
- Also raised and accepted as-is: rust-cache hashes the whole `Cargo.toml`
  including `[package.metadata.*]`, so a packaging-only commit burns a full
  cache generation. Upstream's behaviour, nothing to do here.

## Verification

Workflow-only, but run in full since every commit lands on main verbatim:
`cargo fmt --check`, both clippy legs, `cargo test --workspace --all-targets
--locked` and `cargo deny check` all green. YAML parses.
