### PR TITLE
test(server): stop the body-cap test racing the transport

### DIFF
--- a/crates/bugwarden/tests/common/raw_post.rs
+++ b/crates/bugwarden/tests/common/raw_post.rs
@@ -1,0 +1,74 @@
+//! Raw-socket POST for tests that must observe an answer the server gives
+//! before it has read what it was sent.
+//!
+//! Included by `#[path]` from each user rather than declared in
+//! `common/mod.rs`: that module is compiled into every test binary that
+//! says `mod common;`, so a helper only two of them use would be
+//! `dead_code` in the rest, which `-D warnings` rejects.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+/// The status line the server answers a POST of `body` to `/mcp`,
+/// presenting `authorization` when one is given.
+///
+/// Raw TCP rather than reqwest, because a refusal can arrive while the body
+/// is still being written and is followed by a close: the remaining write
+/// then fails with a connection reset, and reqwest abandons the response it
+/// already holds along with it. Here the send is best-effort and the read is
+/// what the caller waits on, so the answer is observed whether or not the
+/// rest of the body ever landed — the only way to test a server that
+/// deliberately refuses before consuming what it was sent.
+///
+/// Stops at the status line: an ADMITTED body is answered with a chunked
+/// `text/event-stream` that ends itself, after which the connection idles in
+/// keep-alive — so a read to EOF would wait on a close nothing here performs.
+/// Empty means the server answered nothing at all.
+pub async fn post_status_line(
+    addr: SocketAddr,
+    authorization: Option<&str>,
+    body: &[u8],
+) -> String {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    let credential = authorization.map_or_else(String::new, |v| format!("Authorization: {v}\r\n"));
+    let mut request = format!(
+        "POST /mcp HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\n\
+         Accept: application/json, text/event-stream\r\n{credential}\
+         Content-Length: {}\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    request.extend_from_slice(body);
+
+    let socket = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect to the listener");
+    let (mut reader, mut writer) = socket.into_split();
+    let sender = tokio::spawn(async move {
+        let _ = writer.write_all(&request).await;
+        // Hold the write half past the last byte. Dropping it half-closes
+        // the connection, and hyper reads that as the caller leaving: on an
+        // ADMITTED body, whose answer is still being produced when the write
+        // finishes, it then closes with no answer at all. `abort` below
+        // releases it once the status line is in hand.
+        std::future::pending::<()>().await;
+    });
+    let mut line = Vec::new();
+    // Byte at a time so a reset mid-line keeps what already arrived; the
+    // buffered readers make no such promise.
+    let read = async {
+        let mut byte = [0u8; 1];
+        while let Ok(1) = reader.read(&mut byte).await {
+            if byte[0] == b'\n' {
+                break;
+            }
+            line.push(byte[0]);
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(10), read)
+        .await
+        .expect("the server must answer");
+    sender.abort();
+    String::from_utf8_lossy(&line).trim_end().to_owned()
+}

--- a/crates/bugwarden/tests/http_auth_wiremock.rs
+++ b/crates/bugwarden/tests/http_auth_wiremock.rs
@@ -49,6 +49,9 @@ use serde_json::{json, Value};
 use wiremock::matchers::{any, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+#[path = "common/raw_post.rs"]
+mod raw_post;
+
 /// 32 printable non-space characters each, and distinct.
 const WRITE_TOKEN: &str = "0123456789abcdef0123456789abcdef";
 const READ_TOKEN: &str = "fedcba9876543210fedcba9876543210";
@@ -351,58 +354,6 @@ async fn every_unauthenticated_request_gets_one_byte_identical_refusal() {
     }
 }
 
-/// The status line the server answers a POST of `body`, presenting
-/// `authorization` when one is given.
-///
-/// Raw TCP rather than reqwest, because every answer this drives arrives
-/// while the body is still being written and is followed by a close: the
-/// remaining write then fails with a connection reset, and reqwest abandons
-/// the response it already holds along with it. Here the send is
-/// best-effort and the read is what the test waits on, so the answer is
-/// read whether or not the rest of the body ever landed — which is the only
-/// way to observe a server that deliberately refuses before consuming what
-/// it was sent.
-async fn oversized_post_status(
-    addr: SocketAddr,
-    authorization: Option<&str>,
-    body: &[u8],
-) -> String {
-    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
-
-    let credential = authorization.map_or_else(String::new, |v| format!("Authorization: {v}\r\n"));
-    let mut request = format!(
-        "POST /mcp HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\n\
-         Accept: application/json, text/event-stream\r\n{credential}\
-         Content-Length: {}\r\n\r\n",
-        body.len()
-    )
-    .into_bytes();
-    request.extend_from_slice(body);
-
-    let socket = tokio::net::TcpStream::connect(addr)
-        .await
-        .expect("connect to the listener");
-    let (mut reader, mut writer) = socket.into_split();
-    let sender = tokio::spawn(async move {
-        let _ = writer.write_all(&request).await;
-    });
-    let mut response = Vec::new();
-    // `read_to_end` keeps what it already read when the peer resets, which
-    // is exactly the case under test; only a server that answers nothing at
-    // all leaves the buffer empty.
-    let read = async { reader.read_to_end(&mut response).await };
-    tokio::time::timeout(Duration::from_secs(10), read)
-        .await
-        .expect("the server must answer")
-        .ok();
-    sender.abort();
-    String::from_utf8_lossy(&response)
-        .lines()
-        .next()
-        .unwrap_or_default()
-        .to_owned()
-}
-
 #[tokio::test]
 async fn an_oversized_body_from_a_stranger_is_refused_by_the_gate_not_the_cap() {
     // The gate is a layer in FRONT of rmcp, so an unauthenticated caller
@@ -413,14 +364,14 @@ async fn an_oversized_body_from_a_stranger_is_refused_by_the_gate_not_the_cap() 
     // Past the 4 MiB floor the default policy derives.
     let oversized = "x".repeat(5 * 1024 * 1024).into_bytes();
 
-    let anonymous = oversized_post_status(addr, None, &oversized).await;
+    let anonymous = raw_post::post_status_line(addr, None, &oversized).await;
     assert!(
         anonymous.starts_with("HTTP/1.1 401"),
         "the gate answers first: {anonymous:?}"
     );
 
     let authenticated =
-        oversized_post_status(addr, Some(&format!("Bearer {WRITE_TOKEN}")), &oversized).await;
+        raw_post::post_status_line(addr, Some(&format!("Bearer {WRITE_TOKEN}")), &oversized).await;
     assert!(
         authenticated.starts_with("HTTP/1.1 413"),
         "a credentialed caller reaches the cap, and only then: {authenticated:?}"
@@ -431,7 +382,7 @@ async fn an_oversized_body_from_a_stranger_is_refused_by_the_gate_not_the_cap() 
     // upload at all still sees the boundary. DESIGN.md's #52 disclosure note
     // says so; this is what makes that sentence true.
     let read_scope =
-        oversized_post_status(addr, Some(&format!("Bearer {READ_TOKEN}")), &oversized).await;
+        raw_post::post_status_line(addr, Some(&format!("Bearer {READ_TOKEN}")), &oversized).await;
     assert!(
         read_scope.starts_with("HTTP/1.1 413"),
         "the read scope reaches the cap too: {read_scope:?}"

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -55,6 +55,9 @@ use serde_json::{json, Value};
 use wiremock::matchers::{any, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+#[path = "common/raw_post.rs"]
+mod raw_post;
+
 /// Build the http-transport `Cli` against `mock`, with `key_file` when the
 /// test runs in server-held mode. Every field an ambient environment
 /// variable could set behind the fixed arguments below is then assigned
@@ -765,15 +768,18 @@ async fn traceparent_over_http_lands_in_the_audit_record() {
 }
 
 /// POST a raw JSON-RPC `initialize` whose serialized body is at least
-/// `bytes` long, and answer with the HTTP status the transport gave it.
+/// `bytes` long, and answer with the status line the transport gave it.
 ///
 /// The size rides on `clientInfo.title`, a plain string field: what is
 /// under test is the transport's body cap, which is applied while the body
 /// is still being collected — before any tool, session or guard exists —
 /// so the cheapest well-formed request that the cap can refuse is the
 /// handshake itself. A body the cap admits is answered `200`; one it
-/// refuses is answered `413` with no JSON-RPC message at all.
-async fn initialize_body_of(addr: SocketAddr, bytes: usize) -> reqwest::StatusCode {
+/// refuses is answered `413` with no JSON-RPC message at all — and
+/// answered mid-write, before the body it is refusing has been read, which
+/// is why the status line comes off a raw socket rather than a reqwest
+/// round-trip the peer's reset would discard (#167).
+async fn initialize_body_of(addr: SocketAddr, bytes: usize) -> String {
     let request = |title: String| {
         json!({
             "jsonrpc": "2.0",
@@ -796,15 +802,7 @@ async fn initialize_body_of(addr: SocketAddr, bytes: usize) -> reqwest::StatusCo
         "the padding must reach the target size"
     );
 
-    reqwest::Client::new()
-        .post(format!("http://{addr}/mcp"))
-        .header("Accept", "application/json, text/event-stream")
-        .header("Content-Type", "application/json")
-        .body(body)
-        .send()
-        .await
-        .expect("the request must reach the server")
-        .status()
+    raw_post::post_status_line(addr, None, &body).await
 }
 
 #[tokio::test]
@@ -828,24 +826,25 @@ async fn the_body_cap_follows_the_policy_attachment_ceiling() {
     )
     .await;
     let admitted = initialize_body_of(permissive, 5 * 1024 * 1024).await;
-    assert_eq!(
-        admitted, 200,
+    assert!(
+        admitted.starts_with("HTTP/1.1 200"),
         "a body the policy's own attachment cap permits must not be refused \
-         by the transport"
+         by the transport: {admitted:?}"
     );
-    assert_eq!(
-        initialize_body_of(permissive, 10 * 1024 * 1024).await,
-        413,
-        "past the derived cap the memory bound still holds"
+    let past_derived = initialize_body_of(permissive, 10 * 1024 * 1024).await;
+    assert!(
+        past_derived.starts_with("HTTP/1.1 413"),
+        "past the derived cap the memory bound still holds: {past_derived:?}"
     );
 
     // Nothing was loosened for everyone else: under the default policy the
     // 4 MiB floor stands, and the very same 5 MiB body is refused.
     let floored = serve_http(http_cli(&mock, Some(file.path())), "", &mock, None).await;
-    assert_eq!(
-        initialize_body_of(floored, 5 * 1024 * 1024).await,
-        413,
-        "a policy that permits no such attachment keeps the 4 MiB floor"
+    let at_floor = initialize_body_of(floored, 5 * 1024 * 1024).await;
+    assert!(
+        at_floor.starts_with("HTTP/1.1 413"),
+        "a policy that permits no such attachment keeps the 4 MiB floor: \
+         {at_floor:?}"
     );
 
     // A refused body reaches neither tool nor guard, so it also reaches no


### PR DESCRIPTION
Closes #167.

Two commits: extract #159's raw status-line POST into a shared helper, then move
`the_body_cap_follows_the_policy_attachment_ceiling` onto it.

## The issue's diagnosis was right; the plan's mechanism was not

Planning claimed the full response had to be skipped because reading it would
hang. Measured instead: `read_to_end` returns `Ok(1005)`. The real defect is the
opposite of a hang — the sender task finishes, drops the `OwnedWriteHalf`, and
that half-close makes hyper abandon a response it has not written:

```
DBG write of 5243027 bytes -> Ok(())
DBG read stopped after 0 bytes -> Ok(0)
```

Verified in the pinned sources rather than inferred: hyper 1.11.0 builds servers
with `h1_half_close: false` (`server/conn/http1.rs:245`, `proto/h1/conn.rs:54`),
and `mid_message_detect_eof` forces a read on a mid-message connection with an
empty buffer, turning `num_read == 0` into `Err(new_incomplete())`. Fixed by
holding the write half open until the existing `sender.abort()`.

Reading only the status line is kept — it is what the callers want — but the
comment now gives the true reason: the SSE body self-terminates
(`stream::once`, and `SseBody::poll_frame` only consults keep-alive on
`Pending`), and it is the *connection* idling in keep-alive that makes a read to
EOF wait on a close nothing here performs.

Only an admitted body reaches that state, which is why #159 was safe: its legs
are all refused before their body is read — `expect_json` returns 413 on the
first frame past the cap without draining
(`rmcp-3.1.4/.../server_side_http.rs:205-233`) — so hyper never looks for the
EOF there. The hazard turns on those two library defaults, not on socket buffer
sizes, so it is worth rechecking on an rmcp or hyper bump. Sharing the helper
fixes it for `http_auth_wiremock.rs` too, where it could not yet fire.

## Review

Two adversarial lenses, both MERGE-SAFE, no blocking findings. Two prose fixes
applied; a third finding was deliberately left out and filed as #174.

The lenses killed two mutations the implementation had not tried (a hardcoded
status line; a half-body send), and proved the `#[path]` dead-code justification
empirically — a seeded unused `pub fn` in `common/mod.rs` really does fail
clippy for `tools_wiremock`.

**One review claim was wrong and is not reflected here.** A lens reported this
host cannot reproduce the bug, reasoning that large socket buffers let the body
fit in flight. That is the precondition for the *#159 mid-write race*; the
half-close bug has the inverted trigger — it needs `write_all` to **complete**,
since only then is the writer dropped and the FIN sent, so large buffers make it
*more* likely. The trace above is from this host, 3 failures in 60 pre-fix runs;
40 clean runs cannot exclude a 5% rate (P ≈ 13%).

## What holds the test up

Mutation, not soak. Forcing the `server.rs` call site to
`MAX_REQUEST_BODY_FLOOR` fails the admitted leg on `HTTP/1.1 413`; forcing it to
`MAX_REQUEST_BODY_CEILING` fails both refusal legs on `HTTP/1.1 200 OK`. Bodies
stay a real 5/10 MiB so mid-write refusal is still what is proven, the admitted
leg asserts an exact 200 so a 400 from broken padding still fails, and the
zero-upstream assertion is byte-identical. The new form additionally pins the
HTTP version, which the old `reqwest::StatusCode` compare did not.

`DESIGN.md` needs no edit — its bullet states outcomes only, and all three still
hold.

## Verification

Five AGENTS.md commands green at the tip (17 binaries, 631 tests) and on
`08caa5a` in isolation, so both commits are bisectable. Rebased onto `54b397b`.
The hyper and rmcp source claims above were re-verified independently in the
vendored crates.
