### PR TITLE
ci: gate rustdoc and doctests in the rust job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,28 @@ jobs:
         # --all-targets skips bins whose required-features are off, so the
         # asset generator needs its own leg to stay warning-free.
         run: cargo clippy -p bugwarden --features gen --all-targets -- -D warnings
+      - name: Doc
+        # rustdoc warnings are not errors, so a broken link exits 0 without
+        # this. Escalated here, not in [workspace.lints], matching the clippy
+        # split; private items because most of this repo's prose is on them.
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --workspace --no-deps --document-private-items --locked
+      - name: Doc (gen tool)
+        # Same required-features gap as the clippy leg above. Neither leg
+        # reaches main.rs: default target selection skips the `bugwarden`
+        # bin because it shares the lib's name, and --bins would collide on
+        # the lib's doc output path. main.rs stays human-reviewed.
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc -p bugwarden --features gen --no-deps --document-private-items --locked
       - name: Test
         run: cargo test --workspace --all-targets --locked
+      - name: Doctest
+        # --all-targets never runs doctests, and zero exist today (the one
+        # fence is toml), so this gates the first future Rust example. Keeps
+        # RUSTDOCFLAGS per-step: job-level would leak into this collection.
+        run: cargo test --workspace --doc --locked
 
   rust-macos:
     # Portability check on macOS (Apple Silicon, aarch64-apple-darwin): build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,10 @@ Run commands from the repository root:
 cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo clippy -p bugwarden --features gen --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --locked
+RUSTDOCFLAGS="-D warnings" cargo doc -p bugwarden --features gen --no-deps --document-private-items --locked
 cargo test --workspace --all-targets --locked
+cargo test --workspace --doc --locked
 cargo deny check
 ```
 
@@ -121,9 +124,9 @@ are never a justification for undoing them.
 - A dependency change must update `Cargo.lock`, preserve the MSRV, and pass
   `cargo deny check`. Prefer the smallest compatible version change; do not
   run a broad `cargo update` as part of an unrelated change.
-- `typos` runs as its own workflow and is not part of the five verification
-  commands; `typos.toml` is an allowlist of deliberate spellings, never a
-  mask for a real typo.
+- `typos` runs as its own workflow and is not part of the verification
+  commands above; `typos.toml` is an allowlist of deliberate spellings,
+  never a mask for a real typo.
 
 ## Commits and Pull Requests
 

--- a/crates/bugwarden-core/src/client.rs
+++ b/crates/bugwarden-core/src/client.rs
@@ -93,7 +93,7 @@ impl UpstreamStats {
 /// Run `fut` with `stats` collecting every Bugzilla request made on this
 /// task, then return its output.
 ///
-/// The one choke point is [`BugzillaClient::send`], so the count covers
+/// The one choke point is `BugzillaClient::send`, so the count covers
 /// requests the caller cannot itself see — a guard classification, a
 /// `whoami`, a search window's chunk scan — with no call site opting in.
 /// Nested scopes shadow rather than nest: the innermost one collects.

--- a/crates/bugwarden/completions/_bugwarden
+++ b/crates/bugwarden/completions/_bugwarden
@@ -15,7 +15,7 @@ _bugwarden() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" : \
-'--bugzilla-server=[Base URL of the Bugzilla server (e.g., '\''https\://bugzilla.example.com'\''). Environment variable BUGZILLA_SERVER is used if the argument is not provided]:BUGZILLA_SERVER:_default' \
+'--bugzilla-server=[Base URL of the Bugzilla server (e.g., \`https\://bugzilla.example.com\`). Environment variable BUGZILLA_SERVER is used if the argument is not provided]:BUGZILLA_SERVER:_default' \
 '--transport=[Transport for the MCP server\: '\''http'\'' (default) or '\''stdio'\''. Environment variable MCP_TRANSPORT can also be used]:TRANSPORT:((http\:"Streamable HTTP transport (default). Clients send the Bugzilla API key per-request via the API key header, unless \`--api-key-file\` selects server-held key mode (then the header is not consulted at all)"
 stdio\:"Stdio transport. The API key comes from \`--api-key\` / \`BUGZILLA_API_KEY\` or \`--api-key-file\` at startup"))' \
 '--host=[Host address for the MCP server to listen on (http transport only). Defaults to 127.0.0.1 or the MCP_HOST environment variable]:HOST:_default' \

--- a/crates/bugwarden/completions/bugwarden.fish
+++ b/crates/bugwarden/completions/bugwarden.fish
@@ -1,4 +1,4 @@
-complete -c bugwarden -l bugzilla-server -d 'Base URL of the Bugzilla server (e.g., \'https://bugzilla.example.com\'). Environment variable BUGZILLA_SERVER is used if the argument is not provided' -r
+complete -c bugwarden -l bugzilla-server -d 'Base URL of the Bugzilla server (e.g., `https://bugzilla.example.com`). Environment variable BUGZILLA_SERVER is used if the argument is not provided' -r
 complete -c bugwarden -l transport -d 'Transport for the MCP server: \'http\' (default) or \'stdio\'. Environment variable MCP_TRANSPORT can also be used' -r -f -a "http\t'Streamable HTTP transport (default). Clients send the Bugzilla API key per-request via the API key header, unless `--api-key-file` selects server-held key mode (then the header is not consulted at all)'
 stdio\t'Stdio transport. The API key comes from `--api-key` / `BUGZILLA_API_KEY` or `--api-key-file` at startup'"
 complete -c bugwarden -l host -d 'Host address for the MCP server to listen on (http transport only). Defaults to 127.0.0.1 or the MCP_HOST environment variable' -r

