### PR TITLE
docs: correct the rmcp 3.1.4 stateless-routing description

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,10 +555,10 @@ server names itself and its version — `bugwarden` and the release it was
 built from — never the SDK's.
 
 Every session must complete the `initialize` handshake. A request that
-carries a protocol revision in its own `_meta` instead — the handshake-free
-lifecycle — is refused whatever revision it names, because a server that
-answered it would be talking to a client it never greeted, and no audit
-record could say who that was.
+declares a protocol revision in its own `_meta` instead of negotiating one is
+refused whatever revision it names — some such requests skip the handshake
+outright, and a server that answered those would be talking to a client it
+never greeted, with no audit record able to say who that was.
 
 The advertised capability set is tools only: bugwarden registers no MCP
 prompts and no MCP resources. `summarize_bug` is a tool that returns prompt

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -420,21 +420,30 @@ fn max_request_body_bytes(max_attachment_bytes: u64) -> usize {
         .clamp(MAX_REQUEST_BODY_FLOOR, MAX_REQUEST_BODY_CEILING)
 }
 
-/// Whether this request took rmcp's handshake-free lifecycle.
+/// Whether this request declares its own protocol revision in `_meta`.
 ///
-/// The transport routes on the PRESENCE of
-/// `_meta.io.modelcontextprotocol/protocolVersion`, whatever revision that
-/// key names — not on the negotiated revision, and not on
-/// [`SUPPORTED_PROTOCOL_VERSIONS`]. So excluding `2026-07-28` does not keep
-/// a request off that path: a client naming a revision this build does
-/// serve reaches the handler with no `initialize` behind it, and rmcp
-/// synthesises its peer with the SDK's own build identity as `client_info`.
-/// Served, such a call would put a client the server never spoke to into
-/// the audit stream, with no session record anchoring it — a plausible
-/// wrong attribution, which is the one an audit trail can least afford.
+/// rmcp 3.1.4 routes on `_meta` shape, not on the negotiated revision and
+/// not on [`SUPPORTED_PROTOCOL_VERSIONS`]: the stateless path takes a
+/// request naming `2026-07-28` or newer, or one carrying BOTH
+/// `io.modelcontextprotocol/protocolVersion` and `…/clientCapabilities`.
+/// So excluding `2026-07-28` does not keep a request off that path — a
+/// client naming a revision this build does serve, with both keys, reaches
+/// the handler with no `initialize` behind it, and rmcp synthesises its peer
+/// with the SDK's own build identity as `client_info`. Served, such a call
+/// would put a client the server never spoke to into the audit stream, with
+/// no session record anchoring it — a plausible wrong attribution, which is
+/// the one an audit trail can least afford.
 ///
-/// No revision this build serves defines that lifecycle, so a request
-/// carrying it is out of contract and is refused.
+/// No revision this build serves defines that lifecycle, so the declaration
+/// is out of contract and is refused wherever it arrives. Broader than the
+/// routing on purpose: a sub-2026 declaration lacking `clientCapabilities`
+/// takes the session path, so this also fires on requests that did complete a
+/// handshake. Separately, the routing reads more than `_meta` — the
+/// `MCP-Protocol-Version` header, and `initialize`'s own `protocolVersion` —
+/// but neither needs cover here: a header-only `2026-07-28` is refused by the
+/// transport before any handler, and an `initialize` naming it does take the
+/// stateless path but is recorded from `request.client_info`, never from the
+/// synthesized peer.
 fn skips_the_handshake(ctx: &RequestContext<RoleServer>) -> bool {
     ctx.meta.protocol_version().is_some()
 }
