### PR TITLE
chore: tighten comments added with the recent OTLP work

### DIFF
--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -748,19 +748,14 @@ pub struct OutcomeInfo {
     /// result exists to measure — a protocol error, or a refusal the audit
     /// gate records before it is built.
     ///
-    /// Produced, not necessarily delivered: a record whose write survived
-    /// but whose `record_event` still failed can be followed by a fail-mode
-    /// swap, leaving this sizing a payload the client never received.
-    /// [`OutcomeInfo::class`] and [`GuardInfo::verdict`] have the same
-    /// property; the record describes the call, not the wire.
-    ///
-    /// It sizes the PAYLOAD, and the verdict does not bound it. `denied` is
-    /// the *worst* verdict of the call, not a claim that nothing was
-    /// served: a multi-bug `bug_info` with one denied id records `denied`
-    /// over an envelope carrying the bugs it did serve, so that record's
-    /// size tracks those bodies. Only where the whole payload is one
-    /// uniform denial does the size reduce to a function of the caller's
-    /// own id width. Reading this as "how big was the refusal" is wrong.
+    /// Produced, not necessarily delivered: a fail-mode swap after a
+    /// failed `record_event` can leave this sizing a payload the client
+    /// never received — like [`OutcomeInfo::class`] and
+    /// [`GuardInfo::verdict`], the record describes the call, not the
+    /// wire. And the verdict does not bound it: `denied` is the *worst*
+    /// verdict of the call, not a claim that nothing was served, so a
+    /// multi-bug `bug_info` with one denied id still sizes the bugs it
+    /// served. Reading this as "how big was the refusal" is wrong.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_bytes: Option<u64>,
 }

