### PR TITLE
ci: build rust-msrv on the MSRV, not the pinned channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,17 +140,48 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
+      - name: Read the MSRV from Cargo.toml
+        id: msrv
+        shell: bash
+        run: |
+          set -euo pipefail
+          msrv="$(sed -n 's/^rust-version = "\([^"]*\)".*/\1/p' Cargo.toml)"
+          if [ -z "$msrv" ]; then
+            echo "::error::cannot read rust-version from Cargo.toml"
+            exit 1
+          fi
+          echo "msrv=$msrv" >> "$GITHUB_OUTPUT"
+          # The action only sets the rustup default, which rust-toolchain.toml
+          # outranks; an ambient RUSTUP_TOOLCHAIN outranks the toml in turn.
+          echo "RUSTUP_TOOLCHAIN=$msrv" >> "$GITHUB_ENV"
       - name: Install Rust toolchain (MSRV)
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
-          # Keep in sync with rust-version in Cargo.toml.
-          toolchain: "1.88"
+          toolchain: ${{ steps.msrv.outputs.msrv }}
       - name: Cache cargo
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
           workspaces: . -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Assert the toolchain is the MSRV
+        # If the export above ever stops working, fail here instead of
+        # silently re-testing the pinned channel.
+        shell: bash
+        env:
+          MSRV: ${{ steps.msrv.outputs.msrv }}
+        run: |
+          set -euo pipefail
+          rustc --version
+          cargo --version
+          actual="$(rustc --version | cut -d' ' -f2)"
+          case "$actual" in
+            "$MSRV" | "$MSRV".*) ;;
+            *)
+              echo "::error::MSRV job is on rustc $actual, expected $MSRV"
+              exit 1
+              ;;
+          esac
       - name: Build (MSRV)
         run: cargo build --workspace --locked
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,17 @@ cargo deny check
 Use the toolchain pinned in `rust-toolchain.toml` (repo root, currently
 `1.98.0`). That pin, the `toolchain:` inputs in `.github/workflows/`, and
 the `FROM rust:` tag in the `Dockerfile` all name the same version and move
-together; the `rust-msrv` and `rust-beta` inputs are deliberate exceptions.
-The workspace MSRV is declared once in `Cargo.toml`
-(`rust-version = "1.88"`); do not introduce APIs or dependencies which
-require a newer compiler without deliberately updating both the pin and the
-MSRV policy. CI and reproducible local checks use the committed
-`Cargo.lock`, so use `--locked` for verification.
+together; `rust-msrv` (the MSRV) and `rust-beta` (`beta`) are the deliberate
+exceptions. An input only installs that toolchain and sets the rustup
+default, which `rust-toolchain.toml` outranks: a job compiles with the pin
+unless it also overrides the toml. Only `rust-msrv` does (an exported
+`RUSTUP_TOOLCHAIN`, asserted against `rustc --version`); `rust-beta` does
+not, so it re-tests the pin rather than beta. The workspace MSRV is declared
+once in `Cargo.toml` (`rust-version = "1.88"`) and `rust-msrv` reads it from
+there; do not introduce APIs or dependencies which require a newer compiler
+without deliberately updating both the pin and the MSRV policy. CI and
+reproducible local checks use the committed `Cargo.lock`, so use `--locked`
+for verification.
 
 ## Workspace Architecture
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,8 @@
 # Pinned toolchain for reproducible local checks. Keep in sync with the CI
-# toolchain inputs in .github/workflows/ and with the Dockerfile's rust tag,
-# which ci.yml's toolchain-drift job compares against this channel; the
-# workspace MSRV (rust-version in Cargo.toml) is a separate, lower bound.
+# toolchain inputs that name this channel (rust-msrv and rust-beta
+# deliberately differ) and with the Dockerfile's rust tag, which ci.yml's
+# toolchain-drift job compares against this channel; the workspace MSRV
+# (rust-version in Cargo.toml) is a separate, lower bound.
 [toolchain]
 channel = "1.98.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Closes #137.

`rust-msrv` was not testing the MSRV. The pinned dtolnay/rust-toolchain
action only runs `rustup default <tc>` — and even that is
`continue-on-error` — while `rust-toolchain.toml` outranks the rustup
default, so the job compiled with the pinned channel (1.98.0), not 1.88.
Since `rust-msrv` is one of main's nine required contexts, an MSRV
violation could land green.

The job now derives the version from `Cargo.toml`'s `rust-version`,
exports it as `RUSTUP_TOOLCHAIN`, and asserts the effective `rustc` before
building — so the literal `1.88` is gone from CI and the old "keep in sync"
comment is replaced by enforcement.

## Proof, both directions

Fixed job, replayed step by step:

```
msrv=1.88
rustc 1.88.0 (6b00bc388 2025-06-23)
Finished `dev` profile ...          REPLAY EXIT=0
```

Same replay without the export — i.e. main as it stands:

```
::error::MSRV job is on rustc 1.98.0, expected 1.88     EXIT=1
```

A deliberate violation (`File::lock`, stabilised in 1.89) fails the fixed
job and **passed the old one**:

```
new wiring: error[E0658]: use of unstable library feature `file_lock`  EXIT=101
old wiring: Finished `dev` profile ...                                 EXIT=0
```

The workspace genuinely compiles on 1.88 today, `--locked` included — no
MSRV bump was needed or made.

## Why `RUSTUP_TOOLCHAIN`

`cargo +1.88` and `rustup override` also outrank the toolchain file. The
env var wins on covering every later step, including `Swatinem/rust-cache`,
whose key is hashed from the effective rustc — with `cargo +1.88` the key
would name 1.98.0 while the cached artifacts were 1.88.

## Adversarial review before opening

A reviewer re-derived the mechanism, the empty-sed guard, the
version-comparison matrix and the cache-key reasoning independently, found
no vacuous-pass path, and returned NOT MERGE-SAFE on two confidently-false
prose statements: AGENTS.md asserted the `toolchain:` inputs "all name the
same version" — which this very change falsifies — and three places claimed
`RUSTUP_TOOLCHAIN` was the *only* mechanism outranking the toolchain file,
contradicting #137's own list of fixes. Both were verified against rustup
and corrected before this PR.

## Related, deliberately not fixed here

`rust-beta` is inert by the identical mechanism — it installs beta then
compiles the pin, so the early-warning job has been re-testing 1.98.0.
Tracked as #160; switching it on will surface real new-lint noise, which is
a judgement call rather than part of this fix.