@@ -3996,10 +4005,11 @@ impl ServerHandler for BugWarden {
         if skips_the_handshake(&context) {
             // Recorded before it is refused, like every other turned-away
             // call: a stream that went quiet for a whole request class
-            // could not be read as a complete account. `client` is left
-            // absent rather than carrying the placeholder identity the
-            // handshake-free path synthesises — the record says the caller
-            // is unknown, because it is.
+            // could not be read as a complete account. `client` is absent
+            // by policy, not ignorance: on the stateless path `peer_info`
+            // is rmcp's placeholder, in-session it is the real handshake
+            // identity, and one refusal class must not be recorded two
+            // ways. `session.id` is still present when there is one.
             if let Some(audit) = self.audit.clone() {
                 let event = audit::AuditEventKind::ToolCall(Box::new(audit::ToolCallEvent {
                     client: audit::ClientInfo {
@@ -4230,8 +4240,8 @@ impl ServerHandler for BugWarden {
         context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
         // Refused on the same terms as a tool call: the listing is pruned
-        // per deployment (I13), so serving it to a handshake-free caller
-        // would disclose which tools this policy removed. Unrecorded, as
+        // per deployment (I13), so answering one of these would disclose
+        // which tools this policy removed. Unrecorded, as
         // every listing is — schema v1 has no event kind for one.
         if skips_the_handshake(&context) {
             return Err(handshake_required());

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -536,14 +536,17 @@ async fn an_unparsable_allowed_hosts_entry_is_a_startup_error() {
 
 #[tokio::test]
 async fn a_handshake_free_call_is_refused_and_never_names_a_client() {
-    // rmcp routes a request to its handshake-free lifecycle on the mere
-    // PRESENCE of `_meta.io.modelcontextprotocol/protocolVersion` — whatever
-    // revision that key names — and synthesises the peer with the SDK's own
-    // build identity. So a client naming 2025-11-25, a revision this build
-    // does serve, reaches a tool with no `initialize` behind it, and the
-    // record would name `rmcp`/<sdk version>: a client the server never
-    // spoke to. Narrowing SUPPORTED_PROTOCOL_VERSIONS cannot close this —
-    // the routing never consults it — so the handler refuses the request.
+    // rmcp 3.1.4 routes to its handshake-free lifecycle when the request's
+    // revision is 2026-07-28 or newer, or `_meta` carries BOTH
+    // `protocolVersion` and `clientCapabilities`, synthesising the peer with
+    // the SDK's own build
+    // identity. The body below sends both keys at 2025-11-25 deliberately:
+    // that is the one shape still reachable on a revision this build serves
+    // — a tool with no `initialize` behind it, recorded as `rmcp`/<sdk
+    // version>, a client the server never spoke to. Drop `clientCapabilities`
+    // and it takes the session path instead, proving nothing.
+    // Narrowing SUPPORTED_PROTOCOL_VERSIONS cannot close it either, the
+    // routing never consults it, so the handler refuses the request.
     let mock = MockServer::start().await;
     mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1753,22 +1753,36 @@ wired, `server.rs` and `main.rs` are the reference.
   must likewise be built in this crate rather than in the library that
   holds the HTTP client (issue #55, "Caller identity on the wire" above).
 - **rmcp trap — the handshake-free lifecycle is chosen by `_meta` shape, not
-  by revision.** `message_has_per_request_protocol_version`
-  (`transport/streamable_http_server/tower.rs`) routes a request to the
-  stateless path when `_meta.io.modelcontextprotocol/protocolVersion` is
-  merely PRESENT, whatever revision it names, and that path synthesises a
-  peer whose `client_info` is `Implementation::default()` — the SDK's own
-  crate name and version. Narrowing the revision list therefore does **not**
-  keep a request off it: a client naming `2025-11-25`, which this build
-  serves, would otherwise reach a tool with no `initialize` behind it and
+  by `SUPPORTED_PROTOCOL_VERSIONS`.** In rmcp 3.1.4 `is_legacy_request`
+  (`transport/streamable_http_server/tower.rs`) sends a POST down the
+  stateless path when the request's revision is `2026-07-28` or newer — the
+  `_meta` one, or `initialize`'s own `protocolVersion`, falling back to the
+  `MCP-Protocol-Version` header and then `2025-03-26` — **or** when a
+  non-`initialize` request carries the whole discover shape — BOTH
+  `io.modelcontextprotocol/protocolVersion` and `…/clientCapabilities`
+  (`missing_required_keys(&V_2026_07_28).is_empty()`). Re-read that predicate
+  on every rmcp bump: it is version-specific, this description was already
+  wrong once, and nothing fails when the prose goes stale. Two rmcp gates
+  narrow it — the version key alone below `2026-07-28` takes the session path
+  instead, and `handler/server.rs` refuses a per-request revision outside
+  `supported_protocol_versions()` — but neither closes it, because neither
+  covers a revision this build *does* serve sent with both keys. That still
+  reaches `serve_negotiated_request_directly`, whose synthesised peer carries
+  `client_info = Implementation::default()` — the SDK's own crate name and
+  version. Served, it would reach a tool with no `initialize` behind it and
   land in the audit stream as a client the server never spoke to. So
-  `call_tool` and `list_tools` refuse any request carrying that key
-  (`skips_the_handshake`), and a refused call is recorded with `client`
-  absent rather than with the placeholder. `server/discover` takes the same
-  path unconditionally in rmcp; it answers `get_info` only and reaches no
-  tool, guard or router. General rule: **no `_meta` key and no `Mcp-*` header
-  may carry a security decision** — like `KNOWN_VERSIONS`, they are the SDK's
-  vocabulary, not this build's contract.
+  `call_tool` and `list_tools` refuse any request carrying the version key
+  (`skips_the_handshake`), and a refused call is recorded with `client` absent
+  rather than with the placeholder. Grep misleads here:
+  `message_has_per_request_protocol_version` tests presence alone, and inside
+  the stateless arm that presence does pick a route — but nothing it decides
+  gets a request INTO that arm; everywhere else it only feeds header
+  validation. `server/discover` is never answered from a session: only
+  `serve_negotiated_request_directly` serves it, and it refuses every shape
+  but a `_meta` carrying both keys at a revision this build serves. It answers
+  `get_info` only and reaches no tool, guard or router. General rule: **no
+  `_meta` key and no `Mcp-*` header may carry a security decision** — like
+  `KNOWN_VERSIONS`, they are the SDK's vocabulary, not this build's contract.
 - `list_tools` names every `ListToolsResult` field: `result_type` is
   `COMPLETE`, and the 2026-07-28 cache hints stay absent while that revision
   is unserved. When it is adopted, `cache_scope` is `Private` — the listing is


### PR DESCRIPTION
PR 0 of #34's stage-2 sequence (finding C1). Docs and comments only, no
behaviour change — the `skips_the_handshake` predicate is byte-identical across
the commit.

## The claim was born false, not made false by a bump

The `_meta`-shape trap said rmcp routes to the handshake-free lifecycle on the
**mere presence** of `io.modelcontextprotocol/protocolVersion`, whatever revision
it names. That was never true of any SDK this repo has shipped on:

- `git log -S` puts the sentence's only introduction in `8f95f50` — the 2.2→3.1
  bump itself;
- 3.1.0's `is_legacy_request` and `uses_legacy_lifecycle` are byte-identical to
  3.1.4's;
- rmcp **2.2.0 did not inspect `_meta` when routing at all** — `handle_post`
  branched on `stateful_mode` (default true, never overridden here) and the
  presence of `Mcp-Session-Id`, with the no-session-id arm demanding an
  `InitializeRequest`. The handshake-free path was unreachable over HTTP.

So no version pin or bump-time recheck would have caught this. That is a
different lesson from "recheck version-specific claims on bumps", and it is why
every version-specific claim in the new text names rmcp 3.1.4.

## What 3.1.4 actually does

`is_legacy_request` takes the stateless path when the request's revision is
>= 2026-07-28 — `_meta`, else `initialize`'s body, else the
`MCP-Protocol-Version` header, else 2025-03-26 — **or** when a non-`initialize`
request carries BOTH `protocolVersion` and `clientCapabilities`. rmcp separately
refuses a per-request revision outside `supported_protocol_versions()`.

**The hazard survives, narrowed**: a revision this build *does* serve, sent with
both keys, still reaches `serve_negotiated_request_directly` and its
`Implementation::default()` placeholder peer. So the refusal stays load-bearing,
and the existing test still exercises a reachable path — only its comment was
wrong.

Probed against a live server: 2025-11-25 with both keys hits
`skips_the_handshake` (-32600); the version key alone gets the session path's
422; 2026-07-28 gets rmcp's -32022, but only once `Mcp-Method`/`Mcp-Name` are
supplied, SEP-2243 header validation answering -32020 first.

## Three comments in server.rs asserted the same equivalence

Found by the final review, one line above a hunk two earlier passes had both
verified:

- the predicate's rustdoc **summary line** said "whether this request took the
  handshake-free lifecycle" — but an in-session call declaring a revision is
  refused with a completed handshake behind it (probed: it rides `create_stream`
  and still gets -32600);
- the refusal comment justified an absent `client` as *ignorance*. On that same
  session an ordinary call records `greeted-client`/`4.2` off `peer_info`, so
  absence there is **uniformity across the refused class**, not ignorance;
- `list_tools` called the same caller "handshake-free".

## Review

Opus adversarial (MERGE-SAFE, 6 non-blocking) then Fable final, which returned
**NOT MERGE-SAFE** on the two comment defects above and passed the fixed state.
Two of three rounds introduced a fresh false claim in the *replacement* prose —
each time a mechanism clause inferred one step past what was probed. The
surviving text asserts only observed outcomes or read source lines; the
`server/discover` and grep passages were rewritten to outcome-only for exactly
that reason, and the call-site archaeology lives in the commit body rather than
in DESIGN.md, where it would rot on any rmcp refactor.

## Found and tracked, deliberately not folded in

- **#180** — `initialize` records carry no `session.id` (the id is minted for the
  response), so the record that exists to anchor a session cannot be joined to
  it. Undermines #34's decision (a); must be settled before schema v2 freezes.
- **#179** — a test comment calls `server/discover` an unauthenticated
  pre-request surface "while #32 is open"; #32 closed and #105 put the bearer
  gate around the whole router.

#34's C3 note was also corrected: the forged-`mcp-session-id` grouping is
reachable **today** on refusal records, not only once stage 2 serves the path.

## Verification

All eight AGENTS.md commands re-run independently on the final commit: green,
634 tests, 0 failed.
