### PR TITLE
feat(audit): populate the record's upstream block

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,8 +895,32 @@ A `tool_call` also carries `trace` when the client sends a valid W3C
 `traceparent` in the request's `_meta`, which makes the call correlatable
 with the client's own trace. The parse is strict and silent: a malformed
 value leaves the field absent, is never logged, and never influences the
-guard or the response. Schema v1 reserves an `upstream` field for
-Bugzilla-side timings; nothing emits it yet, so do not build on it.
+guard or the response.
+
+A `tool_call` that reached Bugzilla also carries `upstream`, the Bugzilla
+side of the call: `requests`, how many requests the client issued (REST and
+otherwise — `quicksearch_syntax` fetches `page.cgi`), counted whether they
+succeeded or not; `status`, the HTTP status of the last request to
+complete, absent where that request got no response at all rather than
+reporting an earlier one's status as the outcome; and `latency_ms`, the
+total time spent waiting on Bugzilla, each request measured until its body
+has been read. The count is taken inside the client, so it includes the
+work a tool does on your behalf and not just the obvious fetch — the
+guard's per-bug classification, the identity lookup, a search window's
+chunked scan, and the deliberate padding requests that keep a denial from
+being cheaper than a serve. It counts what the client sent, so a redirect
+chain followed inside one of them is one request here and several on the
+wire. It is three integers and nothing else: no URL, no header, no body.
+The whole block is absent, never zeroed, when the call contacted Bugzilla
+not at all — `bug_url`, an unknown tool, a refusal decided from the request
+alone — so its absence is a statement.
+
+Do not expect `requests` to be derivable from the other counts. The
+`bugs_quicksearch` record further down spends three on fifty scanned rows:
+the window scan reads whole 200-row chunks and only an empty page ends it,
+so a fifty-row answer costs a second page to learn there is no more, and
+the link-disclosure classify after it is issued even with no links to
+disclose (skipping it would price "no links" below "links, all hidden").
 
 ### What can never appear in a record
 
@@ -914,7 +938,7 @@ parameter — `comment`, `summary`, `description`, `url`, `whiteboard`,
 presence and size but never its content.
 
 ```json
-{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":7,"session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"event":"tool_call","client":{"name":"example-agent","version":"1.4.2"},"request":{"tool":"bugs_quicksearch","id":"3","params":{"limit":50,"offset":0,"query":"kernel panic","status":"ALL"}},"guard":{"verdict":"served_filtered","policy_hash":"sha256:58013baa090cf77630373ab50cc5eaf2d679ec5a06e8a336600fc89b23bb8604","suppressed_count":2,"suppressed_ids":[1290040,1290041],"redacted_fields":[],"scan":{"scanned":50,"dropped":2}},"outcome":{"class":"ok","duration_ms":52,"response_bytes":6218}}
+{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":7,"session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"event":"tool_call","client":{"name":"example-agent","version":"1.4.2"},"request":{"tool":"bugs_quicksearch","id":"3","params":{"limit":50,"offset":0,"query":"kernel panic","status":"ALL"}},"guard":{"verdict":"served_filtered","policy_hash":"sha256:58013baa090cf77630373ab50cc5eaf2d679ec5a06e8a336600fc89b23bb8604","suppressed_count":2,"suppressed_ids":[1290040,1290041],"redacted_fields":[],"scan":{"scanned":50,"dropped":2}},"upstream":{"requests":3,"status":200,"latency_ms":48},"outcome":{"class":"ok","duration_ms":52,"response_bytes":6218}}
 ```
 
 A reader of the file should skip empty lines and tolerate at most one

