### PR TITLE
docs(design): stamp rmcp 3.1.4

### DIFF
--- a/crates/bugwarden/src/config.rs
+++ b/crates/bugwarden/src/config.rs
@@ -204,7 +204,7 @@ impl Cli {
     /// authority (`*`, a scheme-carrying URL, `a;b`, a percent-encoded
     /// comma, zero-width unicode, a space-containing typo) is a startup
     /// error. Bare IPv6 (`::1`) is matchable: it is rmcp's default
-    /// loopback spelling. rmcp 3.1.2's `parse_allowed_authority` would
+    /// loopback spelling. rmcp 3.1.4's `parse_allowed_authority` would
     /// otherwise keep an unparsable list (validation on) and store a host
     /// no inbound `Host` header will ever equal — a silent deny-all.
     pub fn checked_allowed_hosts(&self) -> anyhow::Result<Option<Vec<&str>>> {
@@ -298,7 +298,7 @@ impl Cli {
     }
 }
 
-/// True when `entry` is a Host authority rmcp 3.1.2 would compare to a
+/// True when `entry` is a Host authority rmcp 3.1.4 would compare to a
 /// successfully parsed inbound `Host`.
 ///
 /// `http::uri::Authority` is the same parser rmcp uses. A bare IPv6
@@ -668,7 +668,7 @@ mod tests {
 
     #[test]
     fn unparsable_allowed_hosts_are_a_startup_error_named_in_the_message() {
-        // Each of these is what rmcp 3.1.2 would store (or skip) without
+        // Each of these is what rmcp 3.1.4 would store (or skip) without
         // matching any inbound Host — validation on, deny-all. Refusing
         // them here is what makes that fail at startup instead of one 403
         // at a time. Deleting the refusal, or warning and continuing, must

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -510,7 +510,7 @@ async fn an_allowed_hosts_entry_naming_no_host_leaves_validation_off() {
 
 #[tokio::test]
 async fn an_unparsable_allowed_hosts_entry_is_a_startup_error() {
-    // The same path `serve_http` and `main` take: rmcp 3.1.2 would store
+    // The same path `serve_http` and `main` take: rmcp 3.1.4 would store
     // `*` as a host that matches only `Host: *`, turning validation on as
     // a silent deny-all. Refusing here is what the operator sees instead
     // of one 403 at a time.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1643,7 +1643,7 @@ names an endpoint.
 ## rmcp 3.1 usage notes
 
 Reference source is the rmcp this workspace pins, unpacked in the local
-registry: `~/.cargo/registry/src/*/rmcp-3.1.2/` — today's version, and the
+registry: `~/.cargo/registry/src/*/rmcp-3.1.4/` — today's version, and the
 directory holding the `rmcp` package's `manifest_path` in `cargo metadata
 --format-version 1` on any day, so it follows `Cargo.lock` rather than a copy
 of it and is by construction the source this build compiles against. Every rmcp
@@ -1653,8 +1653,8 @@ routing traps), `handler/server/router/tool.rs` (`ToolRouter`, incl.
 `remove_route` / `has_route` — I13), `model.rs` and `model/serde_impl.rs`
 (`InitializeResult`, the `_meta` strip), `service.rs` (the serve loop); the
 `#[tool_router]` / `#[tool_handler]` expansions are in the sibling
-`rmcp-macros-3.1.2` tree. The published crate carries no `examples/` — those
-live upstream at the `rmcp-v3.1.2` tag — but for how this server is actually
+`rmcp-macros-3.1.4` tree. The published crate carries no `examples/` — those
+live upstream at the `rmcp-v3.1.4` tag — but for how this server is actually
 wired, `server.rs` and `main.rs` are the reference.
 
 - `rmcp = { version = "3.1", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }`
@@ -1866,7 +1866,7 @@ wired, `server.rs` and `main.rs` are the reference.
   comma-only now. An entry that is not a hostname or `host:port` — `*`, a
   scheme-carrying URL, `a;b`, a percent-encoded comma, zero-width unicode, a
   space-containing typo — is a startup error (`Cli::checked_allowed_hosts`);
-  rmcp 3.1.2's `parse_allowed_authority` would otherwise keep validation on
+  rmcp 3.1.4's `parse_allowed_authority` would otherwise keep validation on
   and store (or skip) a host no inbound `Host` matches, a silent deny-all
   discovered one 403 at a time. HTTP start logs one info line stating
   whether Host validation is on or off and, when on, the resolved list


### PR DESCRIPTION
Closes #135.

`Cargo.lock` has pinned rmcp 3.1.4 since #132, but dependabot cannot carry
the doc half of a bump. Eight sites now name 3.1.4 — the four in
`docs/DESIGN.md` the issue listed, plus four more restating the same
`parse_allowed_authority` claim in `config.rs` doc comments and one test.
A repo-wide sweep found no ninth; remaining bare `rmcp 3.1` mentions are
deliberate family-level references.

## Every claim re-verified against 3.1.4, not assumed

The vendored tree was located through `cargo metadata`, and a whole-tree
diff shows only five `src/` files differ from 3.1.2. `tower.rs`, the entire
`handler/` tree, `model.rs`, `service.rs` and rmcp-macros' `src/` are
byte-identical, so the Host-validation argument, the `_meta`-shape routing
trap and the schemars pass all still read as written.
`StreamableHttpServerConfig` still has exactly ten fields at the documented
defaults; `ProtocolVersion::LATEST` is still `2025-11-25` (upstream #1105
confirmed still open); `CacheScope::default()` is still `Public` with the
hints gated on the negotiated revision. **`get_tool` still takes no
`RequestContext`, so #116's premise is intact and untouched.**

Nothing was added about 3.1.4's new pre-init JSON-RPC error: DESIGN.md
describes no such path, and for this build it is stdio-only.

## Adversarial review before opening

A documentation-lens reviewer re-derived all of the above independently and
found the diff merge-safe, with one blocking finding against the **commit
message**: a dropped "behaviour" qualifier made a count of server-side
changes false. Verified and corrected before this PR — three server-side
files changed, not one, and DESIGN.md describes none of them.

All five AGENTS.md verification commands pass (631 tests, deny clean).
