### PR TITLE
fix(otel): say which variable won the logs-specific override

### DIFF
--- a/crates/bugwarden/src/otel.rs
+++ b/crates/bugwarden/src/otel.rs
@@ -1525,7 +1525,7 @@ mod tests {
         .expect("grpc must be refused wherever it came from");
         assert!(
             format!("{err}").contains(LOGS_PROTOCOL_VAR),
-            "the error must name the losing variable, not its general twin: {err}"
+            "the error must name the logs-specific variable that won, not its general twin: {err}"
         );
     }
 


### PR DESCRIPTION
Closes #164.

A test assertion message described the OTLP logs-specific override
backwards — it spoke of "the losing variable" when
`OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` is the one that *wins* precedence and is
what the startup error names. The message asserted the opposite of the
`contains(LOGS_PROTOCOL_VAR)` check one line above it.

Same inversion as the `resolve()` doc corrected in #163; that PR was
comment-only, so the runtime string was left for this one.

## Premise established from the code, not the issue

`resolve()` checks the logs-specific variable first for the endpoint,
protocol and headers alike: each `Some` arm binds `*_var` to the `LOGS_*`
constant and only the `None` arm falls back, and that same binding is what
every refusal interpolates. So the logs-specific variable wins and the
error names the one that took effect — confirming #163's correction rather
than resting on it.

A sweep of the whole repo for the same phrasing (README, DESIGN.md, the gen
binary, integration tests) found no other inversion; the remaining
"lost"/"losing" hits are the unrelated probe-startup race and the audit-gap
counter.

Text only — no assertion, control flow or behaviour touched, and nothing
matches on the altered string. All five AGENTS.md commands pass.

Adversarial review returned MERGE-SAFE with no findings.
