### PR TITLE
fix(server): source audit session.id from the session layer, never the client header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
+ "futures-core",
  "http",
  "reqwest",
  "rmcp",

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -43,6 +43,10 @@ rmcp = { version = "3.1", features = [
     "transport-streamable-http-server",
 ] }
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
+# `Stream`, to name the return types of the `SessionManager` wrapper in
+# `http_session`. Already in the lock file through rmcp; the facade crate
+# `futures` would pull executor and sink machinery nothing here uses.
+futures-core = "0.3"
 # Same crate rmcp uses to parse Host authorities (`parse_allowed_authority`).
 http = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "net", "time"] }

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -461,8 +461,12 @@ pub enum GapReason {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SessionInfo {
-    /// Server-assigned session identifier, when the transport has one
-    /// (streamable HTTP does; a stdio session is the process itself).
+    /// Server-assigned session identifier, present when the transport
+    /// actually opened a session: over http the id rmcp minted, over
+    /// stdio the process itself. Never a client-supplied value — the
+    /// `mcp-session-id` request header is not read (#180) — so the
+    /// handshake-free stateless path, which opens no session, records
+    /// none.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// Which transport carried the session.
@@ -1437,7 +1441,8 @@ pub struct AuditState {
     pub policy_hash: Option<String>,
     /// Session id stamped into stdio records. One process is one stdio
     /// session, so `<pid>-<unix epoch secs at startup>` anchors those
-    /// records the way the `mcp-session-id` header anchors http ones.
+    /// records the way the transport-minted id anchors http ones (see
+    /// [`crate::http_session`] — never the request header, #180).
     pub stdio_session_id: String,
 }
 

--- a/crates/bugwarden/src/http_session.rs
+++ b/crates/bugwarden/src/http_session.rs
@@ -1,0 +1,222 @@
+//! Session-id provenance for the streamable-HTTP transport.
+//!
+//! The `mcp-session-id` REQUEST header is not the session id. rmcp mints
+//! the id *after* it has injected the HTTP request parts, so an
+//! `initialize` request never carries one; and on the stateless path the
+//! header reaches the handler unvalidated, because `has_session` runs only
+//! on the session branch. Reading it therefore lost the id on exactly the
+//! record meant to anchor a session, and copied a forgeable one onto
+//! refusals (issue #180).
+//!
+//! [`AuditedSessionManager`] closes both: `SessionManager` receives the
+//! minted id together with the owned message, and message extensions
+//! travel verbatim into the handler's context — `RequestContext` for a
+//! request, `NotificationContext` for a notification — so stamping
+//! [`TransportSessionId`] there hands the handler the transport's own
+//! value. Same seam rmcp uses for its `SessionRestoreMarker`.
+
+use std::sync::Arc;
+
+use futures_core::Stream;
+use rmcp::model::{ClientJsonRpcMessage, GetExtensions as _, ServerJsonRpcMessage};
+use rmcp::transport::streamable_http_server::session::{
+    local::{LocalSessionManager, LocalSessionManagerError},
+    EventStore, RestoreOutcome, ServerSseMessage, SessionId, SessionManager,
+};
+
+/// The transport-minted session id, carried to the handler in the request
+/// extensions. `SessionId` is rmcp's `Arc<str>`.
+///
+/// The audit stream's only source for `SessionInfo::id` on http: present
+/// exactly when the transport really opened a session, so a stateless
+/// caller cannot supply one.
+#[derive(Debug, Clone)]
+pub struct TransportSessionId(pub SessionId);
+
+/// [`LocalSessionManager`] with [`TransportSessionId`] stamped into every
+/// message that becomes a handler context.
+///
+/// Everything else delegates unchanged — `restore_session` and
+/// `event_store` included, so wiring either up later does not silently
+/// fall back to the trait defaults this wrapper would otherwise inherit.
+#[derive(Debug, Default)]
+pub struct AuditedSessionManager {
+    inner: LocalSessionManager,
+}
+
+/// Stamp `id` where the serve loop will move it into the handler's
+/// context: `RequestContext::extensions` for a request,
+/// `NotificationContext::extensions` for a notification.
+///
+/// Responses and errors are the client's answers to the server's own
+/// requests: they reach no handler and have no extensions to stamp.
+fn stamp(message: &mut ClientJsonRpcMessage, id: &SessionId) {
+    match message {
+        ClientJsonRpcMessage::Request(req) => {
+            req.request
+                .extensions_mut()
+                .insert(TransportSessionId(id.clone()));
+        }
+        ClientJsonRpcMessage::Notification(notification) => {
+            notification
+                .notification
+                .extensions_mut()
+                .insert(TransportSessionId(id.clone()));
+        }
+        ClientJsonRpcMessage::Response(_) | ClientJsonRpcMessage::Error(_) => {}
+    }
+}
+
+impl SessionManager for AuditedSessionManager {
+    type Error = LocalSessionManagerError;
+    type Transport = <LocalSessionManager as SessionManager>::Transport;
+
+    async fn create_session(&self) -> Result<(SessionId, Self::Transport), Self::Error> {
+        self.inner.create_session().await
+    }
+
+    /// The `initialize` request — the one message whose id exists only
+    /// here, minted between the parts injection and this call.
+    async fn initialize_session(
+        &self,
+        id: &SessionId,
+        mut message: ClientJsonRpcMessage,
+    ) -> Result<ServerJsonRpcMessage, Self::Error> {
+        stamp(&mut message, id);
+        self.inner.initialize_session(id, message).await
+    }
+
+    async fn has_session(&self, id: &SessionId) -> Result<bool, Self::Error> {
+        self.inner.has_session(id).await
+    }
+
+    async fn close_session(&self, id: &SessionId) -> Result<(), Self::Error> {
+        self.inner.close_session(id).await
+    }
+
+    /// Every in-session request: `id` is the header value rmcp already
+    /// checked against `has_session`, so the stamp is the validated one.
+    async fn create_stream(
+        &self,
+        id: &SessionId,
+        mut message: ClientJsonRpcMessage,
+    ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error> {
+        stamp(&mut message, id);
+        self.inner.create_stream(id, message).await
+    }
+
+    /// In-session notifications, `notifications/initialized` included.
+    /// Defensive today and deliberately untested: this build implements no
+    /// notification handler, so no notification produces a record and
+    /// deleting this stamp fails nothing. It is here so the first one that
+    /// does is anchored rather than silently id-less.
+    async fn accept_message(
+        &self,
+        id: &SessionId,
+        mut message: ClientJsonRpcMessage,
+    ) -> Result<(), Self::Error> {
+        stamp(&mut message, id);
+        self.inner.accept_message(id, message).await
+    }
+
+    async fn create_standalone_stream(
+        &self,
+        id: &SessionId,
+    ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error> {
+        self.inner.create_standalone_stream(id).await
+    }
+
+    async fn resume(
+        &self,
+        id: &SessionId,
+        last_event_id: String,
+    ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error> {
+        self.inner.resume(id, last_event_id).await
+    }
+
+    async fn restore_session(
+        &self,
+        id: SessionId,
+    ) -> Result<RestoreOutcome<Self::Transport>, Self::Error> {
+        self.inner.restore_session(id).await
+    }
+
+    fn event_store(&self) -> Option<Arc<dyn EventStore>> {
+        self.inner.event_store()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::{
+        ClientNotification, ClientRequest, ClientResult, ErrorData, InitializedNotification,
+        JsonRpcMessage, PingRequest, RequestId,
+    };
+
+    fn session() -> SessionId {
+        SessionId::from("sess-180")
+    }
+
+    fn stamped(message: &ClientJsonRpcMessage) -> Option<&str> {
+        let extensions = match message {
+            ClientJsonRpcMessage::Request(req) => req.request.extensions(),
+            ClientJsonRpcMessage::Notification(notification) => {
+                notification.notification.extensions()
+            }
+            ClientJsonRpcMessage::Response(_) | ClientJsonRpcMessage::Error(_) => return None,
+        };
+        extensions.get::<TransportSessionId>().map(|id| &*id.0)
+    }
+
+    #[test]
+    fn stamp_reaches_a_request() {
+        // The tool-call shape: without this the in-session records lose
+        // their id entirely, since nothing else carries it any more.
+        let mut message = ClientJsonRpcMessage::request(
+            ClientRequest::PingRequest(PingRequest::default()),
+            RequestId::Number(1),
+        );
+        stamp(&mut message, &session());
+        assert_eq!(stamped(&message), Some("sess-180"));
+    }
+
+    #[test]
+    fn stamp_reaches_a_notification() {
+        // `notifications/initialized` arrives through `accept_message`,
+        // the third call site — a stamp on requests alone would leave any
+        // notification-driven record unanchored.
+        let mut message = ClientJsonRpcMessage::notification(
+            ClientNotification::InitializedNotification(InitializedNotification::default()),
+        );
+        stamp(&mut message, &session());
+        assert_eq!(stamped(&message), Some("sess-180"));
+    }
+
+    #[test]
+    fn stamp_leaves_responses_and_errors_alone() {
+        // Client answers to server-initiated requests: they reach no
+        // handler and have no extensions to stamp. Compared as serialized
+        // JSON, since extensions are not part of the wire form — what this
+        // pins is that the arm is a no-op on everything the message does
+        // carry, variant included.
+        let json =
+            |m: &ClientJsonRpcMessage| serde_json::to_value(m).expect("a message serializes");
+
+        let mut response =
+            ClientJsonRpcMessage::response(ClientResult::empty(()), RequestId::Number(7));
+        let before = json(&response);
+        stamp(&mut response, &session());
+        assert!(matches!(response, ClientJsonRpcMessage::Response(_)));
+        assert_eq!(json(&response), before);
+
+        let mut error = JsonRpcMessage::error(
+            ErrorData::internal_error("boom", None),
+            Some(RequestId::Number(7)),
+        );
+        let before = json(&error);
+        stamp(&mut error, &session());
+        assert!(matches!(error, ClientJsonRpcMessage::Error(_)));
+        assert_eq!(json(&error), before);
+    }
+}

--- a/crates/bugwarden/src/lib.rs
+++ b/crates/bugwarden/src/lib.rs
@@ -13,6 +13,7 @@ pub mod audit;
 pub mod config;
 /// Bearer authentication for the streamable-HTTP transport.
 pub mod http_auth;
+pub mod http_session;
 /// OTLP export of the audit stream (load-bearing) and of the server's
 /// own diagnostics (best-effort).
 pub mod otel;

--- a/crates/bugwarden/src/main.rs
+++ b/crates/bugwarden/src/main.rs
@@ -13,15 +13,13 @@ use bugwarden::audit::{
     TransportKind,
 };
 use bugwarden::http_auth::{self, HttpEnv};
+use bugwarden::http_session::AuditedSessionManager;
 use bugwarden::otel::{self, OtelEnv, Pipeline};
 use bugwarden::{config, server};
 use bugwarden_core::{guard::Guard, policy::Policy};
 use clap::Parser;
 use rmcp::{
-    transport::{
-        stdio,
-        streamable_http_server::{session::local::LocalSessionManager, StreamableHttpService},
-    },
+    transport::{stdio, streamable_http_server::StreamableHttpService},
     ServiceExt,
 };
 use tracing_subscriber::layer::SubscriberExt as _;
@@ -264,9 +262,15 @@ async fn main() -> anyhow::Result<()> {
                 let config = server
                     .http_server_config()?
                     .with_cancellation_token(ct.child_token());
+                // Load-bearing pair with `serve_http` in
+                // tests/http_transport_wiremock.rs: the audit session id
+                // comes from this wrapper's stamp and nowhere else, so a
+                // plain LocalSessionManager here serves every http record
+                // with no session id at all. The join test forces the
+                // harness; only review forces this call site.
                 let service = StreamableHttpService::new(
                     move || Ok(server.clone()),
-                    LocalSessionManager::default().into(),
+                    AuditedSessionManager::default().into(),
                     config,
                 );
                 // `resolve_for` returns the gate for every http start, so the

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -2159,11 +2159,16 @@ impl BugWarden {
         }
     }
 
-    /// The session an audit record belongs to. http: the server-assigned
-    /// `mcp-session-id` header and, when the listener was built with
-    /// connect-info, the remote peer address — both from the HTTP request
-    /// parts rmcp copies into the request extensions. stdio: the
-    /// process-scoped session id from [`AuditState`].
+    /// The session an audit record belongs to. http: the id the transport
+    /// minted, stamped into the request extensions by
+    /// [`AuditedSessionManager`](crate::http_session::AuditedSessionManager),
+    /// plus the remote peer address when the listener was built with
+    /// connect-info. stdio: the process-scoped session id from
+    /// [`AuditState`].
+    ///
+    /// Never the `mcp-session-id` request header (issue #180): it does not
+    /// exist yet on `initialize`, and on the stateless path it is
+    /// unvalidated client text.
     fn session_info(
         &self,
         ctx: &RequestContext<RoleServer>,
@@ -2175,22 +2180,21 @@ impl BugWarden {
                 transport: TransportKind::Stdio,
                 remote: None,
             },
-            Transport::Http => {
-                let parts = ctx.extensions.get::<axum::http::request::Parts>();
-                audit::SessionInfo {
-                    id: parts
-                        .and_then(|p| p.headers.get("mcp-session-id"))
-                        .and_then(|v| v.to_str().ok())
-                        .map(str::to_owned),
-                    transport: TransportKind::Http,
-                    remote: parts
-                        .and_then(|p| {
-                            p.extensions
-                                .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
-                        })
-                        .map(|ci| ci.0.to_string()),
-                }
-            }
+            Transport::Http => audit::SessionInfo {
+                id: ctx
+                    .extensions
+                    .get::<crate::http_session::TransportSessionId>()
+                    .map(|session| session.0.to_string()),
+                transport: TransportKind::Http,
+                remote: ctx
+                    .extensions
+                    .get::<axum::http::request::Parts>()
+                    .and_then(|p| {
+                        p.extensions
+                            .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+                    })
+                    .map(|ci| ci.0.to_string()),
+            },
         }
     }
 
@@ -4009,7 +4013,11 @@ impl ServerHandler for BugWarden {
             // by policy, not ignorance: on the stateless path `peer_info`
             // is rmcp's placeholder, in-session it is the real handshake
             // identity, and one refusal class must not be recorded two
-            // ways. `session.id` is still present when there is one.
+            // ways. `session.id` is still present when there is one:
+            // this refusal is broader than rmcp's stateless routing (see
+            // `skips_the_handshake`), so a declaration that took the
+            // session branch arrives with its real id stamped, while a
+            // stateless one had no session to stamp (#180).
             if let Some(audit) = self.audit.clone() {
                 let event = audit::AuditEventKind::ToolCall(Box::new(audit::ToolCallEvent {
                     client: audit::ClientInfo {

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -30,7 +30,18 @@
 //! - the POST body cap going back to a fixed value, which refuses uploads
 //!   the operator's `global.max_attachment_bytes` permits, or losing its
 //!   4 MiB floor, which would let a policy shrink the transport's memory
-//!   bound (or remove it entirely at `0`).
+//!   bound (or remove it entirely at `0`);
+//! - `session_info` taking the audit `session.id` from the `mcp-session-id`
+//!   REQUEST header again, which leaves every `initialize` record without
+//!   the id that would join it to its own session and lets a stateless
+//!   caller file a refusal under a live session's id (#180);
+//! - serving on a bare `LocalSessionManager` instead of
+//!   `AuditedSessionManager`, or a wrapper that stamps in only one of
+//!   `initialize_session` / `create_stream`, mints a fresh id per message,
+//!   or carries one id across sessions;
+//! - the handshake refusal clearing `session.id`, which would unanchor the
+//!   refusals that DID open a session — invisible to every other test,
+//!   because the stateless refusal's id is absent either way.
 
 use std::io::Write as _;
 use std::net::SocketAddr;
@@ -38,6 +49,7 @@ use std::sync::Arc;
 
 use bugwarden::audit::{AuditConfig, AuditEvent, AuditEventKind, AuditSink, AuditState, FailMode};
 use bugwarden::config::Cli;
+use bugwarden::http_session::AuditedSessionManager;
 use bugwarden::server::{BugWarden, USER_AGENT};
 use bugwarden_core::client::BugzillaClient;
 use bugwarden_core::guard::Guard;
@@ -46,9 +58,7 @@ use clap::Parser as _;
 use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::service::{RoleClient, RunningService};
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
-use rmcp::transport::streamable_http_server::{
-    session::local::LocalSessionManager, StreamableHttpService,
-};
+use rmcp::transport::streamable_http_server::StreamableHttpService;
 use rmcp::transport::StreamableHttpClientTransport;
 use rmcp::ServiceExt as _;
 use serde_json::{json, Value};
@@ -108,9 +118,12 @@ async fn serve_http(
     let config = server
         .http_server_config()
         .expect("the test Host list must be matchable");
+    // Load-bearing pair with main.rs: the session id an audit record
+    // carries is stamped by this wrapper, so a harness on the plain
+    // LocalSessionManager would test a server no deployment runs.
     let service = StreamableHttpService::new(
         move || Ok(server.clone()),
-        LocalSessionManager::default().into(),
+        AuditedSessionManager::default().into(),
         config,
     );
     let router = axum::Router::new().nest_service("/mcp", service);
@@ -857,5 +870,391 @@ async fn the_body_cap_follows_the_policy_attachment_ceiling() {
         upstream.is_empty(),
         "no handshake may contact Bugzilla: {} request(s)",
         upstream.len()
+    );
+}
+
+/// An audit sink writing JSONL to `path`, wired as a deployment wires one.
+fn audit_to(path: &std::path::Path) -> Arc<AuditState> {
+    let sink = AuditSink::open(AuditConfig {
+        path: Some(path.to_path_buf()),
+        fsync: false,
+        fail_mode: None,
+        rotate_max_bytes: 0,
+        rotate_keep: 8,
+        suppressed_ids: true,
+    })
+    .expect("audit sink must open");
+    Arc::new(AuditState::new(sink, FailMode::Open, None))
+}
+
+/// Every record written to `path`, in file order.
+fn audit_events(path: &std::path::Path) -> Vec<AuditEvent> {
+    std::fs::read_to_string(path)
+        .expect("audit file must be readable")
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str(l).expect("every audit line must parse"))
+        .collect()
+}
+
+/// A POST to `/mcp`, carrying `session` as the `mcp-session-id` request
+/// header when one is given. Bounded, so a stream that never ends fails the
+/// test instead of hanging the run.
+fn mcp_post(addr: SocketAddr, session: Option<&str>) -> reqwest::RequestBuilder {
+    let mut builder = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .expect("reqwest client")
+        .post(format!("http://{addr}/mcp"))
+        .header("Accept", "application/json, text/event-stream")
+        .header("Content-Type", "application/json");
+    if let Some(id) = session {
+        builder = builder.header("mcp-session-id", id);
+    }
+    builder
+}
+
+/// Handshake as `client_name` and return the session id rmcp minted, read
+/// off the RESPONSE header.
+///
+/// Raw reqwest rather than the rmcp client because that header is the whole
+/// point: the `initialize` REQUEST cannot carry the id — it does not exist
+/// yet — so anything reading the request header records nothing here.
+async fn raw_initialize(addr: SocketAddr, client_name: &str) -> String {
+    let response = mcp_post(addr, None)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": client_name, "version": "1" }
+            }
+        }))
+        .send()
+        .await
+        .expect("the initialize request must reach the server");
+    assert!(
+        response.status().is_success(),
+        "the handshake must succeed, got {}",
+        response.status()
+    );
+    let id = response
+        .headers()
+        .get("mcp-session-id")
+        .expect("rmcp answers initialize with a minted session id")
+        .to_str()
+        .expect("the minted id is ascii")
+        .to_owned();
+    // Drain the one-message SSE body: the handshake is complete only once
+    // the server has produced its result.
+    let _ = response.text().await.expect("an initialize response body");
+
+    let accepted = mcp_post(addr, Some(&id))
+        .json(&json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }))
+        .send()
+        .await
+        .expect("the initialized notification must reach the server");
+    assert!(
+        accepted.status().is_success(),
+        "notifications/initialized must be accepted, got {}",
+        accepted.status()
+    );
+    id
+}
+
+/// Call `tool` inside session `id` over raw HTTP; returns the SSE body.
+async fn raw_call_in_session(addr: SocketAddr, id: &str, tool: &str, args: Value) -> String {
+    let response = mcp_post(addr, Some(id))
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": { "name": tool, "arguments": args }
+        }))
+        .send()
+        .await
+        .expect("the tool call must reach the server");
+    assert!(
+        response.status().is_success(),
+        "an in-session tool call must be routed, got {}",
+        response.status()
+    );
+    response.text().await.expect("a tool call response body")
+}
+
+/// The `initialize` record whose client called itself `name`.
+fn initialize_of<'a>(events: &'a [AuditEvent], name: &str) -> &'a AuditEvent {
+    events
+        .iter()
+        .find(|e| match &e.kind {
+            AuditEventKind::Initialize(ev) => ev.client.name.as_deref() == Some(name),
+            _ => false,
+        })
+        .unwrap_or_else(|| panic!("no initialize record names {name}"))
+}
+
+/// The `tool_call` record whose client called itself `name`.
+fn tool_call_of<'a>(events: &'a [AuditEvent], name: &str) -> &'a AuditEvent {
+    events
+        .iter()
+        .find(|e| match &e.kind {
+            AuditEventKind::ToolCall(ev) => ev.client.name.as_deref() == Some(name),
+            _ => false,
+        })
+        .unwrap_or_else(|| panic!("no tool_call record names {name}"))
+}
+
+#[tokio::test]
+async fn initialize_record_joins_its_session() {
+    // Issue #180: the record whose whole job is to anchor a session had no
+    // join key. `session_info` read the `mcp-session-id` REQUEST header,
+    // which cannot exist on `initialize` — rmcp mints the id afterwards and
+    // returns it on the response — so the anchor was written with `id:
+    // None` and a reader could only join by adjacency.
+    let mock = MockServer::start().await;
+    mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
+
+    let dir = tempfile::tempdir().expect("audit temp dir");
+    let audit_path = dir.path().join("audit.jsonl");
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock, Some(audit_to(&audit_path))).await;
+
+    let wire_id = raw_initialize(addr, "joining-client").await;
+    let body = raw_call_in_session(addr, &wire_id, "bug_info", json!({ "bug_ids": [7] })).await;
+    assert!(
+        body.contains("\"result\""),
+        "the in-session call must be served: {body}"
+    );
+
+    let events = audit_events(&audit_path);
+    let init = events
+        .iter()
+        .find(|e| matches!(e.kind, AuditEventKind::Initialize(_)))
+        .expect("the handshake is recorded");
+    let call = events
+        .iter()
+        .find(|e| matches!(e.kind, AuditEventKind::ToolCall(_)))
+        .expect("the tool call is recorded");
+
+    assert_eq!(
+        init.session.id.as_deref(),
+        Some(wire_id.as_str()),
+        "the anchor must carry the id the transport minted and put on the wire"
+    );
+    assert_eq!(
+        call.session.id, init.session.id,
+        "the tool call must join its own initialize"
+    );
+    assert!(
+        init.seq < call.seq,
+        "the anchor precedes what it anchors: {} vs {}",
+        init.seq,
+        call.seq
+    );
+}
+
+#[tokio::test]
+async fn concurrent_sessions_join_to_their_own_initialize() {
+    // Two sessions, handshakes interleaved and the calls issued in the
+    // reverse order, so adjacency — the nearest preceding initialize from
+    // the same remote, which #180 says is not a join — answers wrongly for
+    // both. Kills a wrapper carrying id state ACROSS calls (set at
+    // initialize, read at create_stream): it stamps the newer session onto
+    // the older one's call.
+    //
+    // Sequential by construction, so it does NOT kill a wrapper that sets
+    // and re-reads shared state WITHIN one call. Only overlapping traffic
+    // separates that from correct code, and measured here it killed such a
+    // mutant in 2 of 20 runs at 8 concurrent sessions — a guard that weak
+    // would launder the regression it is meant to catch, so it is left out
+    // deliberately. (#167 rhymes without matching: there a race-dependent
+    // observation was made deterministic by changing the mechanism; here
+    // no deterministic mechanism exists, so the coverage goes rather than
+    // the determinism.) What excludes that class is structural, not this
+    // test: `stamp` takes the id as a parameter, and the wrapper adds no
+    // state of its own to `LocalSessionManager`.
+    let mock = MockServer::start().await;
+    mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
+
+    let dir = tempfile::tempdir().expect("audit temp dir");
+    let audit_path = dir.path().join("audit.jsonl");
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock, Some(audit_to(&audit_path))).await;
+
+    let a = raw_initialize(addr, "client-a").await;
+    let b = raw_initialize(addr, "client-b").await;
+    assert_ne!(a, b, "two handshakes are two sessions");
+    // b calls first: record order is not handshake order.
+    raw_call_in_session(addr, &b, "bug_info", json!({ "bug_ids": [7] })).await;
+    raw_call_in_session(addr, &a, "bug_info", json!({ "bug_ids": [7] })).await;
+
+    let events = audit_events(&audit_path);
+    assert_eq!(
+        initialize_of(&events, "client-a").session.id.as_deref(),
+        Some(a.as_str()),
+        "a's anchor must carry a's minted id"
+    );
+    assert_eq!(
+        initialize_of(&events, "client-b").session.id.as_deref(),
+        Some(b.as_str()),
+        "b's anchor must carry b's minted id"
+    );
+    assert_eq!(
+        tool_call_of(&events, "client-a").session.id.as_deref(),
+        Some(a.as_str()),
+        "a's call must join a's initialize, not the nearest one"
+    );
+    assert_eq!(
+        tool_call_of(&events, "client-b").session.id.as_deref(),
+        Some(b.as_str()),
+        "b's call must join b's initialize, not the nearest one"
+    );
+}
+
+#[tokio::test]
+async fn a_forged_session_id_is_not_copied_into_a_refusal_record() {
+    // The other half of #180. `serve_negotiated_request_directly` injects
+    // the request Parts verbatim and `has_session` runs only on the session
+    // branch, so on the stateless path `mcp-session-id` is client free
+    // text: a caller that never handshook could file its refusal under a
+    // live session's id. The record answers with no id rather than a
+    // forgeable one (#34: a forgeable id is worse than none).
+    let mock = MockServer::start().await;
+    mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
+
+    let dir = tempfile::tempdir().expect("audit temp dir");
+    let audit_path = dir.path().join("audit.jsonl");
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock, Some(audit_to(&audit_path))).await;
+
+    let victim = raw_initialize(addr, "real-client").await;
+
+    // The one handshake-free shape still reachable on a revision this build
+    // serves (see `a_handshake_free_call_is_refused_and_never_names_a_client`),
+    // wearing the live session's id.
+    let response = mcp_post(addr, Some(&victim))
+        .header("MCP-Protocol-Version", "2025-11-25")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "bug_info",
+                "arguments": { "bug_ids": [7] },
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2025-11-25",
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                }
+            }
+        }))
+        .send()
+        .await
+        .expect("the forged request must reach the server");
+    let body = response.text().await.expect("a body");
+    assert!(
+        !body.contains("a plain bug"),
+        "a handshake-free call must not be served: {body}"
+    );
+
+    let events = audit_events(&audit_path);
+    let calls: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e.kind, AuditEventKind::ToolCall(_)))
+        .collect();
+    assert_eq!(calls.len(), 1, "the refused call is recorded exactly once");
+    assert_eq!(
+        calls[0].session.id, None,
+        "a client-supplied session id must never become a record's id; \
+         the forged value was {victim}"
+    );
+    // The victim's own anchor is untouched: only the forger loses an id.
+    assert_eq!(
+        initialize_of(&events, "real-client").session.id.as_deref(),
+        Some(victim.as_str()),
+        "the handshake that really happened keeps its anchor"
+    );
+}
+
+#[tokio::test]
+async fn a_refused_call_in_a_session_keeps_its_session_anchor() {
+    // The refused class spans BOTH arrivals, and only this one has a
+    // session to name. `skips_the_handshake` fires on any `_meta` protocol
+    // declaration, which is deliberately broader than rmcp's stateless
+    // routing: a sub-2026 declaration without `clientCapabilities` stays on
+    // the session branch (see that function's rustdoc), so the refusal is
+    // recorded with the real minted id and joins its own `initialize` —
+    // the join #180 newly makes possible, since that anchor had no id
+    // before. Pinned because prose alone got this backwards once.
+    //
+    // The `MCP-Protocol-Version` header is load-bearing: without it rmcp
+    // answers -32020 ("request _meta protocolVersion requires
+    // MCP-Protocol-Version header") before any handler runs, and this test
+    // would pass having recorded no refusal at all — true for the wrong
+    // reason.
+    let mock = MockServer::start().await;
+    mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
+
+    let dir = tempfile::tempdir().expect("audit temp dir");
+    let audit_path = dir.path().join("audit.jsonl");
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock, Some(audit_to(&audit_path))).await;
+
+    let wire_id = raw_initialize(addr, "declaring-client").await;
+    let response = mcp_post(addr, Some(&wire_id))
+        .header("MCP-Protocol-Version", "2025-11-25")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "bug_info",
+                "arguments": { "bug_ids": [7] },
+                "_meta": { "io.modelcontextprotocol/protocolVersion": "2025-11-25" }
+            }
+        }))
+        .send()
+        .await
+        .expect("the declaring call must reach the server");
+    let body = response.text().await.expect("a body");
+    assert!(
+        body.contains("requires the initialize handshake"),
+        "the declaration must be refused by the handler, not served or \
+         turned away by the transport: {body}"
+    );
+    let upstream = mock.received_requests().await.unwrap_or_default();
+    assert!(
+        upstream.is_empty(),
+        "a refused call must contact no upstream: {} request(s)",
+        upstream.len()
+    );
+
+    let events = audit_events(&audit_path);
+    let calls: Vec<_> = events
+        .iter()
+        .filter_map(|e| match &e.kind {
+            AuditEventKind::ToolCall(ev) => Some((e, ev.as_ref())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(calls.len(), 1, "the refused call is recorded exactly once");
+    let (record, event) = calls[0];
+    assert_eq!(event.client.name, None, "a refusal names no client");
+    assert!(event.guard.is_none(), "the guard never ran");
+
+    let anchor = initialize_of(&events, "declaring-client");
+    assert_eq!(
+        record.session.id.as_deref(),
+        Some(wire_id.as_str()),
+        "a refusal that DID open a session keeps its id"
+    );
+    assert_eq!(
+        record.session.id, anchor.session.id,
+        "and so joins the initialize that anchors it"
     );
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1184,9 +1184,13 @@ Decisions, all deliberate:
 - **Record provenance.** `guard.policy_hash` is `sha256:<hex>` over the
   policy file bytes, so a record ties to the exact policy that produced
   it (`None` under the built-in default policy). stdio sessions are
-  anchored by `<pid>-<startup epoch>`; http sessions by the
-  `mcp-session-id` header, with the remote address when the listener
-  provides connect-info.
+  anchored by `<pid>-<startup epoch>`; http sessions by the id the
+  transport minted — stamped into the request extensions by the
+  `SessionManager` wrapper in `http_session`, never read from the
+  `mcp-session-id` request header (issue #180) — with the remote address
+  when the listener provides connect-info. The `initialize` record carries
+  it too, so the anchor joins to what it anchors; a handshake-free
+  stateless request opens no session and its record carries no id.
 - **Trace enrichment (issue #28).** When a tool call's `params._meta`
   carries a `traceparent` (SEP-414), its trace and span ids are copied
   into the record's `trace` field — the pre-dispatch fail-closed gate
@@ -1783,6 +1787,26 @@ wired, `server.rs` and `main.rs` are the reference.
   `get_info` only and reaches no tool, guard or router. General rule: **no
   `_meta` key and no `Mcp-*` header may carry a security decision** — like
   `KNOWN_VERSIONS`, they are the SDK's vocabulary, not this build's contract.
+- **rmcp trap — `mcp-session-id` is a validated header on only one of the two
+  routes.** In rmcp 3.1.4 the session branch of `handle_post`
+  (`transport/streamable_http_server/tower.rs`) checks the header against
+  `has_session` before it routes on it, and 404s an id it does not know; the
+  stateless branch has no such check and `serve_negotiated_request_directly`
+  injects the request Parts verbatim, so on that route the header is client
+  free text. On `initialize` there is no header at all — rmcp mints the id
+  after injecting the Parts and returns it on the *response*. Sourcing the
+  audit `session.id` from that header therefore did both wrong things at once
+  (issue #180): the record that exists to anchor a session had no join key,
+  and a stateless refusal could be filed under a live session's id. The id now
+  rides a `TransportSessionId` request extension stamped by this build's own
+  `SessionManager` wrapper (`http_session`), which is handed the minted id
+  together with the owned message — the seam rmcp itself uses for
+  `SessionRestoreMarker`, message extensions reaching `RequestContext`
+  verbatim. Re-check both halves on every rmcp bump: that `SessionManager`
+  still receives the message, and that the stateless branch still validates no
+  session. Deliberate consequence: a stateless refusal records no session id
+  even when the caller innocently echoed one, because a forgeable id is worse
+  than none (#34).
 - `list_tools` names every `ListToolsResult` field: `result_type` is
   `COMPLETE`, and the 2026-07-28 cache hints stay absent while that revision
   is unserved. When it is adopted, `cache_scope` is `Private` — the listing is
@@ -2297,7 +2321,18 @@ wired, `server.rs` and `main.rs` are the reference.
   startup error from `http_server_config` — the same call `serve_http` and
   `main` take — so it cannot reach rmcp as a silent deny-all. The info
   line and the unparsable refusal are also pinned in server.rs / config.rs
-  unit tests (deleting either fails a test).
+  unit tests (deleting either fails a test). Session-id provenance (#180),
+  driven over the raw wire because the value in question is a header no
+  rmcp client exposes: the `initialize` record carries the id rmcp minted
+  and returned on the RESPONSE, and a tool call in that session carries
+  the same one at a later `seq`; two sessions each join their own
+  `initialize` rather than the nearest; a handshake-free request wearing
+  a live session's `mcp-session-id` is refused with NO id recorded, never
+  that session's; and — because the handshake refusal is deliberately
+  broader than rmcp's stateless routing — a declaration that stayed on
+  the session branch is refused WITH its real id and joins its own
+  `initialize`. That last arm is the only test pinning it, and the
+  comment asserting it has been wrong once.
 - Configuration tests (crates/bugwarden/tests/env_config.rs, the REAL
   process environment): every flag is settable from the environment, which
   is what a container deployment configures through (#31/#32). ONE test by
@@ -2461,8 +2496,10 @@ wired, `server.rs` and `main.rs` are the reference.
   ambient timing: a threshold over a localhost round trip is either
   flaky or so loose a constant passes it, so the assertion is that a
   delayed request's total EXCEEDS an undelayed one's by most of the
-  delay. The http `session` block (its id and remote peer)
-  is observed only over a hand-built value; the stdio arm is pinned. The
+  delay. The http `session.id` is now pinned end to end against the id on
+  the wire (issue #180); `remote` is still observed only over a
+  hand-built value, no harness serving with connect-info; stdio is
+  pinned. The
   `bug_history` window (issue #142) is pinned on both sides: a `head` that
   actually omits entries records `history_window` in `redacted_fields`
   under verdict `served_filtered`, while params covering every entry stay


### PR DESCRIPTION
Closes #180. Prerequisite for #34's PR 1 — schema v2 documents the
session-anchoring story, and v2 is a one-way commitment, so the story has to be
true first.

## One defect, two symptoms

`session_info` sourced the audit record's `session.id` from the **client-supplied**
`mcp-session-id` request header.

1. **`initialize` records had no id.** rmcp mints the id *after* injecting the
   request Parts and attaches it only to the **response** header, so the header
   is absent on the initialize request. The record whose stated purpose is to
   anchor a session could not be joined to it — anchoring worked only by
   adjacency, which breaks under interleaving.
2. **Refusal records could carry a forged id.** On the stateless branch
   `serve_negotiated_request_directly` injects the Parts verbatim; `has_session`
   runs only on the session branch. Live on main, and reproduced first try — T2
   failed with `left: Some("ce64c630-…")`, the **victim's** live session id.

## The fix

`StreamableHttpService` takes a `SessionManager` that bugwarden supplies, and
`initialize_session(id, message)` / `create_stream(id, message)` receive both the
minted id and the owned message, whose extensions propagate verbatim into
`RequestContext`. rmcp uses this pattern itself for `SessionRestoreMarker`.

So: `AuditedSessionManager` delegates to `LocalSessionManager` and stamps a
`TransportSessionId` extension; `session_info` reads it and the header read is
**deleted** — nothing in `src/` reads `mcp-session-id` any more. The id recorded
is the one rmcp puts on the wire, so operator and client logs see one id, not
two.

Not a schema change: `SessionInfo.id` already promised "Server-assigned session
identifier". Goldens untouched, v1 stays v1.

**Behavioural deltas:** in-session records byte-identical (the validated header
value *is* what is passed to `create_stream`); `initialize` records gain their
id; stateless refusals lose the copied value even when echoed innocently —
deliberate, per #34's "a forgeable id is worse than none".

**Bonus the plan didn't anticipate:** a session-branch refusal now joins its own
`initialize`. That refusal records `client: {}` by policy, so the `initialize`
is the only record naming the caller — and it was the one that couldn't be found.

## Tests

Four, all red on main (proven before any fix existed), each carrying the
mutation it kills. The one worth calling out is **T1b**: a wrapper sharing one id
across sessions is killed by it *alone* — T1 and T2 both pass that mutant.

`a_refused_call_in_a_session_keeps_its_session_anchor` earns its place by
measurement: with it skipped, clearing `session.id` on the refusal path passes
**640 tests across 19 binaries**. It is the sole guard, for exactly the claim
three passes over this file disagreed about.

**A concurrency assertion was deliberately omitted.** A "last id wins" wrapper is
killed 2 times in 20 runs at 8 concurrent sessions; a `MutexGuard`-held variant 0
in 20. A guard that weak reports the class as covered while passing 9 of 10 CI
runs with the regression live, so the test stays deterministic and the exclusion
rests on a structural argument instead — `stamp` takes the id as a parameter and
the wrapper adds no state of its own. The test's comment claims only what it
proves.

`accept_message` is stamped but **unkillable today** — bugwarden implements no
notification handler, so removing it fails nothing. Kept and documented as
defensive rather than left to look tested; a reviewer confirmed no seam-level
test can reach it.

## Review

Opus adversarial returned NOT MERGE-SAFE on two false sentences; Fable's final
pass returned MERGE-SAFE after re-deriving both judgment calls itself.

**One of those blockers was my error, not the implementer's.** I asserted this
change would falsify a comment PR 0 had just landed and instructed a rewrite.
It didn't: `skips_the_handshake` is broader than rmcp's stateless routing, so a
session-branch arrival is refused *with* its real id — which that file's own
rustdoc says. A true sentence was replaced with a false one on a
security-relevant provenance comment. Now correct, and pinned by the fourth test
so it cannot go wrong a third time.

## Found and tracked, not folded in

**#183** — a `///` on a `pub mod` whose file has `//!` docs resolves the module's
intra-doc links in the parent scope; `audit`, `http_auth` and `otel` carry the
same shape and pass only because their lines contain no links. **#184** — this
test file's module header claims every test connects an rmcp client for key
custody; four of these don't.

## Verification

All eight AGENTS.md commands re-run independently on the final commit: green,
18 tests in the transport file, 0 failed. `futures-core` was already in the lock
via rmcp — one-line diff, no new crate, MSRV untouched.
