### PR TITLE
test(server): stop the oversized-body test racing the transport

### DIFF
--- a/crates/bugwarden-core/src/policy.rs
+++ b/crates/bugwarden-core/src/policy.rs
@@ -237,9 +237,9 @@ pub struct Matcher {
     /// Case-insensitive substrings searched in the bug's whiteboard.
     ///
     /// A whiteboard the classification data does not carry is unknown, not
-    /// empty, and unknown resolves per `unknown_matches` in
-    /// [`Matcher::matches`] (I4). An empty whiteboard is knowledge: it
-    /// simply contains no substring.
+    /// empty, so the criterion yields [`MatchOutcome::Unknown`], which
+    /// [`Policy::classify`] resolves fail-closed (I4). An empty whiteboard
+    /// is knowledge: it simply contains no substring.
     #[serde(default)]
     pub whiteboard_contains: Vec<String>,
     /// Case-insensitive substrings searched in the bug's summary.
@@ -257,8 +257,8 @@ pub struct Matcher {
     /// Group NAMES differ per instance, so a policy that must hold on any
     /// Bugzilla cannot enumerate them; this criterion asks the
     /// instance-independent question instead. A bug whose group list could
-    /// not be read answers neither way and resolves per `unknown_matches`
-    /// (I4), whichever side the rule asked about.
+    /// not be read answers neither way, so the criterion is undecidable
+    /// whichever side the rule asked about and resolves fail-closed (I4).
     #[serde(default)]
     pub group_restricted: Option<bool>,
     /// Matches on whether the REQUESTING account authored the bug: `true`
@@ -271,18 +271,18 @@ pub struct Matcher {
     /// against the bug's `creator`. When the relationship cannot be
     /// established — the creator is unreadable, OR the caller's identity
     /// did not resolve (no identity rule triggered a lookup, or `whoami`
-    /// failed) — the criterion is undecidable and resolves per
-    /// `unknown_matches` fail-closed (I4), whichever side the rule asked
-    /// about. In the create gate the prospective bug's author is
-    /// definitionally the caller, so there `created_by_me` is forced true
-    /// with no lookup at all (see `Guard::may_create`).
+    /// failed) — the criterion is undecidable whichever side the rule
+    /// asked about and resolves fail-closed (I4). In the create gate the
+    /// prospective bug's author is definitionally the caller, so there
+    /// `created_by_me` is forced true with no lookup at all (see
+    /// `Guard::may_create`).
     #[serde(default)]
     pub created_by_me: Option<bool>,
     /// Matches when `creation_time` is newer than `now - N days`.
     ///
-    /// A bug with a missing/unparsable `creation_time` MATCHES this
-    /// criterion (fail closed, I4): this matcher exists to deny or restrict
-    /// young bugs, so a bug of unknown age must be treated as young.
+    /// A bug with a missing/unparsable `creation_time` has no age to
+    /// compare, so the criterion is undecidable and resolves fail-closed
+    /// (I4), exactly like every other unreadable field.
     #[serde(default)]
     pub younger_than_days: Option<i64>,
 }
@@ -590,7 +590,7 @@ pub struct GlobalGuards {
     /// The login `identity_source = "declared"` asserts. Required (and
     /// validated non-blank) exactly when `identity_source = "declared"`;
     /// setting it under `whoami` is a hard startup error rather than a
-    /// silently ignored key (see [`Policy::validate`]). Compared with
+    /// silently ignored key (see [`Policy::from_toml_str`]). Compared with
     /// Bugzilla's own `eq` — case-sensitive (see DESIGN.md).
     #[serde(default)]
     pub identity_login: Option<String>,

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -70,9 +70,12 @@
 //! [`AuditError`]: crate::audit::AuditError
 //! [`AuditEvent`]: crate::audit::AuditEvent
 //! [`AuditEventKind`]: crate::audit::AuditEventKind
+//! [`AuditExport`]: crate::audit::AuditExport
 //! [`AuditSink`]: crate::audit::AuditSink
 //! [`AuditSink::record`]: crate::audit::AuditSink::record
+//! [`FailMode`]: crate::audit::FailMode
 //! [`RequestInfo::params`]: crate::audit::RequestInfo::params
+//! [`select_sinks`]: crate::audit::select_sinks
 
 use std::collections::BTreeMap;
 use std::fs::{File, OpenOptions};

--- a/crates/bugwarden/src/otel.rs
+++ b/crates/bugwarden/src/otel.rs
@@ -52,7 +52,8 @@
 //! [`AuditEvent`]: crate::audit::AuditEvent
 //! [`AuditExport::delivery_failing`]: crate::audit::AuditExport::delivery_failing
 //! [`FailMode`]: crate::audit::FailMode
-//! [`OTEL_EXPORTER_OTLP_HEADERS`]: HEADERS_VAR
+//! [`OTEL_EXPORTER_OTLP_HEADERS`]: crate::otel::HEADERS_VAR
+//! [`Pipeline::probe`]: crate::otel::Pipeline::probe
 
 use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};

--- a/crates/bugwarden/tests/http_auth_wiremock.rs
+++ b/crates/bugwarden/tests/http_auth_wiremock.rs
@@ -351,6 +351,58 @@ async fn every_unauthenticated_request_gets_one_byte_identical_refusal() {
     }
 }
 
+/// The status line the server answers a POST of `body`, presenting
+/// `authorization` when one is given.
+///
+/// Raw TCP rather than reqwest, because every answer this drives arrives
+/// while the body is still being written and is followed by a close: the
+/// remaining write then fails with a connection reset, and reqwest abandons
+/// the response it already holds along with it. Here the send is
+/// best-effort and the read is what the test waits on, so the answer is
+/// read whether or not the rest of the body ever landed — which is the only
+/// way to observe a server that deliberately refuses before consuming what
+/// it was sent.
+async fn oversized_post_status(
+    addr: SocketAddr,
+    authorization: Option<&str>,
+    body: &[u8],
+) -> String {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    let credential = authorization.map_or_else(String::new, |v| format!("Authorization: {v}\r\n"));
+    let mut request = format!(
+        "POST /mcp HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\n\
+         Accept: application/json, text/event-stream\r\n{credential}\
+         Content-Length: {}\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    request.extend_from_slice(body);
+
+    let socket = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect to the listener");
+    let (mut reader, mut writer) = socket.into_split();
+    let sender = tokio::spawn(async move {
+        let _ = writer.write_all(&request).await;
+    });
+    let mut response = Vec::new();
+    // `read_to_end` keeps what it already read when the peer resets, which
+    // is exactly the case under test; only a server that answers nothing at
+    // all leaves the buffer empty.
+    let read = async { reader.read_to_end(&mut response).await };
+    tokio::time::timeout(Duration::from_secs(10), read)
+        .await
+        .expect("the server must answer")
+        .ok();
+    sender.abort();
+    String::from_utf8_lossy(&response)
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .to_owned()
+}
+
 #[tokio::test]
 async fn an_oversized_body_from_a_stranger_is_refused_by_the_gate_not_the_cap() {
     // The gate is a layer in FRONT of rmcp, so an unauthenticated caller
@@ -358,61 +410,32 @@ async fn an_oversized_body_from_a_stranger_is_refused_by_the_gate_not_the_cap() 
     // rests the 413-observability argument on exactly this.
     let mock = MockServer::start().await;
     let addr = serve_guarded(&mock, &both_tokens(), false).await;
-    let http = reqwest::Client::new();
-    let url = format!("http://{addr}/mcp");
     // Past the 4 MiB floor the default policy derives.
-    let oversized = "x".repeat(5 * 1024 * 1024);
+    let oversized = "x".repeat(5 * 1024 * 1024).into_bytes();
 
-    let anonymous = http
-        .post(&url)
-        .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .body(oversized.clone())
-        .send()
-        .await
-        .expect("the server must answer");
-    assert_eq!(anonymous.status().as_u16(), 401, "the gate answers first");
+    let anonymous = oversized_post_status(addr, None, &oversized).await;
+    assert!(
+        anonymous.starts_with("HTTP/1.1 401"),
+        "the gate answers first: {anonymous:?}"
+    );
 
-    let authenticated = http
-        .post(&url)
-        .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .header(
-            reqwest::header::ACCEPT,
-            "application/json, text/event-stream",
-        )
-        .header(
-            reqwest::header::AUTHORIZATION,
-            format!("Bearer {WRITE_TOKEN}"),
-        )
-        .body(oversized)
-        .send()
-        .await
-        .expect("the server must answer");
-    assert_eq!(
-        authenticated.status().as_u16(),
-        413,
-        "a credentialed caller reaches the cap, and only then"
+    let authenticated =
+        oversized_post_status(addr, Some(&format!("Bearer {WRITE_TOKEN}")), &oversized).await;
+    assert!(
+        authenticated.starts_with("HTTP/1.1 413"),
+        "a credentialed caller reaches the cap, and only then: {authenticated:?}"
     );
 
     // The READ scope reaches it too: the cap is a transport limit and the
     // scope gate sits above it in the handler, so a credential that may not
     // upload at all still sees the boundary. DESIGN.md's #52 disclosure note
     // says so; this is what makes that sentence true.
-    let read_scope = http
-        .post(&url)
-        .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .header(
-            reqwest::header::ACCEPT,
-            "application/json, text/event-stream",
-        )
-        .header(
-            reqwest::header::AUTHORIZATION,
-            format!("Bearer {READ_TOKEN}"),
-        )
-        .body("y".repeat(5 * 1024 * 1024))
-        .send()
-        .await
-        .expect("the server must answer");
-    assert_eq!(read_scope.status().as_u16(), 413);
+    let read_scope =
+        oversized_post_status(addr, Some(&format!("Bearer {READ_TOKEN}")), &oversized).await;
+    assert!(
+        read_scope.starts_with("HTTP/1.1 413"),
+        "the read scope reaches the cap too: {read_scope:?}"
+    );
 }
 
 // ---------- the two scopes ----------


### PR DESCRIPTION
Three commits from a fresh-eyes pass over the workspace. One test fix and
two documentation corrections; no behaviour changes.

## test(server): stop the oversized-body test racing the transport

`an_oversized_body_from_a_stranger_is_refused_by_the_gate_not_the_cap`
fails about one run in three, and more often when the whole file runs in
parallel. It is a race in the test, not in the server.

Both refusals the test drives land while the 5 MiB body is still being
written: the bearer gate answers `401` on the request head, and rmcp's
`expect_json` answers `413` the moment a frame crosses the cap. hyper then
closes with the body unread, the peer resets the connection, and reqwest
fails the call with `BodyWrite/ConnectionReset` — discarding a response it
already held.

That is the server behaving as designed. Draining a stranger's 5 MiB before
turning it away is exactly the unauthenticated-work lever the gate exists to
deny, and DESIGN.md rests the 413-observability argument on it, so the test
is what has to change: it was asserting something TCP cannot promise.

The three legs now go over a raw socket. The send is a best-effort task and
the read is what the test waits on — `read_to_end` keeps the bytes it
already took when the peer resets — so the status line is observed whether
or not the rest of the body ever landed. The bodies stay a real 5 MiB, so
401-before-413 is still what is proven, and the coverage contract at the top
of the file ("moving the gate behind rmcp's POST body cap") still fails if
the gate moves.

`the_body_cap_follows_the_policy_attachment_ceiling` in
`http_transport_wiremock.rs` has the same latent race but measured stable
(20/20): only ~1 MiB of its body is left unwritten when the 413 lands.
Deliberately left alone.

## docs(core): correct stale rustdoc in the guard policy

`younger_than_days` claimed that a missing or unparsable `creation_time`
**matches** the criterion. It does not: `evaluate()` yields
`MatchOutcome::Unknown`, as
`matcher_younger_than_days_missing_creation_time_is_unknown` has always
pinned. The difference is not cosmetic — under the documented reading a
`restrict` rule would hand an age-unknown bug the restricted capability set,
where the engine denies it outright (I4).

`whiteboard_contains`, `group_restricted` and `created_by_me` each deferred
to an `unknown_matches` parameter of `Matcher::matches`. Neither has existed
for some time; the path is `Matcher::evaluate` -> `MatchOutcome::Unknown` ->
`Policy::classify`. `identity_login` pointed at the private
`Policy::validate` rather than the public `Policy::from_toml_str`.

The corrected wording matches what README.md's "Unreadable metadata" section
already says.

## docs(server): repair the unresolved links in the module docs

Every module in the binary crate carries a `///` summary on its `pub mod`
line in lib.rs. That fragment merges with the module's own `//!` block and
makes the links inside it resolve in the crate-root scope, which is why both
files already end their module docs with a list of explicit reference
definitions. Links added to the prose since then never got one:
`select_sinks`, `AuditExport` and `FailMode` in audit.rs, `Pipeline::probe`
in otel.rs, all rendering as literal brackets and backticks. otel.rs also
defined `OTEL_EXPORTER_OTLP_HEADERS` as a bare `HEADERS_VAR`.

`cargo doc` is not among the five verification commands, so nothing in CI
was reporting these. bugwarden-core is rustdoc-warning-clean after this PR;
the binary crate has eight left, all either private-item links (they render
as plain text) or the bare URL in config.rs's clap help, which must stay
bare because it is rendered into `--help` and the man page.

## Invariants

No guard behaviour is touched. The test change strengthens nothing and
weakens nothing about I2 (uniform denial) or the bearer gate's position in
front of rmcp — it only changes how the test observes the answer. The
`younger_than_days` correction documents the existing I4 fail-closed
behaviour; it does not alter it.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo clippy -p bugwarden --features gen --all-targets -- -D warnings`,
  `cargo test --workspace --all-targets --locked` (17 binaries), and
  `cargo deny check` all pass on the branch tip **and on each of the three
  commits individually** (bisectability).
- The previously flaky file: 30 consecutive green runs after the change; no
  run of twelve was green before it.
- `cargo doc -p bugwarden-core --no-deps`: zero warnings (was two).