--- a/crates/bugwarden-core/Cargo.toml
+++ b/crates/bugwarden-core/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1"
 chrono = { version = "0.4.34", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["rt"] }
 toml = "1.1"
 tracing = "0.1"
 reqwest = { version = "0.13", default-features = false, features = [

--- a/crates/bugwarden-core/src/client.rs
+++ b/crates/bugwarden-core/src/client.rs
@@ -13,11 +13,93 @@
 //! `CARGO_PKG_*` would name `bugwarden-core` in the access log of every
 //! binary that embeds it (issue #55).
 
-use std::time::Duration;
+use std::future::Future;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Result};
 use chrono::{DateTime, Utc};
 use serde_json::Value;
+
+tokio::task_local! {
+    /// The accounting [`with_upstream_stats`] installed for this task, read
+    /// only by [`BugzillaClient::send`]. Absent outside a scope, where every
+    /// record is a no-op — startup preflight is not a tool call.
+    static UPSTREAM: Arc<UpstreamStats>;
+}
+
+/// Per-scope accounting of the requests a [`BugzillaClient`] made.
+///
+/// Three integers and nothing else: no URL, no header, no body and no error
+/// text ever enters this (I12), so an audit record built from it cannot
+/// carry the API key or Bugzilla content.
+///
+/// Requests are attributed by *task*: a client call counts here when it is
+/// awaited, directly or transitively, inside [`with_upstream_stats`]. Work
+/// moved onto a separate task with `tokio::spawn` leaves the scope and is
+/// not counted.
+#[derive(Debug, Default)]
+pub struct UpstreamStats {
+    requests: AtomicU32,
+    /// Microseconds, summed; rounding each request to whole milliseconds
+    /// would floor a fast server's every wait to zero and lose the total.
+    latency_us: AtomicU64,
+    /// Status of the last request to complete, `0` for "no response".
+    status: AtomicU32,
+}
+
+impl UpstreamStats {
+    /// Record one completed request: how long it took, and the HTTP status
+    /// if a response line arrived at all.
+    fn record(&self, elapsed: Duration, status: Option<u16>) {
+        self.requests.fetch_add(1, Ordering::Relaxed);
+        self.latency_us.fetch_add(
+            u64::try_from(elapsed.as_micros()).unwrap_or(u64::MAX),
+            Ordering::Relaxed,
+        );
+        self.status
+            .store(u32::from(status.unwrap_or(0)), Ordering::Relaxed);
+    }
+
+    /// How many requests this client issued — REST and otherwise (the
+    /// quicksearch syntax page is `page.cgi`), counted whether they
+    /// succeeded or not. Dispatches, not wire requests: nothing overrides
+    /// reqwest's default redirect policy, so a followed redirect chain is
+    /// one request here and several on the wire.
+    pub fn requests(&self) -> u32 {
+        self.requests.load(Ordering::Relaxed)
+    }
+
+    /// Total time spent waiting on Bugzilla, in whole milliseconds. Each
+    /// request is measured from handing it to the transport until its body
+    /// has been read — reading the body is time spent waiting on Bugzilla.
+    pub fn latency_ms(&self) -> u64 {
+        self.latency_us.load(Ordering::Relaxed) / 1_000
+    }
+
+    /// HTTP status of the last request to complete. `None` when that
+    /// request produced no response at all (a transport failure or a
+    /// timeout), which is deliberately not distinguished from "no request
+    /// was made": both mean no status was observed.
+    pub fn status(&self) -> Option<u16> {
+        match self.status.load(Ordering::Relaxed) {
+            0 => None,
+            s => u16::try_from(s).ok(),
+        }
+    }
+}
+
+/// Run `fut` with `stats` collecting every Bugzilla request made on this
+/// task, then return its output.
+///
+/// The one choke point is [`BugzillaClient::send`], so the count covers
+/// requests the caller cannot itself see — a guard classification, a
+/// `whoami`, a search window's chunk scan — with no call site opting in.
+/// Nested scopes shadow rather than nest: the innermost one collects.
+pub async fn with_upstream_stats<F: Future>(stats: Arc<UpstreamStats>, fut: F) -> F::Output {
+    UPSTREAM.scope(stats, fut).await
+}
 
 /// Fields fetched for guard classification of a bug.
 pub const CLASSIFY_FIELDS: &str =
@@ -506,6 +588,10 @@ impl BugzillaClient {
 
     /// Send a prepared request, returning `(status, body)`. Logs method and
     /// path only (no query string — I12) and sanitizes transport errors.
+    ///
+    /// Every request the client makes passes through here, which is what
+    /// makes it the one honest place to count them for
+    /// [`with_upstream_stats`].
     async fn send(
         &self,
         rb: reqwest::RequestBuilder,
@@ -513,10 +599,24 @@ impl BugzillaClient {
         path: &str,
     ) -> Result<(reqwest::StatusCode, String)> {
         tracing::debug!(method, path, "bugzilla request");
-        let resp = rb.send().await.map_err(sanitize)?;
-        let status = resp.status();
-        let body = resp.text().await.map_err(sanitize)?;
-        Ok((status, body))
+        let started = Instant::now();
+        let (seen, out) = match rb.send().await {
+            Ok(resp) => {
+                // Read before the body: a body that fails to read still had
+                // a response line, and that status is the observed one.
+                let status = resp.status();
+                let out = match resp.text().await {
+                    Ok(body) => Ok((status, body)),
+                    Err(e) => Err(sanitize(e)),
+                };
+                (Some(status.as_u16()), out)
+            }
+            Err(e) => (None, Err(sanitize(e))),
+        };
+        // Three integers only, never the URL, headers, body or error (I12).
+        // No scope installed (startup preflight, an embedder) is a no-op.
+        let _ = UPSTREAM.try_with(|stats| stats.record(started.elapsed(), seen));
+        out
     }
 
     /// Authenticated GET of a REST path (relative to `{base_url}/rest`)

--- a/crates/bugwarden-core/tests/guard_wiremock.rs
+++ b/crates/bugwarden-core/tests/guard_wiremock.rs
@@ -6,7 +6,9 @@
 //! client error mapping, the API key never appearing in error text (I12),
 //! and the summary view carrying no sensitive fields.
 
-use bugwarden_core::client::BugzillaClient;
+use std::sync::Arc;
+
+use bugwarden_core::client::{with_upstream_stats, BugzillaClient, UpstreamStats};
 use bugwarden_core::guard::{Guard, SearchRequest};
 use bugwarden_core::policy::{Access, Capability, Policy};
 use serde_json::{json, Value};
@@ -1397,5 +1399,123 @@ async fn classification_fetch_requests_the_creator_field() {
     assert!(
         out[&7].0.allows(Capability::Read),
         "the caller's own bug must classify from a creator-carrying projection"
+    );
+}
+
+#[tokio::test]
+async fn upstream_stats_count_every_request_inside_the_scope_and_none_outside() {
+    // Issue #118: the audit record's `upstream` block is built from this,
+    // so what it counts is what an operator is told the call cost.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/version"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "version": "5.0" })))
+        .mount(&server)
+        .await;
+    let bz = client(&server);
+
+    // Outside a scope the recording is a no-op, not a panic: startup
+    // preflight and any embedder call the same client.
+    bz.version(KEY).await.expect("version must succeed");
+
+    let stats = Arc::new(UpstreamStats::default());
+    with_upstream_stats(Arc::clone(&stats), async {
+        bz.version(KEY).await.expect("version must succeed");
+        bz.version(KEY).await.expect("version must succeed");
+    })
+    .await;
+    // Two, not three: the pre-scope call is not attributed to this scope.
+    assert_eq!(stats.requests(), 2);
+    assert_eq!(stats.status(), Some(200));
+
+    // A fresh scope starts from zero and sees only its own request.
+    let second = Arc::new(UpstreamStats::default());
+    with_upstream_stats(Arc::clone(&second), async {
+        bz.version(KEY).await.expect("version must succeed");
+    })
+    .await;
+    assert_eq!(second.requests(), 1);
+}
+
+#[tokio::test]
+async fn upstream_stats_count_a_failed_request_with_no_status() {
+    // A request that never got a response line still cost a round trip, so
+    // it is counted — but there is no status to report, and the previous
+    // request's must not stand in for it.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/version"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({ "error": true })))
+        .mount(&server)
+        .await;
+    let reachable = client(&server);
+    let refused = BugzillaClient::new(&refused_base_url(), false, TEST_USER_AGENT)
+        .expect("client must build");
+
+    let stats = Arc::new(UpstreamStats::default());
+    tokio::time::timeout(
+        REFUSED_CONNECT_BUDGET,
+        with_upstream_stats(Arc::clone(&stats), async {
+            // An error STATUS is still a response: counted, and reported.
+            assert!(reachable.version(KEY).await.is_err());
+            assert!(refused.version(KEY).await.is_err());
+        }),
+    )
+    .await
+    .expect("a refused loopback connect must not hang");
+
+    assert_eq!(stats.requests(), 2, "both round trips cost something");
+    assert_eq!(
+        stats.status(),
+        None,
+        "the last request produced no response, so no status is reported"
+    );
+}
+
+#[tokio::test]
+async fn upstream_stats_latency_tracks_the_wait_and_not_a_constant() {
+    // Differential, because a constant passes any lower bound: the SAME
+    // request behind a mounted delay must cost most of that delay more
+    // than it does without one. No ambient-timing threshold, so nothing
+    // here depends on how fast the loopback happens to be.
+    const DELAY_MS: u64 = 200;
+    let quick = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/version"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "version": "5.0" })))
+        .mount(&quick)
+        .await;
+    let delayed = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/version"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!({ "version": "5.0" }))
+                .set_delay(std::time::Duration::from_millis(DELAY_MS)),
+        )
+        .mount(&delayed)
+        .await;
+
+    let quick_stats = Arc::new(UpstreamStats::default());
+    with_upstream_stats(Arc::clone(&quick_stats), async {
+        client(&quick).version(KEY).await.expect("version");
+    })
+    .await;
+    let delayed_stats = Arc::new(UpstreamStats::default());
+    with_upstream_stats(Arc::clone(&delayed_stats), async {
+        client(&delayed).version(KEY).await.expect("version");
+    })
+    .await;
+
+    assert!(
+        delayed_stats.latency_ms() >= DELAY_MS,
+        "the mounted delay is time spent waiting: {} ms",
+        delayed_stats.latency_ms()
+    );
+    assert!(
+        delayed_stats.latency_ms() >= quick_stats.latency_ms() + DELAY_MS / 2,
+        "latency must track the wait, not report a fixed number: {} ms delayed vs {} ms quick",
+        delayed_stats.latency_ms(),
+        quick_stats.latency_ms()
     );
 }

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -409,7 +409,9 @@ pub struct ToolCallEvent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guard: Option<GuardInfo>,
     /// The Bugzilla side of the call. Absent when Bugzilla was never
-    /// contacted (denied before any upstream request, or a local tool).
+    /// contacted: a local tool, a refusal answered from the request alone,
+    /// or the pre-dispatch gate. Absence means zero requests, never
+    /// "not measured".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub upstream: Option<UpstreamInfo>,
     /// How the call ended, from the client's point of view.
@@ -723,16 +725,33 @@ pub enum Verdict {
     Refused,
 }
 
-/// The Bugzilla side of a tool call.
+/// The Bugzilla side of a tool call, counted at the client's own send
+/// choke point ([`bugwarden_core::client::UpstreamStats`]) — so it covers
+/// the requests a handler never sees: guard classifications,
+/// `resolve_caller`'s whoami, the search window's chunk scan,
+/// `create_bug`'s padding classify.
+///
+/// Three integers by construction: nothing here can carry a URL, a
+/// header, a body, an error text, or the API key (I12).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct UpstreamInfo {
-    /// How many Bugzilla REST requests the call made.
+    /// How many requests the client issued — REST and otherwise
+    /// (`quicksearch_syntax` fetches `page.cgi`), counted whether they
+    /// succeeded or not. Dispatches, not wire requests: a redirect chain
+    /// reqwest follows inside one of them counts once. Never zero: a call
+    /// that did not contact Bugzilla at all omits the whole block.
     pub requests: u32,
-    /// HTTP status of the final upstream response, when one was received.
+    /// HTTP status of the last request to complete. Absent where that
+    /// request produced no response at all — a transport failure or a
+    /// timeout — rather than reporting an earlier request's status as if
+    /// it were the outcome.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<u16>,
-    /// Total time spent waiting on Bugzilla, in milliseconds.
+    /// Total time spent waiting on Bugzilla, in milliseconds: each
+    /// request from hand-off to the transport until its body has been
+    /// read, summed. Reading the body is time spent waiting on Bugzilla,
+    /// so it counts.
     pub latency_ms: u64,
 }
 
@@ -1629,7 +1648,9 @@ impl AuditCell {
         self.lock().redacted_fields.insert(field.to_owned());
     }
 
-    /// Note the Bugzilla side of the call, where the caller has it.
+    /// Note the Bugzilla side of the call. Called once per tool call by
+    /// the `call_tool` wrapper, from the accounting the core client
+    /// collected over the dispatch — never by a tool.
     pub fn note_upstream(&self, upstream: UpstreamInfo) {
         self.lock().upstream = Some(upstream);
     }

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use base64::{engine::general_purpose, Engine as _};
-use bugwarden_core::client::{BugzillaClient, CLASSIFY_FIELDS};
+use bugwarden_core::client::{with_upstream_stats, BugzillaClient, UpstreamStats, CLASSIFY_FIELDS};
 use bugwarden_core::guard::{Guard, SearchRequest, SearchWindow};
 use bugwarden_core::policy::{Access, Action, Capability, IdentitySource};
 use chrono::{DateTime, Utc};
@@ -4126,19 +4126,35 @@ impl ServerHandler for BugWarden {
 
         let cell = Arc::new(AuditCell::default());
         context.extensions.insert(Arc::clone(&cell));
+        // Upstream accounting for the whole dispatch (issue #118). Scoped
+        // here, not per handler: a handler cannot see the guard's classify
+        // fetches, `resolve_caller`'s whoami, the search window's chunk
+        // scan, or create_bug's padding classify, so only the client's own
+        // choke point counts them all.
+        let stats = Arc::new(UpstreamStats::default());
         // Recorded like any other call, refused or not: exactly one record,
         // with no guard verdict and no upstream leg, the same shape an
         // unknown tool name produces.
         let result = if reachable {
-            self.tool_router
-                .call(ToolCallContext::new(self, request, context))
-                .await
+            let dispatch = self
+                .tool_router
+                .call(ToolCallContext::new(self, request, context));
+            with_upstream_stats(Arc::clone(&stats), dispatch).await
         } else {
             Err(tool_not_found())
         };
 
         // Exactly one record per call, whatever `result` is — including
         // an unknown tool or another protocol error from the router.
+        // Zero requests leaves the block absent: "Bugzilla was never
+        // contacted" is what its absence means, so it must not be a zero.
+        if stats.requests() > 0 {
+            cell.note_upstream(audit::UpstreamInfo {
+                requests: stats.requests(),
+                status: stats.status(),
+                latency_ms: stats.latency_ms(),
+            });
+        }
         let upstream = cell.take_upstream();
         let guard = cell.into_guard_info(audit.policy_hash.as_deref(), audit.sink.suppressed_ids());
         let guard_verdict = guard.as_ref().map(|g| g.verdict);

--- a/crates/bugwarden/tests/audit_wiremock.rs
+++ b/crates/bugwarden/tests/audit_wiremock.rs
@@ -335,6 +335,15 @@ fn minimal_args(tool: &str) -> Value {
     }
 }
 
+/// Requests wiremock has actually served, the independent ground truth the
+/// record's `upstream.requests` is measured against.
+async fn upstream_hits(mock: &MockServer) -> usize {
+    mock.received_requests()
+        .await
+        .expect("wiremock records requests by default")
+        .len()
+}
+
 #[tokio::test]
 async fn every_routed_tool_writes_exactly_one_record_per_call() {
     let mock = MockServer::start().await;
@@ -354,7 +363,9 @@ async fn every_routed_tool_writes_exactly_one_record_per_call() {
     let mut expected = 1;
     assert_eq!(read_events(&audited.audit_path).len(), expected);
     for tool in &tools {
+        let before = upstream_hits(&mock).await;
         let _ = call(&audited.client, &tool.name, minimal_args(&tool.name)).await;
+        let hits = upstream_hits(&mock).await - before;
         expected += 1;
         // Read IMMEDIATELY after the response future resolves: the
         // record must already be on disk (persisted before response).
@@ -389,6 +400,37 @@ async fn every_routed_tool_writes_exactly_one_record_per_call() {
             "version too: {:?}",
             tc.client
         );
+        // Issue #118, the same blind spot at the `upstream` block: it was
+        // read only off the hand-built goldens. Measured against what
+        // wiremock independently served, so a hardcoded count cannot pass
+        // the whole walk — bug_info fans out to a classify plus a body
+        // fetch, quicksearch_syntax makes its one non-REST page.cgi call,
+        // and bug_url makes none.
+        assert_eq!(
+            tc.upstream.map_or(0, |u| u.requests) as usize,
+            hits,
+            "calling {} must record every upstream request it made: {:?}",
+            tool.name,
+            tc.upstream
+        );
+        assert_eq!(
+            tc.upstream.is_some(),
+            hits > 0,
+            "and carry the block exactly when Bugzilla was contacted: {}",
+            tool.name
+        );
+        if let Some(upstream) = tc.upstream {
+            // The fixture answers 200 everywhere, so the recorded status is
+            // the observed one and not a default. latency_ms is asserted
+            // present only: against a localhost mock its magnitude rounds
+            // to 0 ms and no threshold on it could fail.
+            assert_eq!(
+                upstream.status,
+                Some(200),
+                "and the status the fixture returned: {}",
+                tool.name
+            );
+        }
     }
 }
 
@@ -421,25 +463,37 @@ async fn refusal_paths_write_exactly_one_record_each() {
     let audited = audited_client_for(policy, &mock, "test-key").await;
 
     let mut expected = 1; // initialize
-    let mut check = |events: Vec<AuditEvent>, verdict: Verdict, rule: Option<&str>| {
+
+    // `requests` is the upstream count the record must carry (issue #118):
+    // a refusal decided from the request alone contacts Bugzilla not at all
+    // and must leave the block absent, while a DENIAL still paid for the
+    // classify that produced the verdict.
+    let mut check = |events: Vec<AuditEvent>, verdict: Verdict, rule: Option<&str>, reqs: u32| {
         expected += 1;
         assert_eq!(events.len(), expected, "exactly one new record");
         let tc = last_tool_call(&events);
         let guard = tc.guard.as_ref().expect("the guard was consulted");
         assert_eq!(guard.verdict, verdict);
         assert_eq!(guard.rule.as_deref(), rule);
+        assert_eq!(
+            tc.upstream.map_or(0, |u| u.requests),
+            reqs,
+            "upstream requests: {:?}",
+            tc.upstream
+        );
+        assert_eq!(tc.upstream.is_some(), reqs > 0);
     };
 
     // too_many_ids: 26 distinct ids.
     let ids: Vec<u64> = (1..=26).collect();
     let refused = call(&audited.client, "bug_info", json!({ "bug_ids": ids })).await;
     assert_eq!(refused.is_error, Some(true));
-    check(read_events(&audited.audit_path), Verdict::Refused, None);
+    check(read_events(&audited.audit_path), Verdict::Refused, None, 0);
 
     // Empty id list.
     let refused = call(&audited.client, "bug_info", json!({ "bug_ids": [] })).await;
     assert_eq!(refused.is_error, Some(true));
-    check(read_events(&audited.audit_path), Verdict::Refused, None);
+    check(read_events(&audited.audit_path), Verdict::Refused, None, 0);
 
     // A guard denial names its rule in the record — and nowhere else.
     let denied = call(&audited.client, "bug_history", json!({ "id": 99 })).await;
@@ -448,6 +502,7 @@ async fn refusal_paths_write_exactly_one_record_each() {
         read_events(&audited.audit_path),
         Verdict::Denied,
         Some("hide-secret"),
+        1,
     );
     // The denial is a well-formed response: outcome class stays ok.
     let events = read_events(&audited.audit_path);
@@ -466,7 +521,23 @@ async fn refusal_paths_write_exactly_one_record_each() {
     )
     .await;
     assert_eq!(refused.is_error, Some(true));
-    check(read_events(&audited.audit_path), Verdict::Refused, None);
+    // The padded create refusal: no POST, but one classify against bug 0.
+    check(read_events(&audited.audit_path), Verdict::Refused, None, 1);
+
+    // A DENIED bug_info: the classify that produced the verdict ran and the
+    // link-disclosure padding after it did, but no body fetch — the exact
+    // two-request shape, measured at the client's send choke point, which
+    // no handler could have reported (the padding is inside the guard).
+    let denied = call(&audited.client, "bug_info", json!({ "bug_ids": [99] })).await;
+    // bug_info answers a denial inside its envelope's `restricted` list, so
+    // this is a well-formed response — the denial lives in the record.
+    assert_eq!(denied.is_error, Some(false));
+    check(
+        read_events(&audited.audit_path),
+        Verdict::Denied,
+        Some("hide-secret"),
+        2,
+    );
 }
 
 #[tokio::test]

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1248,6 +1248,56 @@ Decisions, all deliberate:
   treat a size as it treats a count. Exported as the OTLP attribute
   `bugwarden.response_bytes` beside the verdict, absent when unmeasured,
   so a collector aggregates size per tool without parsing every body.
+- **Upstream accounting (issue #118).** `upstream = {requests, status,
+  latency_ms}` is populated from `BugzillaClient::send`, the single point
+  every request the client makes passes through, collected into a
+  `bugwarden_core::client::UpstreamStats` that `call_tool` scopes around
+  the whole dispatch (`with_upstream_stats`) and drains into the cell just
+  before `take_upstream`. Instrumenting the handlers instead would
+  systematically undercount: a handler cannot see the guard's per-id
+  classify fetches, `resolve_caller`'s whoami, the search window's chunk
+  scan (up to ten requests), `disclosable`'s I2 link padding, or
+  `create_bug`'s padding classify — all of which are requests the call
+  really made and an operator really pays for. The scope is a
+  `tokio::task_local`, which is why `bugwarden-core` names tokio as a
+  direct dependency; that is a runtime edge core already had through
+  reqwest, and it was preferred over threading a stats handle through
+  every client and guard signature, which would have put an audit-shaped
+  out-parameter across the whole public API of the portable domain crate
+  to buy a coverage guarantee the compiler cannot actually make (it
+  forces a value to be passed, not the right one). The known limit: a
+  handler that moved work onto its own task with `tokio::spawn` would
+  leave the scope and go uncounted. No handler spawns today, and the
+  router walk's per-tool equality against wiremock's request log fences
+  only half of it. An AWAITED spawn is caught: the mock logs a request
+  before its response resolves, so the uncounted request is inside that
+  tool's snapshot window and the two numbers disagree. A DETACHED one is
+  not — nothing orders a fire-and-forget task's request against the
+  snapshot, so the miscount drifts into the next tool's window or, on the
+  walk's last tool, off the end of it, and the equality passes over a
+  wrong count. Detached upstream work is a review rule, not a tested one.
+  `requests` counts client dispatches, not wire requests: nothing
+  overrides reqwest's default redirect policy, so up to ten hops inside
+  one `send` are one request here. Three integers and nothing else, so no
+  URL, header, body, error text or API key can reach a record through
+  this path (I12). Absent, never zero, when the call contacted Bugzilla
+  not at all — a local tool like `bug_url`, an unrouted name, a refusal
+  answered from the request alone, the pre-dispatch gate. Absence is a
+  measurement here (zero requests), the opposite side from
+  `outcome.response_bytes`, whose absence means there was nothing to
+  measure. `status` is the last request to complete, absent where that
+  request produced no response at all (transport failure, timeout) rather
+  than reporting an earlier request's status as the outcome; `latency_ms`
+  sums each request from hand-off to the transport until its body has
+  been read, because reading the body is time spent waiting on Bugzilla.
+  Optional and absent-when-unset, so the schema stays v1 and no golden
+  shape moves. Startup preflight runs outside any scope and is counted
+  nowhere: it is not a tool call. Pinned at both levels: the core suite
+  proves the scope counts only its own requests, that a refused connect
+  is counted with `status` cleared to absent, and that `latency_ms`
+  tracks a mounted response delay rather than any constant, while the
+  server suite measures every routed tool's count against wiremock's own
+  request log.
 - **Search-window drop accounting (issue #29).** A `bugs_quicksearch`
   record carries `guard.scan = {scanned, dropped}`: how many upstream rows
   the window scan examined and how many it dropped by verdict — without
@@ -2381,11 +2431,23 @@ wired, `server.rs` and `main.rs` are the reference.
   verdict too. The same blind spot elsewhere in the record: `request.id`
   and the handshake identity on a TOOL-CALL record had been read only off
   the hand-built schema fixtures, and are now asserted for every routed
-  tool. Two fields are asserted absent deliberately — `client.principal`
-  because nothing self-declared is ever promoted into it, and the
-  `upstream` block because `note_upstream` has no production caller, so
-  no real record carries one; each is pinned with a value only over the
-  hand-built golden. The http `session` block (its id and remote peer)
+  tool. `client.principal` is asserted absent deliberately, because
+  nothing self-declared is ever promoted into it, and is pinned with a
+  value only over the hand-built golden. The `upstream` block was the
+  same blind spot until #118 gave it a production caller; the router
+  walk now measures `upstream.requests` for every tool against what
+  wiremock independently served, so a count that ignores its input dies
+  on the fan-out (a served `bug_info` costs three — classify, body fetch,
+  link disclosure — while `bug_url` and `mcp_server_info` touch nothing
+  and keep the block absent). The refusal suite pins the denial side, where
+  a denied `bug_info` costs two — the classify plus `disclosable`'s I2
+  padding — against a refusal decided from the request alone, which
+  costs zero. `latency_ms` needs a mounted response delay to be pinned
+  at all, which is why it is asserted in the core suite and not off
+  ambient timing: a threshold over a localhost round trip is either
+  flaky or so loose a constant passes it, so the assertion is that a
+  delayed request's total EXCEEDS an undelayed one's by most of the
+  delay. The http `session` block (its id and remote peer)
   is observed only over a hand-built value; the stdio arm is pinned. The
   `bug_history` window (issue #142) is pinned on both sides: a `head` that
   actually omits entries records `history_window` in `redacted_fields`


### PR DESCRIPTION
Closes #118.

Records `requests`, `status` and `latency_ms` at the single HTTP choke point
`BugzillaClient::send`, scoped with a `tokio::task_local!` installed around the
router dispatch and drained into the audit record.

## Why the choke point, not the handlers

A handler cannot count what the guard spends on its behalf, and that is most of
the cost: the batched classify in `assess`, `resolve_caller`'s whoami, the
window scan's chunks, and `disclosable`'s deliberate bug-0 padding. Counting at
`send` is the only place that sees all of it.

## The architectural call

`tokio::task_local` over threading `&UpstreamStats` through the signatures.
Threading is compile-*forced*, not compile-*checked* — a future call site
passing `&UpstreamStats::default()` compiles and undercounts just as silently
as an escaped scope — while the cost lands on `bugwarden-core`'s public API
(~20 `pub async fn` plus the guard's), making every embedder carry bugwarden's
audit concept. AGENTS.md's rule forbids `rmcp`, `axum`, `clap` and MCP/transport
crates; tokio is none of them, was already in the graph via reqwest, and
`Cargo.lock` is byte-identical after the change (`features = ["rt"]` only).

The scope is lost across `tokio::spawn`. DESIGN.md now states that limit
precisely: an **awaited** spawn is fenced by the router walk's ground-truth
equality against wiremock's request log, a **detached** one is not, because
nothing orders a fire-and-forget request against the per-tool snapshot.

## Review

Three adversarial lenses: security MERGE-SAFE, correctness MERGE-SAFE, docs
NOT MERGE-SAFE. Two blocking and four non-blocking findings, all fixed.

The side-channel question was raised and refuted with DESIGN.md: the audit
reader is inside the trust boundary, and the record already carries `verdict`,
the denying rule name and `suppressed_ids` — strictly more revealing than a
request count. Client responses are byte-identical with the scope on or off, so
I2 is untouched. I12/I15 hold by construction: `u32`, `Option<u16>`, `u64` are
the only types on the path.

Mutations killed, each verified independently by a reviewer: `note_upstream`
made a no-op; the recording in `send` deleted; `record()` storing instead of
adding; a zero block emitted instead of absence; and — new — **reordering
`take_upstream` after `into_guard_info`**, a load-bearing contract that until
now rested on statement order alone.

**Three review findings were themselves wrong**, caught by measuring rather than
complying:

- The README sample's request count is **3**, not the 2 the review derived. The
  scan loop costs 2, but `bugs_quicksearch` then calls `disclosable`
  (`server.rs:2720`), which pads to a bug-0 request so "no links" and "every
  link hidden" cannot be told apart by the clock (I2). Taking the reviewed
  number would have left the front-page sample still impossible.
- The proposed latency test would not have killed the mutant that motivated it:
  a constant `7777` passes any lower bound. The test here is differential — the
  same request behind a mounted delay must cost at least half that delay *more*
  than it does without one — which kills any constant and cannot flake on a slow
  loopback.
- A served `bug_info` costs 3, not 2; only the denied one costs 2. Probing every
  tool in the walk is what caught it.

DESIGN.md's claim that latency magnitude could not be asserted ("no threshold on
it could fail") was false — localhost latencies measure 2–9 ms — and is replaced
with why the assertion has to be differential.

## Verification

Five AGENTS.md commands green. Re-verified independently: `bugwarden` lib 232,
`audit_wiremock` 36, `bugwarden-core` lib 172, `guard_wiremock` 46 (+1, the new
latency test). The `disclosable` padding and the 3-request count were confirmed
at the source, not taken from the report.