--- a/crates/bugwarden/src/main.rs
+++ b/crates/bugwarden/src/main.rs
@@ -124,12 +124,10 @@ async fn main() -> anyhow::Result<()> {
     if let Some(pipeline) = &otel {
         // Fills the slot the diagnostics layer installed above reads.
         let _ = otel_slot.set(pipeline.clone());
-        // The delivery probe, mirroring the identity preflight: audit
-        // records are load-bearing on this collector, so a deployment
-        // that cannot deliver them refuses to start — a startup failure
-        // now beats a wave of fail-mode refusals under load. Bounded
-        // retry inside, because a collector starting alongside us is
-        // allowed to lose the race by a few seconds.
+        // The delivery probe, mirroring the identity preflight: a
+        // deployment that cannot deliver its audit records refuses to
+        // start (bounded retry inside — a co-starting collector may lose
+        // the race by a few seconds).
         pipeline.probe().await?;
         tracing::info!(
             "OTLP export enabled: audit records are exported to the configured \

--- a/crates/bugwarden/src/otel.rs
+++ b/crates/bugwarden/src/otel.rs
@@ -202,7 +202,7 @@ const SCOPE_NAME: &str = "bugwarden";
 // Configuration
 // ---------------------------------------------------------------------------
 
-/// What the four OTLP variables held when the process started.
+/// What the OTLP variables held when the process started.
 ///
 /// A plain struct rather than a direct read of `std::env`, so resolution is
 /// a function of its argument and a test states its own world instead of
@@ -227,7 +227,7 @@ pub struct OtelEnv {
 }
 
 impl OtelEnv {
-    /// Read the four variables out of the process environment.
+    /// Read the variables out of the process environment.
     ///
     /// A variable set to the empty string counts as one that was never set,
     /// the same "cleared" idiom unit files and container specs use for
@@ -320,17 +320,14 @@ impl ExportConfig {
 /// - An endpoint that is not an `http://` or `https://` URL.
 /// - A header entry that is not a usable `key=value` HTTP header.
 ///
-/// Every message names the variable that carried the offending value —
-/// the specific one where it was the specific one that lost — and, for a
-/// header list, the position of the offending entry, never a value: a
-/// mispasted credential is exactly what lands in the wrong position
-/// (I12).
+/// Every message names the variable that carried the offending value
+/// (the logs-specific one where that one won) and, for a header list,
+/// the position of the offending entry — never a value: a mispasted
+/// credential is exactly what lands in the wrong position (I12).
 pub fn resolve(env: &OtelEnv) -> anyhow::Result<Option<ExportConfig>> {
-    // The logs-specific variable wins where it is set, and is used as the
-    // operator wrote it — the signal path is appended only to the general
-    // one. Honouring it is not optional decoration: a fleet that sets only
-    // `_LOGS_ENDPOINT` is a fleet that expects logs to be exported, and
-    // reading just the general variable would leave export silently off.
+    // Set alone, the logs-specific variable still turns export ON: a fleet
+    // naming only `_LOGS_ENDPOINT` expects logs, and reading just the
+    // general variable would leave export silently off.
     let (endpoint_var, endpoint, append_path) = match logs_override(env.logs_endpoint.as_deref()) {
         Some(endpoint) => (LOGS_ENDPOINT_VAR, endpoint, false),
         None => (
@@ -854,10 +851,7 @@ impl Pipeline {
     /// not an audit record, which would mean inventing an event kind the
     /// schema does not have — so this exercises the whole path: DNS, TCP,
     /// TLS, the headers, the protocol and the collector's own acceptance.
-    ///
-    /// Bounded retry, because a collector and a server that start together
-    /// race, and losing that race by half a second is not a
-    /// misconfiguration.
+    /// Bounded retry — see [`PROBE_ATTEMPTS`].
     ///
     /// # Errors
     ///

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -517,8 +517,8 @@ impl std::io::Write for ByteCounter {
 /// it cannot for a `ContentBlock` — no float, no non-string key — but an
 /// unmeasured record is the right answer if that ever changes.
 ///
-/// Counts rather than buffers, so the cost is the serialize alone and no
-/// allocation, and it is paid only when auditing is on.
+/// Counts rather than buffers (see `ByteCounter`); paid only when
+/// auditing is on.
 fn response_bytes(result: &Result<CallToolResponse, McpError>) -> Option<u64> {
     let Ok(CallToolResponse::Complete(complete)) = result else {
         return None;
@@ -638,10 +638,8 @@ fn too_many_ids(ids: &[u64]) -> Option<CallToolResult> {
 /// Keep the first `head` and last `tail` items of a list, dropping the
 /// middle. Returns the kept items and how many were omitted.
 ///
-/// One helper for `bug_history` (issue #142) and `bug_comments`: they used to
-/// carry separate implementations that agreed on every input their handlers
-/// can produce, so an edit to one silently forked the two tools' truncation
-/// semantics.
+/// One helper for `bug_history` (issue #142) and `bug_comments`, so an
+/// edit cannot silently fork the two tools' truncation semantics.
 ///
 /// Both callers run it on the post-scrub list (I14), so `omitted` counts only
 /// items the client may see and a dropped item cannot leak by arithmetic

--- a/crates/bugwarden/tests/binary_user_agent.rs
+++ b/crates/bugwarden/tests/binary_user_agent.rs
@@ -21,7 +21,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 const REPLY_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// The ambient environment must not reach the child: every one of these is
-/// read by `Cli`, or — the `OTEL_*` four — by `bugwarden::otel` outside
+/// read by `Cli`, or — the `OTEL_*` set — by `bugwarden::otel` outside
 /// clap entirely (`RUST_LOG` only muddies the captured stderr). Scrubbed as
 /// one set rather than per test — the http-only knobs are inert for a stdio
 /// run today, and pruning them is how the list falls behind `Cli` again.


### PR DESCRIPTION
Comment-only pass over the work agent runs added since `5e1611d`, against
the repo owner's terseness standard: one dense line over a paragraph, drop
what the code already says, keep the reason a thing is pinned or excluded
and any invariant or issue reference.

Net −15 lines across five files. The honest finding is that most of that
work already matched the house style — multi-sentence doc comments are the
norm here, and nearly every long block carries an invariant reference, an
issue id, or a hazard. So this cuts genuine duplication and, more usefully,
fixes three comments that had become **false**.

## Corrections, not just trims

- **"the four OTLP variables"** in three places (`otel.rs` ×2,
  `binary_user_agent.rs`) — stale since the logs-specific trio landed;
  `ENV_VARS` holds seven. Reworded to drop the count rather than restate it,
  so it cannot go stale again.
- **`resolve()`'s garbled clause** — "the specific one where it was the
  specific one that lost" described the override backwards: the
  logs-specific variable *wins*. Replaced with what the code does.

## Trims

`otel.rs`: an inline comment duplicating the function doc directly above it
(keeping the one fact it added — a `_LOGS_ENDPOINT`-only fleet must still
get export on), and a bounded-retry paragraph that was a verbatim twin of
the `PROBE_ATTEMPTS` doc. `main.rs`: the third repetition of the
preflight/retry rationale. `audit.rs`, `server.rs`: paragraphs condensed
where every surviving fact is still stated.

## Deliberately left

The I12 secret-handling notes, the two-gate self-feed protection, the
audit write-before-export ordering, main.rs's load-bearing call-site
ordering, ci.yml's toolchain-precedence facts, the collector example's
uid and rotation hazards, and the tests' coverage-contract headers — those
name mutations that must fail, so they are load-bearing rather than
decorative. DESIGN.md and README are untouched.

All five AGENTS.md commands pass (631 tests, deny clean). The diff is
proven comment-only: filtering `git diff -U0` for changed lines that are
not comments yields nothing.
