### PR TITLE
ci: gate the release container build on the toolchain guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,9 +249,8 @@ jobs:
     # bump can move the container's rustc off the pinned channel with nothing
     # failing. Deliberately not behind the `changes` paths filter: the check
     # is two sed calls, and paths-filter would skip it on a tag push.
-    # release.yml is a separate workflow this job cannot hold back, so on a
-    # tag it only reports the mismatch that shipped; the PR run is where it
-    # flags a bump before it lands.
+    # release.yml carries its own copy gating the image push; this one is the
+    # required context that blocks the merge, so a bump is caught on the PR.
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,12 +241,47 @@ jobs:
           --generate-notes
           dist/*
 
+  toolchain-drift:
+    # ci.yml's guard, script copied verbatim, so a tag push is prevented and
+    # not merely reported. It gates `container` and through it
+    # `container-manifest` alone: the image is the sole artifact the
+    # Dockerfile toolchain reaches (build, package and publish compile under
+    # the rust-toolchain.toml pin), a pushed manifest cannot be cleanly
+    # unshipped, and a container fault must still not hold back binaries or
+    # crates. Same job name deliberately -- release.yml never runs on a pull
+    # request, so this check run cannot collide with the required context of
+    # that name.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Compare Dockerfile rust tags with rust-toolchain.toml channel
+        shell: bash
+        run: |
+          set -euo pipefail
+          tags="$(sed -n 's/^FROM rust:\([0-9][0-9.]*\)-alpine.*/\1/p' Dockerfile)"
+          channel="$(sed -n 's/^channel = "\([^"]*\)".*/\1/p' rust-toolchain.toml)"
+          if [ -z "$tags" ] || [ -z "$channel" ]; then
+            echo "::error::cannot read the Rust version: Dockerfile FROM tags '$tags', rust-toolchain.toml channel '$channel'"
+            exit 1
+          fi
+          # Check every rust stage, so a second one cannot drift past the guard.
+          while IFS= read -r tag; do
+            if [ "$tag" != "$channel" ]; then
+              echo "::error::toolchain drift: Dockerfile builds on rust:$tag but rust-toolchain.toml pins channel $channel -- bump both together"
+              exit 1
+            fi
+          done <<< "$tags"
+          echo "in sync: Dockerfile rust:$channel == rust-toolchain.toml channel $channel"
+
   container:
     # Native runners per architecture: an emulated aws-lc-sys compile under
     # QEMU takes tens of minutes, and ubuntu-24.04-arm makes it unnecessary.
     # Sibling of `publish`, not upstream of it: a broken image build must not
     # hold back the crates.io release of a tag whose binaries already shipped.
-    needs: release
+    needs: [release, toolchain-drift]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
Closes #138 (half B; half A, the branch-protection setting, is already applied).

## Why

`toolchain-drift` lived only in ci.yml, which cannot hold back a separate
workflow. On a tag push it therefore reported drift that had already shipped —
detection, not prevention — and a published ghcr.io manifest cannot be cleanly
unshipped.

release.yml now carries its own copy (script byte-identical to ci.yml's) and
`container` needs it.

## Scope of the gate

Only `container`, and through it `container-manifest`. `release`, `build`,
`package` and `publish` are untouched: they compile with cargo on runners where
the checked-out `rust-toolchain.toml` outranks the action-installed default
(AGENTS.md's toolchain-precedence paragraph), and `release` compiles nothing at
all. The Dockerfile tag reaches the image and nothing else, so gating the
binary/crate path on a Dockerfile-only fault would break release.yml's own rule
that a container fault must not hold back binaries or crates.

The job name is shared with ci.yml's deliberately, for grep-ability. release.yml
triggers on tag pushes only, so its check run never lands on a PR head beside
the now-required `toolchain-drift` context.

ci.yml's comment claiming release.yml was a workflow it could not hold back is
no longer true, so it now points at release.yml's copy instead.

## Half A, for the record

Applied to branch protection on 2026-08-29 and re-verified against the API
today: `main` requires 10 contexts, `toolchain-drift` among them, `strict:false`
preserved and every other protection key byte-identical (scoped PATCH on
`required_status_checks`, not a full PUT).

## Verification

Adversarial review returned MERGE-SAFE with no blocking findings. Independently
re-verified: both `run:` bodies extract identical (724 bytes); release.yml's
trigger block is `push.tags` only with no `if:` anywhere, so the guard cannot be
skipped; the `needs:` graph is `container: [release, toolchain-drift]`,
`container-manifest: container`, `publish: release`.

The committed script was extracted and run against synced, drifted and malformed
inputs: in-sync exits 0; a drifted tag and a sole stage rewritten into an
unmatched shape both exit 1 (the latter via the `-z` emptiness check); a missing
Dockerfile exits 2. Fail-closed in every case reachable by a base-image bump.

The five AGENTS.md commands were run green in the worktree, though the diff is
workflow-YAML only and none of them read workflow files.

## Known, tracked separately

The sed pattern (`^FROM rust:N.N-alpine`, unindented, uppercase, flagless) is
pre-existing from a06fdd5 and mirrored verbatim here to keep the two copies
diffable. An *added* second rust stage in another shape would be skipped while
the job prints "in sync", so the in-script comment "Check every rust stage"
overclaims. Fixing it means changing both copies in lockstep — a separate
logical change, filed as a follow-up.