--- a/crates/bugwarden/man/bugwarden.1
+++ b/crates/bugwarden/man/bugwarden.1
@@ -29,7 +29,7 @@ MCP server for Bugzilla with operator\-controlled security guards
 .SH OPTIONS
 .TP
 \fB\-\-bugzilla\-server\fR \fI<BUGZILLA_SERVER>\fR
-Base URL of the Bugzilla server (e.g., \*(Aqhttps://bugzilla.example.com\*(Aq). Environment variable BUGZILLA_SERVER is used if the argument is not provided
+Base URL of the Bugzilla server (e.g., `https://bugzilla.example.com`). Environment variable BUGZILLA_SERVER is used if the argument is not provided
 .TP
 \fB\-\-transport\fR \fI<TRANSPORT>\fR [default: http]
 Transport for the MCP server: \*(Aqhttp\*(Aq (default) or \*(Aqstdio\*(Aq. Environment variable MCP_TRANSPORT can also be used

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -1622,7 +1622,7 @@ impl AuditCell {
     /// Note a field (or view marker) the GUARD redacted from served bugs
     /// — a decision no single rule made, so the merge carries no rule of
     /// its own. What that does to an already-recorded rule follows
-    /// [`AuditCell::merge`] and nothing else: it CLEARS when this note is
+    /// `AuditCell::merge` and nothing else: it CLEARS when this note is
     /// what upgrades the verdict (`list_attachments` dropping private
     /// metadata off a plain serve), and leaves it standing at equal rank
     /// (`bug_info` records the `ServedFiltered` verdict AND its rule
@@ -1638,7 +1638,7 @@ impl AuditCell {
     /// (`head`/`tail`/length caps). Records the field and upgrades to
     /// `ServedFiltered` exactly as [`AuditCell::note_redacted`] does, but
     /// never writes the rule at all — not even on the strict upgrade
-    /// where [`AuditCell::merge`] would clear it. The client asked for
+    /// where `AuditCell::merge` would clear it. The client asked for
     /// less; no rule decided anything, and clearing would report a call a
     /// rule DID grant as rule-less (issue #67). Order-independent by
     /// construction: it cannot clear a rule a later guard note records,

--- a/crates/bugwarden/src/config.rs
+++ b/crates/bugwarden/src/config.rs
@@ -30,7 +30,7 @@ pub enum Transport {
 #[derive(Parser)]
 #[command(name = "bugwarden", version, about)]
 pub struct Cli {
-    /// Base URL of the Bugzilla server (e.g., 'https://bugzilla.example.com').
+    /// Base URL of the Bugzilla server (e.g., `https://bugzilla.example.com`).
     /// Environment variable BUGZILLA_SERVER is used if the argument is not
     /// provided.
     #[arg(long, env = "BUGZILLA_SERVER")]

--- a/crates/bugwarden/src/http_auth.rs
+++ b/crates/bugwarden/src/http_auth.rs
@@ -143,7 +143,7 @@ fn env_token(var: &str) -> Option<String> {
 /// What is wrong with a token the operator configured.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum TokenFlaw {
-    /// Under [`MIN_TOKEN_LEN`] characters.
+    /// Under `MIN_TOKEN_LEN` characters.
     TooShort,
     /// Holds a byte that cannot ride in an `Authorization` header, or a
     /// space, which usually means a value was pasted with something attached.
@@ -499,7 +499,7 @@ fn unauthorized() -> Response {
     response
 }
 
-/// The scope [`gate`] attached to this request, as the MCP handler sees it.
+/// The scope `gate` attached to this request, as the MCP handler sees it.
 ///
 /// `None` means no scope was attached, which happens over stdio, under
 /// `--insecure-no-auth`, and — were the listener ever built without the gate

--- a/crates/bugwarden/src/otel.rs
+++ b/crates/bugwarden/src/otel.rs
@@ -67,7 +67,7 @@ use tracing_subscriber::Layer;
 
 use crate::audit::{AuditEvent, AuditEventKind, AuditExport, ExportRefused};
 
-/// Collector base URL; [`LOGS_PATH`] is appended to it. Unset or empty —
+/// Collector base URL; `LOGS_PATH` is appended to it. Unset or empty —
 /// with [`LOGS_ENDPOINT_VAR`] unset or empty too — turns the whole feature
 /// off.
 pub const ENDPOINT_VAR: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
@@ -163,7 +163,7 @@ const SELF_TARGET: &str = "bugwarden::otel";
 /// drop warning is the obvious case, but the expensive one is the HTTP
 /// stack underneath: at `RUST_LOG=debug` a single flush makes
 /// `hyper_util`'s connection pool log "pooling idle connection for
-/// <authority>" and `reqwest::connect` log "starting new connection", each
+/// `<authority>`" and `reqwest::connect` log "starting new connection", each
 /// of which would become a record in the NEXT batch, whose flush logs
 /// again — a loop that sustains itself at one export per batch interval
 /// forever, on an idle server, and puts the collector authority on the
@@ -312,7 +312,7 @@ impl ExportConfig {
 ///
 /// The three logs-specific variables override their general counterparts,
 /// as the OTLP specification requires. [`LOGS_ENDPOINT_VAR`] is used
-/// exactly as given — [`LOGS_PATH`] is appended only to [`ENDPOINT_VAR`],
+/// exactly as given — `LOGS_PATH` is appended only to [`ENDPOINT_VAR`],
 /// because the signal-specific form is the operator's whole URL.
 ///
 /// # Errors
@@ -852,7 +852,7 @@ impl Pipeline {
     /// not an audit record, which would mean inventing an event kind the
     /// schema does not have — so this exercises the whole path: DNS, TCP,
     /// TLS, the headers, the protocol and the collector's own acceptance.
-    /// Bounded retry — see [`PROBE_ATTEMPTS`].
+    /// Bounded retry — see `PROBE_ATTEMPTS`.
     ///
     /// # Errors
     ///

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -3980,7 +3980,7 @@ impl ServerHandler for BugWarden {
     }
 
     /// The revisions this handler serves, narrowing the SDK's default of
-    /// every revision it knows (see [`SUPPORTED_PROTOCOL_VERSIONS`]). The
+    /// every revision it knows (see `SUPPORTED_PROTOCOL_VERSIONS`). The
     /// SDK consults this on the handshake, on the stateless request path
     /// and in `server/discover`, so the whole surface narrows with it.
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2626,4 +2626,7 @@ wired, `server.rs` and `main.rs` are the reference.
   runs in-process and logs a line per request, which would feed the very
   loop under test.
 - CI: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
-  `cargo test --workspace --locked`, `cargo deny check`.
+  `cargo test --workspace --locked`, `cargo deny check`, plus
+  `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items --locked`
+  over the workspace and again over the `gen` bin, and
+  `cargo test --workspace --doc --locked`.


### PR DESCRIPTION
Closes #168.

Three steps in the existing `rust` job — no new job, so required contexts are
unchanged — plus the eleven pre-existing rustdoc warnings that would otherwise
turn main red.

## The gate caught a regression before it was even merged

Issue #168's third acceptance criterion claimed `cargo doc` was clean on main.
It was not: planning measured 9 warnings that plain `cargo doc` prints while
exiting 0. Then, while this branch was being built, **#118 landed a tenth**:

```
error: public documentation for `with_upstream_stats` links to private item
`BugzillaClient::send` --> crates/bugwarden-core/src/client.rs:96:30
```

That PR went through three adversarial lenses, a consolidated fix pass and
independent verification. None caught it, because nothing anyone runs executes
`cargo doc`. The defect class this gate exists to stop reproduced itself inside
the window in which the gate was being written — which is the argument for it,
better than any I could make.

## Mechanism: `RUSTDOCFLAGS` in CI, not `[workspace.lints.rustdoc]`

The manifest here declares lint *selection*; escalation to error lives in the CI
command, matching the clippy split — and `Cargo.toml`'s own comment rejects
warn-as-error in the manifest because it blocks scaffolding. `-D warnings`
covers all seven warn-by-default rustdoc lints and auto-adopts future ones,
where an enumerated manifest table would go stale (the true-once failure this
issue exists to kill) and `rustdoc::all` overshoots into allow-by-default lints
with known false positives.

`--document-private-items` because most of this repo's prose lives on private
items; it costs the same and surfaced exactly one extra finding across the whole
corpus. The `gen` leg is load-bearing, not decorative: a broken link injected
into `bugwarden-gen.rs` passes the workspace leg and fails only that one — the
same required-features gap the existing `Clippy (gen tool)` leg exists for.

## Recorded gap

The `bugwarden` bin shares the lib's name, so cargo's default target selection
skips `main.rs` and no doc leg reaches it. `--bins` does catch it, but collides
on the lib's doc output path (cargo#6313) and the collision is a *cargo* warning
that `-D warnings` cannot escalate — so the step would pass while the bin's docs
overwrote the lib's. Left uncovered deliberately, recorded in the step comment.

## Review

Two adversarial lenses, both MERGE-SAFE, no blocking findings. Both open
questions were put to them and both came back against changing course:

- **Keep the de-link on `client.rs:96`.** Making the guard-free `send` public to
  save a hyperlink would add a bypass-shaped public API to a published crate and
  freeze the choke point into semver. `docs/DESIGN.md:1252` already names it in
  plain prose rather than a link, so the crate doc now matches the authority
  doc's convention — and docs.rs cannot render a link to a private item anyway.
- **Leave `main.rs` uncovered.** No collision-free form exists short of renaming
  the bin.

All four touched lint classes were proved to fail the committed step config,
with `invalid_html_tags` injected on a *private* item to show
`--document-private-items` is load-bearing. Control: the same broken link
without `-D warnings` prints a warning and exits 0.

Two prose fixes came out of review: the DESIGN.md bullet's inline-quoted command
was missing `--locked` its neighbour had, and a comment claiming cargo "always
skips" the bin was overbroad read in isolation (true only under default target
selection).

Follow-up filed as #177: `rust-beta` has no doc legs, so the job that exists to
absorb new-lint surprises is the one job not running a gate that deliberately
auto-adopts new lints.

## Verification

Eight AGENTS.md commands green (the block now matches CI flag-for-flag, in CI
order, and its stale "five verification commands" count is dropped rather than
bumped so it cannot rot again). Both doc legs and the doctest leg re-run
independently on the branch: exit 0. The same workspace leg on main: exit 101.

Commit 1 regenerates exactly three asset files, one line each — the `config.rs`
bare-URL fix changes clap help text, which `rust-assets-drift` gates. Commit 2
touches zero build inputs, so both commits are independently green.
