### PR TITLE
ci: build rust-beta on beta, not the pinned channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     continue-on-error: true
+    env:
+      # The action only sets the rustup default, which rust-toolchain.toml
+      # outranks; an ambient RUSTUP_TOOLCHAIN outranks the toml in turn.
+      RUSTUP_TOOLCHAIN: beta
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -109,6 +113,22 @@ jobs:
           # writer, a beta break would freeze this cache — right when a
           # toolchain bump has invalidated the key and PRs need it rebuilt.
           cache-on-failure: true
+      - name: Assert the toolchain is a beta build
+        # Guards the export above. Beta has no fixed version string, so key
+        # off the channel suffix; every stable pin lacks it.
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustc --version
+          cargo --version
+          actual="$(rustc --version | cut -d' ' -f2)"
+          case "$actual" in
+            *-beta | *-beta.*) ;;
+            *)
+              echo "::error::beta job is on rustc $actual, expected a beta build"
+              exit 1
+              ;;
+          esac
       - name: Clippy (beta)
         run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Test (beta)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,14 +22,14 @@ the `FROM rust:` tag in the `Dockerfile` all name the same version and move
 together; `rust-msrv` (the MSRV) and `rust-beta` (`beta`) are the deliberate
 exceptions. An input only installs that toolchain and sets the rustup
 default, which `rust-toolchain.toml` outranks: a job compiles with the pin
-unless it also overrides the toml. Only `rust-msrv` does (an exported
-`RUSTUP_TOOLCHAIN`, asserted against `rustc --version`); `rust-beta` does
-not, so it re-tests the pin rather than beta. The workspace MSRV is declared
-once in `Cargo.toml` (`rust-version = "1.88"`) and `rust-msrv` reads it from
-there; do not introduce APIs or dependencies which require a newer compiler
-without deliberately updating both the pin and the MSRV policy. CI and
-reproducible local checks use the committed `Cargo.lock`, so use `--locked`
-for verification.
+unless it also overrides the toml. Both exceptions do, via an exported
+`RUSTUP_TOOLCHAIN` plus an assert on `rustc --version`; anything else off
+the pin needs the same two parts or it silently re-tests the pin. The
+workspace MSRV is declared once in `Cargo.toml` (`rust-version = "1.88"`)
+and `rust-msrv` reads it from there; do not introduce APIs or dependencies
+which require a newer compiler without deliberately updating both the pin
+and the MSRV policy. CI and reproducible local checks use the committed
+`Cargo.lock`, so use `--locked` for verification.
 
 ## Workspace Architecture
 


### PR DESCRIPTION
Closes #160.

`rust-beta` installed beta and then compiled the pinned channel: the
toolchain action only sets the rustup default (and that step is even
`continue-on-error`), which `rust-toolchain.toml` outranks. So the
early-warning job has been re-testing 1.98.0. Same mechanism #137 fixed for
`rust-msrv`; this is its counterpart.

Verified against live CI, not just locally — the last green main run shows
`rust-beta` installing `rustc 1.99.0-beta.3` while the compile steps
inherit 1.98.0. rustup names the culprit itself: *"the toolchain '1.98.0'
is currently in use (overridden by rust-toolchain.toml)"*.

The job now exports `RUSTUP_TOOLCHAIN: beta` and asserts the effective
`rustc` is a beta build before compiling.

## Why the assert keys on the channel suffix

Beta has no fixed version string, so a literal match is impossible and
`rustc -vV` has no `channel:` field — the `-beta`/`-beta.N` suffix is the
only signal, and every beta build carries it while no stable release does.
Attacked with fabricated toolchains: stable, nightly, `1.99.0-betarc`,
empty output, missing `rustc`, and a toolchain that prints a beta string
then exits non-zero all fail, each for an identifiable reason. It cannot
pass merely because some string came back.

## It lands green

Ran the job's own legs on 1.99.0-beta.3: clippy `-D warnings` clean, full
test suite `0 failed`. No new-lint noise today — and nothing was quieted to
achieve that: the diff touches no `.rs` file and adds no `#[allow]`.

The job stays non-gating — `continue-on-error: true` survives, and
`rust-beta` is confirmed absent from main's nine required contexts, so a
future beta failure reports without blocking merges.

## Note for the first run

`rust-cache` keys on the effective rustc, so this job's cache flips from
the stable hash to the beta one and the first run rebuilds cold. Expected,
self-healing after the first main run, and `cache-on-failure: true` was
already set.

AGENTS.md's toolchain paragraph said `rust-beta` does not override the
toml — true before this change, false after; updated. Adversarial review
returned MERGE-SAFE with no findings.
