### PR TITLE
feat(audit): schema v2 — split suppressed_count, reserve work_context

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,8 +333,10 @@ and the server says so loudly at startup.
 > that only implements the spec's `401` → resource-metadata → OAuth dance will
 > not authenticate; use one that lets you set a header. And the token
 > authenticates a *deployment*, not a caller: audit records carry no
-> `principal`, which stays [issue #32](https://github.com/plusky/bugwarden/issues/32)'s
-> job.
+> `principal` and no `work_context`. Both slots are reserved for a validator
+> that can prove *which* caller made a call and *what work* it was authorized
+> under, which stays
+> [issue #32](https://github.com/plusky/bugwarden/issues/32)'s job.
 
 #### Bugzilla credentials
 
@@ -847,22 +849,27 @@ are byte-identical.
 
 ### Records
 
-One JSON object per line, schema version 1, in three kinds:
+One JSON object per line, schema version 2, in three kinds:
 
 - **`initialize`** — a client opened a session; carries the client's
   self-declared name and version and the *negotiated* protocol revision.
   Written unconditionally, with no knob to suppress it.
 - **`tool_call`** — exactly one per tool invocation, including calls that
   were denied, refused, or aimed at a tool name that does not exist. The
-  tool listing is deliberately not recorded.
+  tool listing is deliberately not recorded. One per *attempt*, precisely:
+  a client that loses a response and re-issues the call produces a second
+  record under a new request id, and two records is the true account — the
+  re-issued call did its upstream work again, so collapsing them would
+  under-report real Bugzilla writes.
 - **`audit_gap`** — records were lost; carries how many and whether the
   cause was a write or a rotation error. The gap is reported in the stream
   itself, so silent loss is impossible to miss.
 
 Every record carries `v`, a millisecond-precision UTC `ts`, a per-process
 monotonic `seq` (the ordering authority — file order equals `seq` order),
-and a `session` naming the transport, the session id and, over http, the
-peer address. A `tool_call` adds the client, the request (tool name, request
+and a `session` naming the transport, the peer address over http, and the
+session id where the transport opened a session at all — a call refused on
+the handshake-free path opened none, and carries no id. A `tool_call` adds the client, the request (tool name, request
 id, parameters), the `outcome` — class, duration and, when there was a
 result to measure, `response_bytes`: the serialized size of the content
 the server produced — the compact JSON of the result's content array,
@@ -886,7 +893,8 @@ tools that consult the guard — a `guard` object:
 | `verdict` | `served`, `served_filtered`, `denied` or `refused`; the worst verdict of the call wins |
 | `rule` | What decided a per-bug assessment. Alongside the policy's own rule names the guard reports its own: `default` when no rule matched — a default-decided call records that literal, never an absent field — `min_bug_age_days` for the age quarantine, `<name>:unreadable-metadata` for a *granting* rule whose verdict hinged on metadata that could not be read (an undecidable deny rule keeps its plain name, having denied for its own reason), `unavailable` for a bug the classification fetch could not reach. A policy naming one of its own rules `default` — or any of the others — is a startup error, so this field says what decided *and* what kind of thing it was. Absent only where no single rule decided: a refusal, the pre-dispatch gate, a search, either arm of the create gate, an id the guard could not assess, a withheld attachment, and a serve that a rule-less note — a suppression, a guard redaction, a search scan that dropped rows — *upgraded* to `served_filtered`, since the worst verdict wins and none of those was any one rule's doing. Only an upgrade clears it: a rule-less note recorded alongside a verdict already that severe leaves the rule standing, which is why `bug_info`'s `summary_view` record still names its rule. A *client-requested* window (the three `*_window` names under `redacted_fields`) never touches the rule at all, upgrade or not, because the client asking for fewer lines decided nothing. A tool removed from the router (read-only mode, `disabled_tools`, discovery off) records no `guard` object at all |
 | `policy_hash` | `sha256:` over the raw policy file bytes, so a record says which policy text judged the call. Absent when no policy file is loaded |
-| `suppressed_count` | How much the response withheld, in total: bug ids on a search or a multi-bug read, plus the private comments and attachment metadata the private-content gate removed. The two never overlap — a call reads its bug ids off the content that survived filtering — so the field is their sum, and it is the authoritative number: never infer a count from the id list, which names bugs only and can be switched off entirely. Two ids under a count of five means three withheld items had no bug id of their own |
+| `suppressed_ids_count` | How many withheld items had a bug id of their own: rows a search dropped, and bug ids scrubbed out of what was served — a hidden `depends_on`, `see_also` or duplicate-marker reference — so a single-bug `bug_comments` or `summarize_bug` call can carry them too. Counted from the guard's own id set *before* the `suppressed_ids` switch can elide the list, so it survives that switch — never infer it from the id list, which may be empty while this is not |
+| `suppressed_other_count` | How many withheld items had no bug id: the private comments and attachment metadata the private-content gate removed, counted but never named. Disjoint from the count above — a call reads its bug ids off the content that survived filtering, so nothing is in both — and no total is recorded, because a stored total beside its own parts can disagree with them. Add them yourself if you want one |
 | `suppressed_ids` | The withheld bug ids, subject to the `suppressed_ids` switch |
 | `redacted_fields` | Names of what a response dropped, never values, of two kinds: what the guard redacted — `summary_view` for a bug served through the redacted summary view — and what the client's own `head`/`tail`/length params cut, `comments_window`, `history_window` and `attachment_window`, present only when the window actually cut something. Only the first kind is a guard decision, which is why the second leaves `rule` standing |
 | `scan` | Present on every served search, carrying how many rows the window scanned and how many it dropped, so `dropped: 0` is a statement and not an omission; absent on a search that failed and on tools that scan nothing. The counts are recorded whatever the `suppressed_ids` switch says: counts are not ids |
@@ -922,6 +930,22 @@ so a fifty-row answer costs a second page to learn there is no more, and
 the link-disclosure classify after it is issued even with no links to
 disclose (skipping it would price "no links" below "links, all hidden").
 
+Not every field in a record is worth the same, and the difference is a
+property of the field rather than of the value it happens to hold.
+`client.name` and `client.version` are *self-declared* — whatever the client
+said about itself, verified by nothing, so they are labels and never
+identities. `client.principal` and `client.work_context` are the opposite,
+*server-verified*: only a validator this server trusts may ever fill them,
+nothing self-declared may be promoted into either, and both are reserved —
+no verifier exists, so neither appears in a record this build writes.
+`session.id` is *server-minted*: records sharing one passed through a single
+transport session and join that session's `initialize` record, which proves
+grouping and says nothing about who was at the other end. Everything else
+that looks like an identifier — `trace`, `request.id`, `session.remote` — is
+a *correlation hint*, client-chosen or path-dependent: useful for joining
+records, evidence of nothing. The normative version of that list lives with
+the schema, in the module documentation of `crates/bugwarden/src/audit.rs`.
+
 ### What can never appear in a record
 
 The schema is closed — fixed structs, fixed vocabularies — and it has no
@@ -938,12 +962,21 @@ parameter — `comment`, `summary`, `description`, `url`, `whiteboard`,
 presence and size but never its content.
 
 ```json
-{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":7,"session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"event":"tool_call","client":{"name":"example-agent","version":"1.4.2"},"request":{"tool":"bugs_quicksearch","id":"3","params":{"limit":50,"offset":0,"query":"kernel panic","status":"ALL"}},"guard":{"verdict":"served_filtered","policy_hash":"sha256:58013baa090cf77630373ab50cc5eaf2d679ec5a06e8a336600fc89b23bb8604","suppressed_count":2,"suppressed_ids":[1290040,1290041],"redacted_fields":[],"scan":{"scanned":50,"dropped":2}},"upstream":{"requests":3,"status":200,"latency_ms":48},"outcome":{"class":"ok","duration_ms":52,"response_bytes":6218}}
+{"v":2,"ts":"2026-02-03T04:05:06.789Z","seq":7,"session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"event":"tool_call","client":{"name":"example-agent","version":"1.4.2"},"request":{"tool":"bugs_quicksearch","id":"3","params":{"limit":50,"offset":0,"query":"kernel panic","status":"ALL"}},"guard":{"verdict":"served_filtered","policy_hash":"sha256:58013baa090cf77630373ab50cc5eaf2d679ec5a06e8a336600fc89b23bb8604","suppressed_ids_count":2,"suppressed_other_count":0,"suppressed_ids":[1290040,1290041],"redacted_fields":[],"scan":{"scanned":50,"dropped":2}},"upstream":{"requests":3,"status":200,"latency_ms":48},"outcome":{"class":"ok","duration_ms":52,"response_bytes":6218}}
 ```
 
 A reader of the file should skip empty lines and tolerate at most one
 unparsable line per outage: a failed write can leave a partial line, and the
 stream heals itself on the next successful record.
+
+Version 2 broke one line shape, deliberately. A `tool_call` written by a
+pre-2 bugwarden carries `guard.suppressed_count`, the single field the two
+counts above replaced, and a version 2 reader rejects that line rather than
+invent a split for a number that cannot be split after the fact. Nothing
+else broke: older `initialize`, `audit_gap` and guard-less `tool_call` lines
+still parse. Records are never rewritten, so a file spanning an upgrade
+holds both versions and every line keeps the `v` it was written with — split
+on that field before assuming what a field name means.
 
 ### OpenTelemetry export
 

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -24,7 +24,7 @@
 //!
 //! # File format
 //!
-//! One JSON object per line (JSONL), schema version 1: see [`AuditEvent`]
+//! One JSON object per line (JSONL), schema version 2: see [`AuditEvent`]
 //! for the envelope and [`AuditEventKind`] for the record kinds. Records
 //! are append-only; [`AuditSink`] optionally rotates the file by size.
 //! A failed write can tear the stream: a failed `write(2)` may leave a
@@ -32,6 +32,34 @@
 //! record with a newline. After an outage the file may therefore contain
 //! one empty line and possibly one torn (unparsable) line — parsers must
 //! skip empty lines and may encounter at most one torn line per outage.
+//!
+//! # Trust tiers
+//!
+//! The fields that name a caller, or that let records be joined to one,
+//! come from four different places — and reading one at the wrong tier
+//! is how an audit trail misleads. The tier is a property of the FIELD,
+//! not of the value it happens to hold: a plausible-looking name is
+//! still self-declared.
+//!
+//! | Tier | Fields | What it is worth |
+//! |---|---|---|
+//! | Self-declared | `client.name`, `client.version` | Whatever the client said about itself. Never verified, by anything: a label, never an identity. |
+//! | Server-verified | `client.principal`, `client.work_context` | Only a validator this server trusts may mint one, and nothing self-declared may be promoted into either. Reserved: no verifier exists, so neither appears in a record THIS BUILD writes — a later build that can prove a caller fills them without moving `v`. |
+//! | Server-minted | `session.id` | Within one deployment's stream, proves that records sharing it passed through one transport session, and joins them to that session's `initialize`. Says nothing about WHO was on the other end. |
+//! | Correlation hint | `trace`, `request.id`, `session.remote` | Client-chosen or path-dependent — a `traceparent` any caller may stamp, an id the client picked, a peer address that is the last proxy's behind one. Useful for joining records; evidence of nothing. |
+//!
+//! This table is normative and versioned with the schema: a new field
+//! that names or correlates a caller belongs to one of these four tiers,
+//! and adding one without saying which is the omission that lets a
+//! reader promote a claim into a fact. The REST of a record — verdicts,
+//! rule names, counts, timings, the tool called — is the server's own
+//! account of what it did rather than a claim about anybody, so the
+//! tiering question does not arise for it. ONE EXCEPTION, and it is the
+//! case a future field is likeliest to hit: [`RequestInfo::params`] is
+//! verbatim CLIENT-authored content, not the server's account of
+//! anything, so a value read out of it is a correlation hint at best and
+//! never an identity — a grouping handle a client was given and handed
+//! back included.
 //!
 //! # What can never appear in a record
 //!
@@ -90,14 +118,85 @@ use sha2::{Digest as _, Sha256};
 
 /// The audit record schema version stamped into every event (`v`).
 ///
-/// It tracks the STRUCTURE a reader must handle — fields, their names,
-/// their types — and not the meaning of what those fields hold. A field
-/// whose definition is corrected without changing the wire shape keeps
-/// `v`, so a corpus at one version can span both readings and the
-/// deployed build, not this number, is the boundary between them (see
-/// `guard.suppressed_count` in DESIGN.md, issue #68). Re-encoding the
-/// stream so that meaning changes ARE visible is #34's business.
-pub const SCHEMA_VERSION: u32 = 1;
+/// It tracks the STRUCTURE a reader must handle — the fields, their
+/// names, their order and their types, and the record kinds — and not
+/// the meaning of what those fields hold. A field whose definition is
+/// corrected without changing the wire shape keeps `v`, so a corpus at
+/// one version can span both readings, with the deployed BUILD and not
+/// this number as the boundary between them. What that structure may
+/// still GROW inside a version is the rule below; the rest of it is
+/// frozen for the version's life.
+///
+/// # The growth rule
+///
+/// Within one version, two changes are allowed:
+///
+/// - adding an OPTIONAL field that is absent when unset;
+/// - adding a new RECORD KIND.
+///
+/// Neither MAY change how an existing field is read. That is a
+/// requirement of the rule, not an observation about it: an optional
+/// field that redefines a field already shipping — a hypothetical
+/// `guard.counts_are_floors`, absent when unset — is structurally
+/// additive and still forbidden, because it is #68's injury again, a
+/// meaning moving invisibly under an unchanged `v`. Such a change moves
+/// the number however optional it looks.
+///
+/// Past that the two differ, and the difference is not symmetric: a new
+/// KIND never reaches a consumer selecting on `event` — one filtering
+/// `event == "tool_call"` does not see it — while a new FIELD has no
+/// such escape and lands in the very records that consumer already
+/// selects. What they share is
+/// the direction of the break they can cause: `deny_unknown_fields`
+/// means a reader built BEFORE the addition rejects a line carrying it,
+/// so staying within a version buys old files new readers, never old
+/// readers new files. The goldens block in this module's tests pins the
+/// discipline that goes with it.
+///
+/// REMOVING, RENAMING, REORDERING or RETYPING a field moves this number.
+/// So a new kind is not a bump, and #32's refusal record — should it
+/// ever be recorded rather than logged — would not force one.
+///
+/// Widening a CLOSED VOCABULARY ([`GapReason`], [`Verdict`],
+/// [`OutcomeClass`], [`TransportKind`]) is NOT the additive case, and it
+/// does move the number. An added field or kind is something a reader
+/// can decline to look at; a new VARIANT lands inside a field every
+/// reader of that kind already reads, and there is nothing to decline.
+/// That missing escape is the difference, so a vocabulary change does
+/// not inherit the licence the other two have.
+///
+/// # What v2 changed
+///
+/// - `guard.suppressed_count` is GONE, split into
+///   [`GuardInfo::suppressed_ids_count`] and
+///   [`GuardInfo::suppressed_other_count`] (issue #68). No total ships:
+///   a total beside its own parts can disagree with them, and losing the
+///   shared field name is what makes the break loud rather than silent.
+/// - [`ClientInfo::work_context`] is reserved beside
+///   [`ClientInfo::principal`], and both are documented as CONTRACTS
+///   about who may fill them rather than as the `None` they hold today
+///   (issue #34).
+///
+/// v1 carried a correction the split supersedes: `suppressed_count`
+/// became the SUM of the two tallies where it had been their maximum,
+/// invisible on the wire and therefore undetectable from a record. That
+/// invisibility is precisely the argument for making the distinction
+/// structural now.
+///
+/// # The v1 break, and its exact scope
+///
+/// Deliberate, and load-bearing. A v2 reader REJECTS every v1
+/// `tool_call` line that carries a `guard` object:
+/// `deny_unknown_fields` refuses `suppressed_count`, and a reader that
+/// accepted it would have to invent a split for a number that cannot be
+/// split after the fact.
+///
+/// It rejects nothing else. v1 `initialize`, `audit_gap`, and
+/// guard-less `tool_call` lines still parse — and parse carrying
+/// `v: 1`, because this reader does not dispatch on `v`. A consumer
+/// holding a mixed corpus must therefore split on that field itself
+/// before assuming either version's semantics.
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// How often a persistently failing sink repeats its `tracing` diagnostic.
 const FAILURE_LOG_INTERVAL: Duration = Duration::from_secs(60);
@@ -339,7 +438,7 @@ pub fn select_sinks(
 }
 
 // ---------------------------------------------------------------------------
-// Event schema (v1)
+// Event schema (v2)
 // ---------------------------------------------------------------------------
 
 /// One audit record: the envelope common to every kind.
@@ -354,7 +453,13 @@ pub fn select_sinks(
 /// structs are closed.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AuditEvent {
-    /// Schema version; always [`SCHEMA_VERSION`].
+    /// Schema version. Write side: this build stamps [`SCHEMA_VERSION`]
+    /// into every record it produces. READ side is not the same claim —
+    /// the deserializer neither checks this field nor dispatches on it,
+    /// so a line off disk carries whatever version wrote it, and a v1
+    /// line outside the v2 break parses with `v: 1` intact (see
+    /// [`SCHEMA_VERSION`]). A consumer holding a mixed corpus must split
+    /// on this value before assuming either version's semantics.
     pub v: u32,
     /// Wall-clock record time, RFC 3339 UTC with millisecond precision.
     /// Stamped by the sink. `seq`, not `ts`, is the ordering authority —
@@ -461,12 +566,32 @@ pub enum GapReason {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SessionInfo {
-    /// Server-assigned session identifier, present when the transport
+    /// Server-MINTED session identifier, present when the transport
     /// actually opened a session: over http the id rmcp minted, over
     /// stdio the process itself. Never a client-supplied value — the
-    /// `mcp-session-id` request header is not read (#180) — so the
-    /// handshake-free stateless path, which opens no session, records
-    /// none.
+    /// `mcp-session-id` request header is not read (#180).
+    ///
+    /// What it GUARANTEES is grouping WITHIN ONE DEPLOYMENT'S STREAM:
+    /// records sharing an id passed through one transport session, and
+    /// that session's `initialize` record carries the same id, so a tool
+    /// record can be joined to the handshake that anchors it.
+    ///
+    /// That scope is load-bearing, not boilerplate. Over stdio the id is
+    /// `<pid>-<startup epoch seconds>`, unique on a host and not beyond
+    /// it, and no field of a record names the deployment that wrote it.
+    /// A collector merging several deployments must therefore key on the
+    /// exporter's `service.name` beside the id — and that name defaults
+    /// to the constant `bugwarden`, so an operator aggregating more than
+    /// one deployment has to set it.
+    ///
+    /// What it does NOT: it is not an identity. A session is a
+    /// connection, and nothing about who was on the other end of it
+    /// follows from the id. Nor does it exist on the handshake-free
+    /// per-request path, which opens no session — there the only
+    /// candidate is the `mcp-session-id` header, unvalidated client text
+    /// that any caller could stamp with a live session's id, and a
+    /// forgeable id is worse than none. Grouping there is
+    /// [`SessionInfo::remote`] plus nothing.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// Which transport carried the session.
@@ -487,21 +612,68 @@ pub enum TransportKind {
 }
 
 /// The calling client's identity, as far as one exists.
+///
+/// Two opposite contracts in one struct. [`ClientInfo::name`] and
+/// [`ClientInfo::version`] are SELF-DECLARED — whatever the client said
+/// about itself, in the `initialize` handshake (the only source this
+/// build has) or, on a handshake-free revision, in the request's own
+/// `_meta`. The source does not change the trust level; neither value is
+/// ever verified against anything. [`ClientInfo::principal`] and
+/// [`ClientInfo::work_context`] are the other contract: SERVER-VERIFIED,
+/// absent until a verifier exists, and never filled from anything
+/// self-declared.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ClientInfo {
-    /// Client name from the `initialize` handshake. Self-declared and
-    /// therefore untrusted: treat it as a label, never as an identity.
+    /// Client name as the client declared it: the `initialize`
+    /// handshake, and per-request `_meta` on a handshake-free revision
+    /// should this build ever serve one — the same trust level either
+    /// way. Self-declared and therefore untrusted: treat it as a label,
+    /// never as an identity.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    /// Client version from the `initialize` handshake. Untrusted, as
-    /// `name` is.
+    /// Client version, from the same source and at the same trust level
+    /// as [`ClientInfo::name`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
-    /// Reserved for a future authenticated identity. Always `None` for
-    /// now; nothing self-declared may ever be promoted into it.
+    /// SERVER-VERIFIED caller identity: who called, as this deployment
+    /// PROVED it — not who the caller says it is.
+    ///
+    /// Reserved. No verifier exists, so this field is absent from every
+    /// record THIS BUILD writes — which is a statement about the build,
+    /// not about the version: the slot is reserved precisely so that a
+    /// build which can prove a caller starts filling it without moving
+    /// `v`. Only a validator this server trusts may ever mint a value
+    /// here — the per-caller credential direction in issue #32 — and
+    /// nothing self-declared may be promoted into it, not
+    /// [`ClientInfo::name`] and not anything a request carries in
+    /// `_meta`. The deployment-wide bearer token does not qualify
+    /// either: it authenticates a deployment, not a caller.
+    ///
+    /// Not the same fact as [`ClientInfo::work_context`] — this one is
+    /// WHO.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub principal: Option<String>,
+    /// SERVER-VERIFIED work item the call was authorized under: a
+    /// maintenance-update identifier, a ticket, whatever a deployment's
+    /// validator binds its credential to. The format is deliberately not
+    /// pinned here — a syntax written into this contract is one issue
+    /// #32's validator would owe.
+    ///
+    /// Reserved, under [`ClientInfo::principal`]'s rule: only a trusted
+    /// validator may fill it, nothing self-declared may be promoted into
+    /// it, and it is absent from every record this build writes — again a
+    /// statement about the build, since filling it is a value change and
+    /// not a version change.
+    ///
+    /// Optional even once verification exists — a fleet-level agent
+    /// belongs to no work item. So absence carries two readings across
+    /// the life of v2: "no verifier yet" while this remains reserved,
+    /// "this caller belongs to no work item" once one ships. Like #68's
+    /// correction inside v1, the boundary is the deployed BUILD and not
+    /// `v`, which tracks structure and not meaning.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub work_context: Option<String>,
 }
 
 /// W3C-style trace correlation ids, when the transport carried any.
@@ -584,6 +756,17 @@ pub struct RequestInfo {
     /// MCP tool name.
     pub tool: String,
     /// JSON-RPC request id, when the transport exposes one.
+    ///
+    /// CLIENT-chosen, so a correlation hint and never an identity:
+    /// nothing stops two callers picking the same id, or one caller
+    /// reusing one.
+    ///
+    /// Records are per-ATTEMPT, not per intended call. A client that
+    /// loses a response and re-issues the call does so under a new id,
+    /// and the re-issued call performs its upstream work again — so two
+    /// records is the true account of what reached Bugzilla.
+    /// Deduplicating them would under-report real mutations, the one
+    /// direction this stream must not err in.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// CLIENT-authored request parameters, passed through an allowlist
@@ -644,10 +827,12 @@ pub struct GuardInfo {
     /// nothing, so they keep the granting rule
     /// ([`AuditCell::note_redacted_client_window`]).
     ///
-    /// Recording `"default"` rather than absence is deliberate — absence
-    /// could not also express "no single rule decided". Schema v1 encodes
-    /// it this way; the decision is recorded in DESIGN.md under "Audit
-    /// stream", and #34 tracks the schema change.
+    /// Recording `"default"` rather than absence is deliberate, and as
+    /// of schema v2 it is DECIDED rather than deferred (issue #67):
+    /// absence already means "no single rule decided" — the enumerated
+    /// cases above — so encoding the default as absence would load a
+    /// second meaning onto it that no reader could separate from the
+    /// first. Recorded in DESIGN.md under "Audit stream".
     ///
     /// [`Access`]: bugwarden_core::policy::Access
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -656,29 +841,37 @@ pub struct GuardInfo {
     /// the exact policy that produced it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub policy_hash: Option<String>,
-    /// How much the guard withheld from the response, in total: the
-    /// withheld bug ids PLUS the suppressed content that carries no bug
-    /// id of its own — private comments and private attachment metadata
-    /// the I5 gate removed. Not a count of bugs, then, and not a count of
-    /// either tally alone.
+    /// How many withheld items had a bug id of their own: the size of
+    /// the id set behind [`GuardInfo::suppressed_ids`] — I14-scrubbed
+    /// links, scrubbed duplicate-marker ids, search rows the scan
+    /// dropped by verdict.
     ///
-    /// The two populations are disjoint by construction, so the sum can
-    /// never double-count. The two tools that feed BOTH tallies —
+    /// Counted from that set BEFORE [`AuditConfig::suppressed_ids`] can
+    /// elide the list, so it survives the switch: with ids off this is
+    /// the only surviving statement of how many bugs were withheld, and
+    /// it must never be re-derived from the emitted vector.
+    pub suppressed_ids_count: u64,
+    /// How many withheld items had NO bug id: private comments and
+    /// private attachment metadata the I5 gate removed — counted, never
+    /// named.
+    ///
+    /// Disjoint from [`GuardInfo::suppressed_ids_count`] by
+    /// construction. The two tools that feed BOTH tallies —
     /// `bug_comments` and `summarize_bug` — derive their duplicate-marker
     /// ids from the comments that SURVIVED the private filter, so a
     /// dropped comment contributes its id to nothing even when it carries
     /// one; `list_attachments`, the third id-less site, names no ids at
     /// all.
     ///
-    /// This count is authoritative — it is the only tally that always
-    /// ships. [`GuardInfo::suppressed_ids`] carries bug ids alone, and
-    /// may be elided entirely by [`AuditConfig::suppressed_ids`], so
-    /// consumers must never infer the count from the id list: two ids
-    /// under a count of five says three withheld items had no bug id, not
-    /// that the record contradicts itself.
-    pub suppressed_count: u64,
+    /// No total ships beside the two (schema v2, issue #68). Addition is
+    /// the reader's, and a stored total could disagree with its own
+    /// parts; the split also makes the difference between the two
+    /// populations legible, which the single summed field never was.
+    pub suppressed_other_count: u64,
     /// The removed bug ids. Left empty by the recording call sites when
-    /// [`AuditConfig::suppressed_ids`] is `false`.
+    /// [`AuditConfig::suppressed_ids`] is `false` — an empty vector then
+    /// says nothing at all about how many there were, which is what
+    /// [`GuardInfo::suppressed_ids_count`] is for.
     pub suppressed_ids: Vec<u64>,
     /// Names of what the response dropped (names only, never values), of
     /// two kinds: what the GUARD redacted from served bugs
@@ -708,7 +901,7 @@ pub struct ScanInfo {
     /// included, because each one was fetched and looked at.
     pub scanned: u64,
     /// Rows the scan dropped by verdict. Authoritative on its own, like
-    /// [`GuardInfo::suppressed_count`]: the dropped ids ride
+    /// [`GuardInfo::suppressed_ids_count`]: the dropped ids ride
     /// [`GuardInfo::suppressed_ids`] and may be elided by configuration,
     /// so consumers must never infer this count from that list.
     pub dropped: u64,
@@ -832,12 +1025,15 @@ pub enum AuditError {
 impl AuditError {
     fn gap_reason(&self) -> GapReason {
         match self {
-            // `Export` reports as a write error on purpose: schema v1's
-            // vocabulary has no spelling for a delivery failure, and
-            // adding one would fork every reader of a v1 corpus over a
-            // record whose shape is unchanged. The DIAGNOSTIC says which
-            // sink failed; the record says only that records were lost.
-            // #34 owns the v2 vocabulary.
+            // `Export` reports as a write error on purpose: `GapReason`
+            // has no spelling for a delivery failure, and v2 declined to
+            // add one. Widening a closed vocabulary is not the growth
+            // rule's additive case — every reader of `audit_gap` meets
+            // the new variant in a field it already reads, with no
+            // `event` filter to opt out of it — so it would cost a
+            // version bump for a record whose shape is unchanged. The
+            // DIAGNOSTIC says which sink failed; the record says only
+            // that records were lost.
             AuditError::Serialize(_) | AuditError::Write(_) | AuditError::Export => {
                 GapReason::WriteError
             }
@@ -1596,9 +1792,10 @@ impl AuditCell {
     /// verdict exactly as [`AuditCell::note_suppressed`] does.
     ///
     /// This tally and [`AuditCell::note_suppressed`]'s id set must stay
-    /// disjoint populations: [`GuardInfo::suppressed_count`] SUMS them,
-    /// so a call site that counted an item here and also named it there
-    /// would count it twice.
+    /// disjoint populations: they ship as two fields a reader ADDS
+    /// ([`GuardInfo::suppressed_other_count`] and
+    /// [`GuardInfo::suppressed_ids_count`]), so a call site that counted
+    /// an item here and also named it there would count it twice.
     pub fn note_suppressed_count(&self, n: u64) {
         if n == 0 {
             return;
@@ -1668,10 +1865,10 @@ impl AuditCell {
     /// Drain the cell into the record's [`GuardInfo`]. `None` when no
     /// verdict was ever noted — the tool performed no guard assessment.
     /// When `suppressed_ids_cfg` is `false` the ids are dropped and only
-    /// the count ships ([`AuditConfig::suppressed_ids`]). The count is
-    /// the id set PLUS the id-less counter (issue #68): the two are
-    /// disjoint populations, so their sum is the total withheld and
-    /// nothing is counted twice.
+    /// the counts ship ([`AuditConfig::suppressed_ids`]). The two tallies
+    /// are projected into their own fields (issue #68, schema v2), never
+    /// summed here: they are disjoint populations, and the reader adds
+    /// them if it wants a total.
     pub fn into_guard_info(
         &self,
         policy_hash: Option<&str>,
@@ -1679,13 +1876,16 @@ impl AuditCell {
     ) -> Option<GuardInfo> {
         let state = std::mem::take(&mut *self.lock());
         let verdict = state.verdict?;
-        let suppressed_count =
-            (state.suppressed_ids.len() as u64).saturating_add(state.suppressed_extra);
+        // From the SET, before the config elision below empties the
+        // emitted vector — deriving it from that vector would zero the
+        // count exactly where it is the only signal left.
+        let suppressed_ids_count = state.suppressed_ids.len() as u64;
         Some(GuardInfo {
             verdict,
             rule: state.rule,
             policy_hash: policy_hash.map(str::to_owned),
-            suppressed_count,
+            suppressed_ids_count,
+            suppressed_other_count: state.suppressed_extra,
             suppressed_ids: if suppressed_ids_cfg {
                 state.suppressed_ids.into_iter().collect()
             } else {
@@ -1723,13 +1923,17 @@ mod tests {
         }
     }
 
-    /// A `tool_call` with every schema field populated.
+    /// A `tool_call` with every schema field populated — the two
+    /// reserved identity slots included, which no record this build
+    /// writes carries. An example value does not bind their contract;
+    /// filling them here is what makes the goldens a shape test.
     fn sample_tool_call() -> AuditEventKind {
         AuditEventKind::ToolCall(Box::new(ToolCallEvent {
             client: ClientInfo {
                 name: Some("example-agent".into()),
                 version: Some("1.4.2".into()),
                 principal: Some("alice@example.org".into()),
+                work_context: Some("SUSE:Maintenance:12345:678901".into()),
             },
             trace: Some(TraceContext {
                 trace_id: "0af7651916cd43dd8448eb211c80319c".into(),
@@ -1747,7 +1951,10 @@ mod tests {
                 verdict: Verdict::ServedFiltered,
                 rule: Some("group-restricted".into()),
                 policy_hash: Some("2b6e8f5d1c9a4e70".into()),
-                suppressed_count: 2,
+                suppressed_ids_count: 2,
+                // Deliberately NOT equal to the ids count: a swap of the
+                // two fields must change the golden's bytes.
+                suppressed_other_count: 3,
                 suppressed_ids: vec![1290040, 1290041],
                 redacted_fields: vec!["cc".into(), "flags".into()],
                 scan: Some(ScanInfo {
@@ -1774,6 +1981,7 @@ mod tests {
                 name: Some("example-agent".into()),
                 version: Some("1.4.2".into()),
                 principal: None,
+                work_context: None,
             },
             protocol_version: Some("2025-06-18".into()),
         })
@@ -1844,18 +2052,46 @@ mod tests {
         }
     }
 
-    // ---------- schema goldens (v1 stability gate) ----------
+    // ---------- schema goldens (v2 stability gate) ----------
     //
     // These strings ARE the wire format. A failure here means the schema
     // changed; that requires a deliberate decision, not an updated
-    // constant. One shape of change stays within v1: adding a field that
-    // is optional and absent when unset (as `guard.scan` was, issue #29).
-    // Such a change updates the golden AND must pin the prior byte
-    // sequence as a GOLDEN_*_PRE_* constant with a test proving old lines
-    // still deserialize. Any other byte change — removing, renaming,
-    // reordering, or retyping a field — requires a version bump.
+    // constant. Never paste serializer output into one of these — that
+    // can only enshrine whatever the code does, bug included; derive the
+    // new bytes by hand from the old ones and let the test judge the
+    // code.
+    //
+    // WITHIN v2 one shape of change is allowed: adding a field that is
+    // optional and absent when unset, or adding a record kind (see
+    // `SCHEMA_VERSION`). An added FIELD updates the golden AND must pin
+    // the prior byte sequence as a GOLDEN_*_PRE_* constant with a test
+    // proving old lines still deserialize; an added KIND has no prior
+    // bytes to pin and simply gains a golden of its own. ACROSS a bump the discipline
+    // inverts: the prior version's line stays pinned — here
+    // `GOLDEN_TOOL_CALL_V1` — with a test proving the current reader
+    // REJECTS it. Removing, renaming, reordering or retyping a field is
+    // what forces that bump.
 
     const GOLDEN_TOOL_CALL: &str = concat!(
+        r#"{"v":2,"ts":"2026-02-03T04:05:06.789Z","seq":7,"#,
+        r#""session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"#,
+        r#""event":"tool_call","#,
+        r#""client":{"name":"example-agent","version":"1.4.2","principal":"alice@example.org","work_context":"SUSE:Maintenance:12345:678901"},"#,
+        r#""trace":{"trace_id":"0af7651916cd43dd8448eb211c80319c","span_id":"b7ad6b7169203331"},"#,
+        r#""request":{"tool":"bug_info","id":"3","params":{"id":1290042,"include_private":false}},"#,
+        r#""guard":{"verdict":"served_filtered","rule":"group-restricted","policy_hash":"2b6e8f5d1c9a4e70","#,
+        r#""suppressed_ids_count":2,"suppressed_other_count":3,"suppressed_ids":[1290040,1290041],"#,
+        r#""redacted_fields":["cc","flags"],"scan":{"scanned":200,"dropped":2}},"#,
+        r#""upstream":{"requests":1,"status":200,"latency_ms":48},"#,
+        r#""outcome":{"class":"ok","duration_ms":52,"response_bytes":1462}}"#,
+    );
+
+    /// The last `tool_call` byte sequence schema v1 produced, pinned so
+    /// the break at v2 is tested rather than assumed. A v2 reader must
+    /// REJECT it: `deny_unknown_fields` refuses `guard.suppressed_count`,
+    /// and there is no honest way to accept it — the field summed two
+    /// populations that cannot be separated after the fact.
+    const GOLDEN_TOOL_CALL_V1: &str = concat!(
         r#"{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":7,"#,
         r#""session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"#,
         r#""event":"tool_call","#,
@@ -1869,47 +2105,40 @@ mod tests {
         r#""outcome":{"class":"ok","duration_ms":52,"response_bytes":1462}}"#,
     );
 
-    /// [`GOLDEN_TOOL_CALL`] as records looked before `outcome.response_bytes`
-    /// existed (issue #145) — byte-identical to the golden before that field,
-    /// same additive-optional shape as the pre-#29 pin below.
-    const GOLDEN_TOOL_CALL_PRE_RESPONSE_BYTES: &str = concat!(
-        r#"{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":7,"#,
-        r#""session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"#,
-        r#""event":"tool_call","#,
-        r#""client":{"name":"example-agent","version":"1.4.2","principal":"alice@example.org"},"#,
-        r#""trace":{"trace_id":"0af7651916cd43dd8448eb211c80319c","span_id":"b7ad6b7169203331"},"#,
-        r#""request":{"tool":"bug_info","id":"3","params":{"id":1290042,"include_private":false}},"#,
-        r#""guard":{"verdict":"served_filtered","rule":"group-restricted","policy_hash":"2b6e8f5d1c9a4e70","#,
-        r#""suppressed_count":2,"suppressed_ids":[1290040,1290041],"redacted_fields":["cc","flags"],"#,
-        r#""scan":{"scanned":200,"dropped":2}},"#,
-        r#""upstream":{"requests":1,"status":200,"latency_ms":48},"#,
-        r#""outcome":{"class":"ok","duration_ms":52}}"#,
-    );
-
-    /// [`GOLDEN_TOOL_CALL`] as records looked before `guard.scan` existed
-    /// (issue #29). The field was added optional-and-absent-when-unset, so
-    /// lines from older files must keep deserializing — to a `None` scan.
-    const GOLDEN_TOOL_CALL_PRE_SCAN: &str = concat!(
-        r#"{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":7,"#,
-        r#""session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"#,
-        r#""event":"tool_call","#,
-        r#""client":{"name":"example-agent","version":"1.4.2","principal":"alice@example.org"},"#,
-        r#""trace":{"trace_id":"0af7651916cd43dd8448eb211c80319c","span_id":"b7ad6b7169203331"},"#,
-        r#""request":{"tool":"bug_info","id":"3","params":{"id":1290042,"include_private":false}},"#,
-        r#""guard":{"verdict":"served_filtered","rule":"group-restricted","policy_hash":"2b6e8f5d1c9a4e70","#,
-        r#""suppressed_count":2,"suppressed_ids":[1290040,1290041],"redacted_fields":["cc","flags"]},"#,
-        r#""upstream":{"requests":1,"status":200,"latency_ms":48},"#,
-        r#""outcome":{"class":"ok","duration_ms":52}}"#,
-    );
+    /// The v1 lines OUTSIDE the break: a `tool_call` from a tool that
+    /// consulted no guard (`bug_url`), and v1's `initialize` and
+    /// `audit_gap`, whose payloads v2 did not touch. None of them names a
+    /// field v2 removed, so all three still parse and still read `v: 1`.
+    /// That is the exact scope of the break, pinned here so widening it
+    /// takes a deliberate edit.
+    const V1_LINES_OUTSIDE_THE_BREAK: [&str; 3] = [
+        concat!(
+            r#"{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":7,"#,
+            r#""session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"#,
+            r#""event":"tool_call","#,
+            r#""client":{"name":"example-agent","version":"1.4.2"},"#,
+            r#""request":{"tool":"bug_url","id":"3","params":{"id":1290042}},"#,
+            r#""outcome":{"class":"ok","duration_ms":1}}"#,
+        ),
+        concat!(
+            r#"{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":1,"session":{"transport":"stdio"},"#,
+            r#""event":"initialize","client":{"name":"example-agent","version":"1.4.2"},"#,
+            r#""protocol_version":"2025-06-18"}"#,
+        ),
+        concat!(
+            r#"{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":9,"session":{"transport":"stdio"},"#,
+            r#""event":"audit_gap","dropped":3,"reason":"write_error"}"#,
+        ),
+    ];
 
     const GOLDEN_INITIALIZE: &str = concat!(
-        r#"{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":1,"session":{"transport":"stdio"},"#,
+        r#"{"v":2,"ts":"2026-02-03T04:05:06.789Z","seq":1,"session":{"transport":"stdio"},"#,
         r#""event":"initialize","client":{"name":"example-agent","version":"1.4.2"},"#,
         r#""protocol_version":"2025-06-18"}"#,
     );
 
     const GOLDEN_AUDIT_GAP: &str = concat!(
-        r#"{"v":1,"ts":"2026-02-03T04:05:06.789Z","seq":9,"session":{"transport":"stdio"},"#,
+        r#"{"v":2,"ts":"2026-02-03T04:05:06.789Z","seq":9,"session":{"transport":"stdio"},"#,
         r#""event":"audit_gap","dropped":3,"reason":"write_error"}"#,
     );
 
@@ -1932,31 +2161,80 @@ mod tests {
     }
 
     #[test]
-    fn tool_call_line_without_response_bytes_still_deserializes() {
-        // A pre-#145 record has no `outcome.response_bytes` bytes at all;
-        // it must parse with the size simply unknown, not defaulted to 0 —
-        // "not measured" and "measured as empty" are different facts.
-        let event: AuditEvent = serde_json::from_str(GOLDEN_TOOL_CALL_PRE_RESPONSE_BYTES)
-            .expect("an old line must parse");
-        let AuditEventKind::ToolCall(tc) = &event.kind else {
-            panic!("expected a tool_call event");
-        };
-        assert_eq!(tc.outcome.response_bytes, None, "absent means unknown");
-        assert_eq!(tc.outcome.duration_ms, 52, "the rest is read unchanged");
+    fn v1_tool_call_with_a_guard_is_rejected() {
+        // The v2 break, tested rather than assumed: `suppressed_count` is
+        // not a field this reader knows, and `deny_unknown_fields` must
+        // refuse the line outright. Dropping that attribute, or adding an
+        // `alias`/`default` that let a v1 line in, would read it with
+        // `suppressed_other_count` silently zeroed — a wrong number where
+        // the old one was merely coarse.
+        let err = serde_json::from_str::<AuditEvent>(GOLDEN_TOOL_CALL_V1)
+            .expect_err("a v1 tool_call carrying a guard must not parse under v2");
+        assert!(
+            err.to_string().contains("suppressed_count"),
+            "the rejection must name the removed field: {err}"
+        );
     }
 
     #[test]
-    fn tool_call_line_without_scan_still_deserializes() {
-        // A pre-#29 record has no `guard.scan` bytes at all; it must parse
-        // into today's types with the scan simply absent.
-        let event: AuditEvent =
-            serde_json::from_str(GOLDEN_TOOL_CALL_PRE_SCAN).expect("an old line must parse");
-        let AuditEventKind::ToolCall(tc) = &event.kind else {
+    fn v1_lines_outside_the_break_still_parse_as_v1() {
+        // The scope of that break, pinned on every line the docs promise
+        // survives it: a v1 line naming no removed field still parses,
+        // and still reads `v: 1`. The reader does not dispatch on `v`, so
+        // a later "helpful" version check would widen the break past what
+        // the schema documents — this test makes that a deliberate edit.
+        let parsed: Vec<AuditEvent> = V1_LINES_OUTSIDE_THE_BREAK
+            .iter()
+            .map(|line| {
+                serde_json::from_str(line).unwrap_or_else(|e| {
+                    panic!("a v1 line outside the break stays readable: {line}: {e}")
+                })
+            })
+            .collect();
+        for event in &parsed {
+            assert_eq!(event.v, 1, "the version is read back, never rewritten");
+        }
+        let AuditEventKind::ToolCall(tc) = &parsed[0].kind else {
             panic!("expected a tool_call event");
         };
-        let guard = tc.guard.as_ref().expect("the old line carries a guard");
-        assert_eq!(guard.scan, None, "absent field means None, not an error");
-        assert_eq!(guard.suppressed_count, 2, "the rest is read unchanged");
+        assert_eq!(tc.guard, None, "the guard-less shape is what survives");
+        assert_eq!(tc.request.tool, "bug_url");
+        assert!(matches!(parsed[1].kind, AuditEventKind::Initialize(_)));
+        assert!(matches!(parsed[2].kind, AuditEventKind::AuditGap(_)));
+    }
+
+    #[test]
+    fn reserved_identity_slots_are_absent_when_none() {
+        // Both server-verified slots are `None` in every record this
+        // build writes, and neither may appear as a key. Dropping either
+        // `skip_serializing_if` would emit `"principal":null` /
+        // `"work_context":null` — a reader cannot tell a null reserved
+        // slot from a verified empty one.
+        let line = serde_json::to_string(&envelope(1, session_stdio(), sample_initialize()))
+            .expect("the fixture serializes");
+        for key in ["principal", "work_context"] {
+            assert!(
+                !line.contains(key),
+                "a reserved slot holding None must emit no key at all: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_written_line_carries_the_current_schema_version() {
+        // The goldens stamp `v` from the fixture; only `write_event`
+        // stamps it on a real record, so this is the one test that reaches
+        // that line. Asserted as the LITERAL bytes: comparing against
+        // `SCHEMA_VERSION` would pass under any value of it.
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = test_cfg(dir.path().join("audit.jsonl"));
+        let sink = AuditSink::open(cfg.clone()).unwrap();
+        sink.record(sample_tool_call(), session_http()).unwrap();
+        let contents = std::fs::read_to_string(live_path(&cfg)).unwrap();
+        assert!(
+            contents.starts_with(r#"{"v":2,"#),
+            "a written record must be stamped v2: {contents}"
+        );
     }
 
     #[test]
@@ -2709,37 +2987,47 @@ mod tests {
         let info = cell.into_guard_info(Some("sha256:ab"), true).unwrap();
         assert_eq!(info.verdict, Verdict::ServedFiltered);
         assert_eq!(info.suppressed_ids, vec![1290040, 1290041]);
-        assert_eq!(info.suppressed_count, 2);
+        assert_eq!(info.suppressed_ids_count, 2);
+        assert_eq!(info.suppressed_other_count, 0);
         assert_eq!(info.policy_hash.as_deref(), Some("sha256:ab"));
     }
 
     #[test]
-    fn cell_suppressed_count_sums_ids_and_counter() {
-        // Issue #68: the two tallies are disjoint populations, so the
-        // count is their TOTAL — not the larger of them, which would
-        // silently under-report whenever both are non-empty.
+    fn cell_split_counters_report_their_own_populations() {
+        // Issue #68 at v2: each tally ships as itself. The two numbers
+        // are deliberately DIFFERENT, so swapping the fields fails here —
+        // which a single summed field structurally could not catch. The
+        // id-less notes also accumulate rather than last-note-wins.
         let cell = AuditCell::default();
         cell.note_suppressed([7]);
         cell.note_suppressed_count(2);
         cell.note_suppressed_count(1);
         let info = cell.into_guard_info(None, true).unwrap();
+        assert_eq!(info.suppressed_ids_count, 1, "one named id");
         assert_eq!(
-            info.suppressed_count, 4,
-            "one named id plus three id-less suppressions"
+            info.suppressed_other_count, 3,
+            "two id-less suppressions plus one more, added not replaced"
         );
         assert_eq!(info.suppressed_ids, vec![7]);
     }
 
     #[test]
-    fn cell_suppressed_ids_config_ships_the_count_only() {
+    fn cell_split_survives_the_ids_config() {
+        // With the ids elided the emitted vector is empty, so a count
+        // derived from IT would read zero — and the operator's only
+        // remaining signal that two bugs were withheld would vanish.
         let cell = AuditCell::default();
         cell.note_suppressed([40, 41]);
         cell.note_suppressed_count(3);
         let info = cell.into_guard_info(None, false).unwrap();
         assert!(info.suppressed_ids.is_empty(), "ids elided by config");
         assert_eq!(
-            info.suppressed_count, 5,
-            "the elided ids still count, and the id-less ones add to them"
+            info.suppressed_ids_count, 2,
+            "counted from the set, not from the vector the config emptied"
+        );
+        assert_eq!(
+            info.suppressed_other_count, 3,
+            "the id-less tally is untouched"
         );
     }
 
@@ -2887,7 +3175,8 @@ mod tests {
         cell.note_suppressed([12, 19]);
         let info = cell.into_guard_info(None, false).unwrap();
         assert!(info.suppressed_ids.is_empty(), "ids elided by config");
-        assert_eq!(info.suppressed_count, 2, "the count still ships");
+        assert_eq!(info.suppressed_ids_count, 2, "the count still ships");
+        assert_eq!(info.suppressed_other_count, 0);
         assert_eq!(
             info.scan,
             Some(ScanInfo {

--- a/crates/bugwarden/src/otel.rs
+++ b/crates/bugwarden/src/otel.rs
@@ -1584,6 +1584,7 @@ mod tests {
                 name: Some("agent".to_owned()),
                 version: None,
                 principal: None,
+                work_context: None,
             },
             trace,
             request: RequestInfo {
@@ -1595,7 +1596,8 @@ mod tests {
                 verdict: Verdict::Denied,
                 rule: Some("embargo".to_owned()),
                 policy_hash: None,
-                suppressed_count: 1,
+                suppressed_ids_count: 1,
+                suppressed_other_count: 0,
                 suppressed_ids: vec![7],
                 redacted_fields: Vec::new(),
                 scan: None,
@@ -1697,7 +1699,8 @@ mod tests {
                     client: ClientInfo {
                         name: None,
                         version: None,
-                        principal: None
+                        principal: None,
+                        work_context: None
                     },
                     protocol_version: None,
                 })),

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -349,14 +349,16 @@ fn allowlisted(params: Option<&JsonObject>) -> BTreeMap<String, Value> {
 }
 
 /// The calling client as it introduced itself in the handshake, for an
-/// audit record. Self-declared, therefore untrusted; `principal` stays
-/// `None` (reserved for a future authenticated identity).
+/// audit record. Self-declared, therefore untrusted; `principal` and
+/// `work_context` stay `None` — both are server-verified slots and this
+/// build has no verifier to fill either.
 fn client_of(ctx: &RequestContext<RoleServer>) -> audit::ClientInfo {
     let peer = ctx.peer.peer_info();
     audit::ClientInfo {
         name: peer.as_ref().map(|p| p.client_info.name.clone()),
         version: peer.as_ref().map(|p| p.client_info.version.clone()),
         principal: None,
+        work_context: None,
     }
 }
 
@@ -2574,7 +2576,8 @@ impl BugWarden {
                 // LOAD-BEARING: harvest from the FILTERED list, never the raw
                 // one. A dropped private comment is already counted id-less
                 // below; naming its marker id too would put one comment in
-                // both tallies, and guard.suppressed_count sums them (#68).
+                // both tallies, which the record ships as two disjoint
+                // fields for a reader to add (#68).
                 let named = Guard::duplicate_marker_ids(&filtered);
                 let disclosable = self
                     .guard
@@ -2742,8 +2745,8 @@ impl BugWarden {
             // and rows dropped by verdict. A dropping scan upgrades the
             // verdict to served_filtered inside note_scan; the dropped
             // ids ride the existing suppressed-ids machinery below —
-            // config gate, suppressed_count, and the BTreeSet union with
-            // the I14-scrubbed link ids (overlap dedupes, a feature).
+            // config gate, suppressed_ids_count, and the BTreeSet union
+            // with the I14-scrubbed link ids (overlap dedupes, a feature).
             cell.note_scan(u64::from(scanned), dropped.len() as u64);
             if !dropped.is_empty() {
                 cell.note_suppressed(dropped.iter().copied());
@@ -3901,8 +3904,8 @@ impl BugWarden {
         // scrubbed there just asks for a summary instead (I14).
         // LOAD-BEARING, as in bug_comments: `comments` is already the
         // FILTERED list here. Harvesting marker ids from the pre-filter one
-        // would count a dropped private comment in both tallies, and
-        // guard.suppressed_count sums them (#68).
+        // would count a dropped private comment in both tallies, which the
+        // record ships as two disjoint fields for a reader to add (#68).
         let named = Guard::duplicate_marker_ids(&comments);
         let disclosable = self
             .guard
@@ -3939,7 +3942,8 @@ impl BugWarden {
 // is load-bearing: the instance router has the write tools / disabled
 // tools removed (I13); the macro default, `Self::tool_router()`, would
 // rebuild an unpruned router. `list_tools` is not audited: no event kind
-// exists for a listing — deliberate for schema v1.
+// exists for a listing — deliberate, and schema v2's growth rule would let
+// one be added without a version bump.
 impl ServerHandler for BugWarden {
     async fn initialize(
         &self,
@@ -3975,6 +3979,7 @@ impl ServerHandler for BugWarden {
                     name: Some(request.client_info.name.clone()),
                     version: Some(request.client_info.version.clone()),
                     principal: None,
+                    work_context: None,
                 },
                 protocol_version: Some(info.protocol_version.as_str().to_string()),
             });
@@ -4024,6 +4029,7 @@ impl ServerHandler for BugWarden {
                         name: None,
                         version: None,
                         principal: None,
+                        work_context: None,
                     },
                     trace: None,
                     request: audit::RequestInfo {
@@ -4122,7 +4128,8 @@ impl ServerHandler for BugWarden {
                     verdict: Verdict::Refused,
                     rule: None,
                     policy_hash: audit.policy_hash.clone(),
-                    suppressed_count: 0,
+                    suppressed_ids_count: 0,
+                    suppressed_other_count: 0,
                     suppressed_ids: Vec::new(),
                     redacted_fields: Vec::new(),
                     // The guard never ran, so no window scan did either.
@@ -4250,7 +4257,7 @@ impl ServerHandler for BugWarden {
         // Refused on the same terms as a tool call: the listing is pruned
         // per deployment (I13), so answering one of these would disclose
         // which tools this policy removed. Unrecorded, as
-        // every listing is — schema v1 has no event kind for one.
+        // every listing is — the schema has no event kind for one.
         if skips_the_handshake(&context) {
             return Err(handshake_required());
         }
@@ -6259,6 +6266,10 @@ mod tests {
         assert_eq!(
             calls[0].client.principal, None,
             "a deployment credential is not a caller (#32)"
+        );
+        assert_eq!(
+            calls[0].client.work_context, None,
+            "and it binds the call to no work item either (#34)"
         );
     }
 

--- a/crates/bugwarden/tests/audit_wiremock.rs
+++ b/crates/bugwarden/tests/audit_wiremock.rs
@@ -400,6 +400,17 @@ async fn every_routed_tool_writes_exactly_one_record_per_call() {
             "version too: {:?}",
             tc.client
         );
+        assert_eq!(
+            (
+                tc.client.principal.as_deref(),
+                tc.client.work_context.as_deref()
+            ),
+            (None, None),
+            "and NEITHER server-verified slot on any routed tool: no verifier \
+             exists, and nothing self-declared may be promoted into one \
+             (#32, #34): {:?}",
+            tc.client
+        );
         // Issue #118, the same blind spot at the `upstream` block: it was
         // read only off the hand-built goldens. Measured against what
         // wiremock independently served, so a hardcoded count cannot pass
@@ -713,7 +724,11 @@ async fn suppressed_ids_reach_the_log_never_the_envelope() {
         "the audit record must carry the suppressed id: {:?}",
         guard.suppressed_ids
     );
-    assert!(guard.suppressed_count >= 1);
+    assert!(guard.suppressed_ids_count >= 1);
+    assert_eq!(
+        guard.suppressed_other_count, 0,
+        "a scrubbed link is an ID suppression and lands in no other tally: {guard:?}"
+    );
     assert_eq!(
         guard.policy_hash.as_deref(),
         Some("sha256:policy-under-test"),
@@ -762,9 +777,10 @@ async fn suppressed_ids_off_records_the_count_never_the_ids() {
     let guard = tc.guard.as_ref().expect("guard info recorded");
     assert_eq!(guard.verdict, Verdict::ServedFiltered);
     assert!(
-        guard.suppressed_count >= 1,
-        "the count survives the elision: {guard:?}"
+        guard.suppressed_ids_count >= 1,
+        "the id count survives the elision: {guard:?}"
     );
+    assert_eq!(guard.suppressed_other_count, 0);
     assert!(
         guard.suppressed_ids.is_empty(),
         "ids are elided when the knob is off: {:?}",
@@ -845,11 +861,12 @@ async fn mount_mixed_suppression(mock: &MockServer) {
 }
 
 #[tokio::test]
-async fn suppressed_count_totals_both_populations_in_one_call() {
-    // Issue #68: one call suppresses three id-less private comments AND
-    // two duplicate-marker bug ids. The count is the TOTAL — five — not
-    // the larger tally, which would report three beside a two-id list and
-    // silently lose two withheld items.
+async fn split_counters_report_both_populations_in_one_call() {
+    // Issue #68 at schema v2: one call suppresses three id-less private
+    // comments AND two duplicate-marker bug ids, and each population is
+    // reported as itself. THE SEPARATING FIXTURE — 3 and 2 are different
+    // numbers on purpose, so swapping the two fields fails here; a single
+    // summed field structurally could not catch that.
     let mock = MockServer::start().await;
     mount_mixed_suppression(&mock).await;
     let audited = audited_client_for(HIDE_SECRET_POLICY, &mock, "test-key").await;
@@ -881,21 +898,26 @@ async fn suppressed_count_totals_both_populations_in_one_call() {
          count that one comment in both tallies"
     );
     assert_eq!(
-        guard.suppressed_count, 5,
-        "three id-less comments plus two withheld ids: {guard:?}"
+        guard.suppressed_ids_count, 2,
+        "the two withheld ids, counted as themselves: {guard:?}"
     );
-    assert!(
-        guard.suppressed_ids.len() < guard.suppressed_count as usize,
-        "the count is authoritative and outruns the id list it may not be \
-         inferred from: {guard:?}"
+    assert_eq!(
+        guard.suppressed_other_count, 3,
+        "the three id-less private comments, counted as themselves: {guard:?}"
+    );
+    assert_eq!(
+        guard.suppressed_ids.len() as u64,
+        guard.suppressed_ids_count,
+        "the id list accounts for its own tally exactly, and for the other \
+         one not at all: {guard:?}"
     );
 }
 
 #[tokio::test]
-async fn summarize_bug_records_the_same_total_as_bug_comments() {
+async fn summarize_bug_records_the_same_split_as_bug_comments() {
     // summarize_bug filters and scrubs the same comments as bug_comments
     // and notes both tallies from its own call site (server.rs), so this
-    // diff changes the number it records too — it needs its own record,
+    // diff changes the numbers it records too — it needs its own record,
     // not bug_comments' by analogy.
     let mock = MockServer::start().await;
     mount_mixed_suppression(&mock).await;
@@ -926,17 +948,22 @@ async fn summarize_bug_records_the_same_total_as_bug_comments() {
         "the same two ids bug_comments names, and 668 no more than it does"
     );
     assert_eq!(
-        guard.suppressed_count, 5,
-        "three id-less comments plus two withheld ids: {guard:?}"
+        guard.suppressed_ids_count, 2,
+        "the same two ids, in the same field: {guard:?}"
+    );
+    assert_eq!(
+        guard.suppressed_other_count, 3,
+        "and the same three id-less comments: {guard:?}"
     );
 }
 
 #[tokio::test]
-async fn suppressed_count_totals_both_populations_with_the_ids_elided() {
+async fn split_counters_survive_the_ids_config() {
     // The same call under `suppressed_ids = false`, which is the case the
-    // issue calls out: with no id list at all, the count is the operator's
-    // ONLY signal that anything was withheld (I3 keeps it from the
-    // client), so it must still total both populations.
+    // issue calls out: with no id list at all the two counts are the
+    // operator's ONLY signal that anything was withheld (I3 keeps it from
+    // the client). `suppressed_ids_count` must therefore come from the id
+    // SET and not from the vector this switch empties.
     let mock = MockServer::start().await;
     mount_mixed_suppression(&mock).await;
     let audited = audited_client_with(HIDE_SECRET_POLICY, &mock, "test-key", false).await;
@@ -953,8 +980,13 @@ async fn suppressed_count_totals_both_populations_with_the_ids_elided() {
         guard.suppressed_ids
     );
     assert_eq!(
-        guard.suppressed_count, 5,
-        "the elided ids still count, and the id-less comments add to them: {guard:?}"
+        guard.suppressed_ids_count, 2,
+        "the elided ids still COUNT — this is the operator's only remaining \
+         statement that two bugs were withheld: {guard:?}"
+    );
+    assert_eq!(
+        guard.suppressed_other_count, 3,
+        "and the id-less tally is untouched by that switch: {guard:?}"
     );
 }
 
@@ -984,7 +1016,8 @@ async fn bug_comments_with_nothing_filtered_stays_served_and_counts_zero() {
         "the fixture's only comment is public and names no bug, so nothing \
          was withheld: {guard:?}"
     );
-    assert_eq!(guard.suppressed_count, 0);
+    assert_eq!(guard.suppressed_ids_count, 0);
+    assert_eq!(guard.suppressed_other_count, 0);
     assert!(guard.suppressed_ids.is_empty());
     assert_eq!(
         guard.rule.as_deref(),
@@ -1072,7 +1105,8 @@ async fn summarize_bug_with_nothing_filtered_stays_served_and_counts_zero() {
         "every comment is public and the only bug they name is disclosable, \
          so nothing was withheld: {guard:?}"
     );
-    assert_eq!(guard.suppressed_count, 0);
+    assert_eq!(guard.suppressed_ids_count, 0);
+    assert_eq!(guard.suppressed_other_count, 0);
     assert!(guard.suppressed_ids.is_empty());
     assert_eq!(
         guard.rule.as_deref(),
@@ -1113,7 +1147,8 @@ async fn bug_info_with_every_link_disclosable_stays_served_and_redacts_nothing()
         Verdict::Served,
         "bug 7 is served whole and its only link was disclosable: {guard:?}"
     );
-    assert_eq!(guard.suppressed_count, 0);
+    assert_eq!(guard.suppressed_ids_count, 0);
+    assert_eq!(guard.suppressed_other_count, 0);
     assert!(guard.suppressed_ids.is_empty());
     assert!(
         guard.redacted_fields.is_empty(),
@@ -1212,7 +1247,8 @@ async fn bug_history_windowing_records_the_omission_it_applied() {
          no rule decided the omission: {guard:?}"
     );
     assert_eq!(
-        guard.suppressed_count, 0,
+        (guard.suppressed_ids_count, guard.suppressed_other_count),
+        (0, 0),
         "nothing else was withheld, so the window is the ONLY thing the \
          filtered verdict can have come from: {guard:?}"
     );
@@ -1266,7 +1302,8 @@ async fn bug_history_window_that_omits_nothing_stays_silent() {
         "and the window note stays silent when nothing was omitted: {:?}",
         guard.redacted_fields
     );
-    assert_eq!(guard.suppressed_count, 0);
+    assert_eq!(guard.suppressed_ids_count, 0);
+    assert_eq!(guard.suppressed_other_count, 0);
     assert!(guard.suppressed_ids.is_empty());
 }
 
@@ -1349,7 +1386,8 @@ async fn bug_info_over_a_summary_view_records_the_redaction_it_applied() {
         "and the restrict rule that granted the summary decided the call"
     );
     assert_eq!(
-        guard.suppressed_count, 0,
+        (guard.suppressed_ids_count, guard.suppressed_other_count),
+        (0, 0),
         "nothing else was withheld, so the summary view is the ONLY thing \
          the filtered verdict can have come from: {guard:?}"
     );
@@ -1427,8 +1465,12 @@ async fn list_attachments_counts_the_private_metadata_it_dropped() {
     let guard = tc.guard.as_ref().expect("guard info recorded");
     assert_eq!(guard.verdict, Verdict::ServedFiltered);
     assert_eq!(
-        guard.suppressed_count, 2,
-        "both dropped attachments are counted: {guard:?}"
+        guard.suppressed_other_count, 2,
+        "both dropped attachments are counted, id-lessly: {guard:?}"
+    );
+    assert_eq!(
+        guard.suppressed_ids_count, 0,
+        "attachment metadata names no bug, so the id tally stays empty: {guard:?}"
     );
     assert!(
         guard.suppressed_ids.is_empty(),
@@ -1479,7 +1521,8 @@ async fn list_attachments_with_nothing_private_stays_served_and_counts_zero() {
         Verdict::Served,
         "a listing that withheld nothing is a clean serve: {guard:?}"
     );
-    assert_eq!(guard.suppressed_count, 0);
+    assert_eq!(guard.suppressed_ids_count, 0);
+    assert_eq!(guard.suppressed_other_count, 0);
     assert!(guard.suppressed_ids.is_empty());
     assert!(
         guard.redacted_fields.is_empty(),
@@ -1658,7 +1701,11 @@ async fn quicksearch_scan_accounting_reaches_the_record_never_the_envelope() {
         vec![2, 4],
         "the dropped ids ride the suppressed-ids machinery"
     );
-    assert_eq!(guard.suppressed_count, 2);
+    assert_eq!(guard.suppressed_ids_count, 2);
+    assert_eq!(
+        guard.suppressed_other_count, 0,
+        "a dropped search row carries its own id, so nothing lands id-less"
+    );
 }
 
 #[tokio::test]
@@ -1774,7 +1821,8 @@ async fn quicksearch_drop_count_survives_the_suppressed_ids_knob() {
     let scan = guard.scan.expect("a search records its scan");
     assert_eq!(scan.dropped, 1, "the count survives the elision");
     assert_eq!(scan.scanned, 3);
-    assert!(guard.suppressed_count >= 1, "so does suppressed_count");
+    assert!(guard.suppressed_ids_count >= 1, "so does the id count");
+    assert_eq!(guard.suppressed_other_count, 0);
     assert!(
         guard.suppressed_ids.is_empty(),
         "ids are elided when the knob is off: {:?}",
@@ -1804,7 +1852,8 @@ async fn quicksearch_clean_scan_records_zero_drops_and_stays_served() {
     );
     assert_eq!(guard.verdict, Verdict::Served, "a clean scan stays served");
     assert!(guard.suppressed_ids.is_empty());
-    assert_eq!(guard.suppressed_count, 0);
+    assert_eq!(guard.suppressed_ids_count, 0);
+    assert_eq!(guard.suppressed_other_count, 0);
 }
 
 #[tokio::test]
@@ -1868,7 +1917,8 @@ async fn quicksearch_over_summary_views_records_the_redaction_it_applied() {
         }),
         "and it is not the scan that filtered it — every row was kept"
     );
-    assert_eq!(guard.suppressed_count, 0);
+    assert_eq!(guard.suppressed_ids_count, 0);
+    assert_eq!(guard.suppressed_other_count, 0);
     assert!(guard.suppressed_ids.is_empty());
 }
 
@@ -2075,7 +2125,8 @@ async fn bug_comments_window_keeps_the_named_rule_that_granted_the_call() {
         Some("allow-openSUSE"),
         "the granting rule by name, so a fallback to `default` fails here: {guard:?}"
     );
-    assert_eq!(guard.suppressed_count, 0);
+    assert_eq!(guard.suppressed_ids_count, 0);
+    assert_eq!(guard.suppressed_other_count, 0);
 }
 
 #[tokio::test]
@@ -2108,9 +2159,10 @@ async fn bug_comments_window_beside_an_i5_suppression_records_no_rule() {
     assert_eq!(guard.redacted_fields, vec!["comments_window".to_string()]);
     assert_eq!(guard.verdict, Verdict::ServedFiltered);
     assert_eq!(
-        guard.suppressed_count, 1,
+        guard.suppressed_other_count, 1,
         "the private comment is counted, id-lessly: {guard:?}"
     );
+    assert_eq!(guard.suppressed_ids_count, 0);
     assert_eq!(
         guard.rule, None,
         "a GUARD suppression upgraded the verdict, so the rule goes with \

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -850,8 +850,9 @@ units and container specs). Decisions, all deliberate:
 Key custody above answers "who authenticates to Bugzilla". This answers the
 other half — who authenticates to bugwarden — for the http transport only.
 Partial delivery of issue #32, deliberately scoped: it authenticates a
-DEPLOYMENT, not a caller, so `ClientInfo.principal` stays `None` and #32 stays
-open until a verified caller identity fills it.
+DEPLOYMENT, not a caller, so `ClientInfo.principal` and
+`ClientInfo.work_context` both stay `None` and #32 stays open until a verified
+caller identity fills them.
 
 Over stdio the client launched the process and is its only principal. Over http
 the port was the whole access control, and under server-held key custody that
@@ -932,8 +933,11 @@ Decisions, all deliberate:
   once per process rather than per request.
 - **Refusals are logged, not audited.** Rejection happens in the layer, before
   `call_tool`, which is where audit records are written — so #32's "refusals
-  must be recorded" cannot be met by the audit stream without a new event kind,
-  and the schema's event set is #34's to decide. What lands instead is a
+  must be recorded" cannot be met by the audit stream without a new event kind.
+  #34 has since decided that: schema v2's growth rule allows a new record kind
+  WITHIN a version — same compatibility profile as an optional field, and a
+  consumer filtering `event == "tool_call"` is untouched — so adding one would
+  not force a v3, and the choice is a design one rather than a schema one. What lands instead is a
   counter logged on the first refusal and then at every power of two: bounded,
   so an unauthenticated client cannot drive log volume, and carrying no token,
   header, path or peer, so it is no oracle. A read-scope caller's refused write
@@ -1156,8 +1160,9 @@ Decisions, all deliberate:
   The record is accepted by every configured sink before the response is
   returned (the file write is synchronous; the OTLP hand-off only queues).
   `initialize` is always recorded, with no configuration knob to turn it
-  off; `list_tools` is not recorded in schema v1 — no event kind exists
-  for a listing, deliberately.
+  off; `list_tools` is not recorded in schema v2 — no event kind exists
+  for a listing, deliberately, and the growth rule would permit adding one
+  without a version bump.
 - **Boundary.** Records go to the sinks the operator named
   (`select_sinks`): the JSONL file (0600, parent 0700), an OTLP
   collector, both, or neither. Never stderr, never any MCP surface. When
@@ -1209,9 +1214,13 @@ Decisions, all deliberate:
   unrelated calls with an id an operator is pivoting on — so they are
   correlation hints, never evidence; attribution rests on the record's
   session and client anchoring, not on `trace`. `tracestate` and `baggage`
-  are deliberately not stored: the schema has no field for either,
-  `tracestate` is client free text, and `baggage` is unbounded client
-  key/values — revisit under #34.
+  are deliberately not stored, and as of schema v2 that is DECIDED and
+  PERMANENT rather than pending (#34): skipped, not capped. The schema has
+  no field for either, `tracestate` is client free text and `baggage` is
+  unbounded client key/values, and a capped copy would still be a
+  client-writable free-text channel into an append-only operator file —
+  I15's no-secrets guarantee is structural, and a length limit does not
+  make it one. Reopening this needs a new argument, not a cap.
 - **Response size accounting (issue #145).** `outcome.response_bytes`
   carries the serialized size of the result's `content` array, so the
   operator stream can quantify a compression win — or a bloat
@@ -1225,12 +1234,17 @@ Decisions, all deliberate:
   refusal before building it and must not spend a serialization sizing a
   fixed text. "Not measured" and "measured as empty" are different facts
   and the reader must be able to tell them apart. Optional and
-  absent-when-unset, so the schema stays v1 (the #29 shape); pre-#145
-  lines are pinned as `GOLDEN_TOOL_CALL_PRE_RESPONSE_BYTES` and must keep
-  deserializing. Backward only: `deny_unknown_fields` means a reader built
-  before #145 REJECTS a post-#145 line outright, so "the schema stays v1"
-  buys old files new readers, not old readers new files — the issue's
-  "older readers ignore it" is wrong about this codebase's own parser.
+  absent-when-unset, so the schema stayed v1 (the #29 shape); pre-#145
+  lines were pinned as `GOLDEN_TOOL_CALL_PRE_RESPONSE_BYTES` and kept
+  deserializing. That promise HELD THROUGH v1 AND WAS REVOKED AT v2: the
+  `suppressed_count` split means a v2 reader rejects any v1 `tool_call`
+  line carrying a `guard` object, pre-#145 and post-#145 alike, so the
+  pinned constant and its test are gone and `GOLDEN_TOOL_CALL_V1` pins the
+  rejection instead ("Schema v2", below). Backward only, then and now:
+  `deny_unknown_fields` means a reader built before #145 REJECTS a
+  post-#145 line outright, so "the schema stays v1" bought old files new
+  readers, not old readers new files — the issue's "older readers ignore
+  it" is wrong about this codebase's own parser.
   THE ISSUE'S SAFETY PREMISE IS ALSO WRONG and the docs must not repeat
   it. It claims "denial responses have constant size by construction". They
   do not, on two counts. The uniform text interpolates the caller's id
@@ -1245,7 +1259,7 @@ Decisions, all deliberate:
   honest statement is the simple one: the field sizes whatever was served,
   and no verdict makes it constant. That is acceptable because it is a count and
   never a byte of content, because the stream already carries
-  `suppressed_count`, `scan` and the ids, and because it reaches no MCP
+  the two suppression counts, `scan` and the ids, and because it reaches no MCP
   surface (I15) — the response itself is byte-identical with the field on
   or off (I3). It is, though, the first payload-derived value in the
   stream, so a deployment shipping records to a lower-trust tier should
@@ -1294,8 +1308,11 @@ Decisions, all deliberate:
   than reporting an earlier request's status as the outcome; `latency_ms`
   sums each request from hand-off to the transport until its body has
   been read, because reading the body is time spent waiting on Bugzilla.
-  Optional and absent-when-unset, so the schema stays v1 and no golden
-  shape moves. Startup preflight runs outside any scope and is counted
+  Optional and absent-when-unset, so the schema stayed v1 and no golden
+  shape moved when the block arrived — a backward promise revoked at v2
+  with the other two ("Schema v2", below): a v1 `tool_call` line carrying
+  a `guard` object no longer parses, whether or not it also carried
+  `upstream`. Startup preflight runs outside any scope and is counted
   nowhere: it is not a tool call. Pinned at both levels: the core suite
   proves the scope counts only its own requests, that a refused connect
   is counted with `status` cleared to absent, and that `latency_ms`
@@ -1315,8 +1332,10 @@ Decisions, all deliberate:
   `{scanned: 0, dropped: 0}`, and a failed search records no scan (the
   error discards its partial accounting along with the window) — so on
   a served search, `dropped: 0` is a statement, not an omission;
-  records from before the field existed deserialize with no scan
-  (optional field, schema still v1). The dropped IDS ride the existing suppressed-ids machinery —
+  records from before the field existed deserialized with no scan
+  (optional field, schema still v1) — a promise that held through v1 and
+  was revoked at v2 along with the pre-#145 one, for the same reason
+  ("Schema v2", below). The dropped IDS ride the existing suppressed-ids machinery —
   unioned into `guard.suppressed_ids` under the same `suppressed_ids`
   config switch, no second knob — while the counts in `scan` are recorded
   regardless of that switch. DELIBERATE verdict change: a search whose
@@ -1383,20 +1402,29 @@ Decisions, all deliberate:
   Going forward the disambiguator is `redacted_fields` holding only
   `*_window` names. Same treatment as #68 below. A tool the router never
   carried (I13) is not any of this: it records no `guard` object.
-  Re-encoding a default decision AS absence would be a record-schema
-  change and is deferred to #34; schema v1 records `"default"`.
-- **What `guard.suppressed_count` totals (issue #68).** The cell keeps two
-  tallies: a `BTreeSet` of bug ids the guard withheld (`note_suppressed` —
+  Re-encoding a default decision AS absence was considered under #34 and
+  DECIDED AGAINST, permanently: absence already means "no single rule
+  decided" — the enumerated cases above — so the default-as-absence
+  encoding would load a second, incompatible meaning onto the same
+  silence, and no reader could separate them. Schema v2 records
+  `"default"`, and this is not deferred to any later version.
+- **The two suppression tallies (issue #68).** The cell keeps two tallies:
+  a `BTreeSet` of bug ids the guard withheld (`note_suppressed` —
   I14-scrubbed links, scrubbed duplicate markers, verdict-dropped search
   rows) and a plain counter of suppressed content that HAS no bug id
   (`note_suppressed_count` — private comments in `bug_comments` and
   `summarize_bug`, private attachment metadata in `list_attachments`).
-  `suppressed_count` is their SUM. It used to be their maximum, which is
-  not a count of anything: a `summarize_bug` call that dropped three
-  private comments while scrubbing two duplicate-marker ids recorded
-  `3` beside a two-element id list, under-reporting by two and still
-  validating. Summing is sound because the populations are disjoint by
-  construction — both comment sites derive their marker ids from the
+  **Schema v2 ships each as its own field**, `suppressed_ids_count` and
+  `suppressed_other_count`, and ships no total ("Schema v2", below).
+  `suppressed_ids_count` is taken from the id SET, before the
+  `suppressed_ids` config switch empties the emitted vector — deriving it
+  from that vector would zero it exactly where it is the only signal left.
+  v1 shipped their SUM in one `suppressed_count`, and before that their
+  maximum, which is not a count of anything: a `summarize_bug` call that
+  dropped three private comments while scrubbing two duplicate-marker ids
+  recorded `3` beside a two-element id list, under-reporting by two and
+  still validating. Both readings rest on the same property, which the
+  split does not retire: the populations are disjoint by construction — both comment sites derive their marker ids from the
   comments that SURVIVED the private filter, so a dropped comment can
   never also contribute an id, and the attachment site names no ids at
   all; within the id set itself a `BTreeSet` dedupes the overlap between
@@ -1410,12 +1438,15 @@ Decisions, all deliberate:
   This matters because I3 forbids telling the CLIENT anything was
   withheld, so the audit stream is the only place the fact surfaces, and
   `suppressed_ids` is gated behind the `suppressed_ids` config switch
-  while the count always ships — a maximum cannot be the authoritative
-  number the field claims to be.
-  ACCEPTED COST, deliberate: no field is added or removed and the wire
-  shape is unchanged, so this stays schema v1 — but parseable is not
-  comparable, and the change of MEANING inside v1 is undetectable from a
-  record. There is no discriminator: an event carries `v`, `ts`, `seq`
+  while the counts always ship — a maximum could not be the authoritative
+  number the field claimed to be.
+  The max→sum correction was an ACCEPTED COST inside v1: no field was
+  added or removed and the wire shape was unchanged, so it stayed schema
+  v1 — but parseable is not comparable, and that change of MEANING inside
+  v1 was undetectable from a record. That invisibility is precisely the
+  argument for making the distinction STRUCTURAL at v2, and the paragraph
+  below is now the history of a corpus, not a live hazard for new
+  records. There is no discriminator: an event carries `v`, `ts`, `seq`
   and `session` only, `initialize` records the CLIENT's version and never
   bugwarden's build, `policy_hash` is unchanged unless the operator
   edited policy, and `suppressed_count >= len(suppressed_ids)` holds
@@ -1434,10 +1465,98 @@ Decisions, all deliberate:
   already documented as authoritative — which a maximum never satisfied,
   making this a correction to the stated contract rather than a new one.
   The rule this relies on is that `v` tracks structure, not meaning; it
-  is now stated on `SCHEMA_VERSION` itself. Splitting the tallies into
-  two fields (`suppressed_ids_count` and `suppressed_other_count`) is the
-  cleaner end state, would have made the change self-announcing, and
-  stays with the v2 work in #34.
+  is stated on `SCHEMA_VERSION` itself. Splitting the tallies into two
+  fields was the cleaner end state all along, and it LANDED at schema v2
+  (#34): the split is self-announcing where the sum was silent, because a
+  v1 consumer reading `suppressed_count` now fails instead of quietly
+  reading a number that means something else.
+
+- **Schema v2 (issue #34).** `SCHEMA_VERSION = 2`. The number is a
+  compatibility commitment, so what a shipped version may still grow is
+  stated on `SCHEMA_VERSION` itself rather than argued per change.
+  - **The growth rule.** Within one version a record may gain an OPTIONAL
+    field that is absent when unset, AND the stream may gain a new RECORD
+    KIND. Neither MAY redefine a field already shipping — an optional
+    flag that changes what an existing field means is structurally
+    additive and still forbidden, being #68's invisible meaning-shift
+    again, and it moves the number. Past that the two are permitted
+    together because they break in one direction: new readers read old
+    files, old readers reject both alike (`deny_unknown_fields` for a
+    field, an unknown `event` tag for a kind), and a consumer selecting
+    `event == "tool_call"` is untouched by a kind it never asked for. Removing, renaming,
+    REORDERING or retyping a field moves the number — reordering included,
+    because serde_json emits declaration order, so the struct edit IS the
+    wire-order decision. Widening a CLOSED VOCABULARY (`GapReason`,
+    `Verdict`, …) moves it too and is not the additive case: an added
+    field or kind is something a reader can decline to look at, while a
+    new variant lands inside a field every reader of that kind already
+    reads. Recorded consequence: a new kind does not force a v3, so #32's
+    refusal record could be added without one.
+  - **What v2 changed, and nothing else.** `guard.suppressed_count` split
+    into `suppressed_ids_count` and `suppressed_other_count` (#68, above),
+    and `client.work_context` reserved beside `client.principal`. No
+    recording behaviour moved with it beyond the `into_guard_info`
+    projection: no cap on a recorded field, no new source for one, no new
+    kind implemented.
+  - **No total field.** The parts ship, the sum does not. A stored total
+    beside its own parts can desync, the total is addition a reader can
+    do, and losing the shared field NAME is what makes the break loud
+    rather than silent.
+  - **`principal` and `work_context` are CONTRACTS, not values.** Both are
+    documented by who may fill them — only a validator this server trusts,
+    never anything self-declared, including anything a request carries in
+    `_meta` — rather than as the `None` they hold, so authentication
+    arriving is a value change and not a v3 over a slot already reserved
+    for exactly it. They are two facts and one field cannot carry both:
+    WHO called, and WHAT WORK the call was authorized under.
+    `work_context` stays optional even once a verifier exists, because a
+    fleet-level agent belongs to no work item; its absence therefore reads
+    "reserved" today and "no work item" then, with the deployed build as
+    the boundary, exactly as #68's correction did inside v1. Its format is
+    deliberately unpinned — an RRID syntax written into the contract is
+    one #32's validator would owe.
+  - **Trust tiers are normative and live with the schema.** The table is
+    in `audit.rs`'s module rustdoc, versioned with the schema and covered
+    by the rustdoc gate. It rules on the fields that name a caller or
+    join records to one, not on the server's own account of what it did
+    (verdicts, counts, timings), which claims nothing about anybody; README carries a PROSE rendering and this file
+    records the decision, because three copies of one table is how they
+    drift. FOUR tiers, deliberately extending the three #34 asks for:
+    `session.id` fits none of them cleanly. This server mints it, so it is
+    not a client claim; it proves grouping and nothing about who was on
+    the other end, so it is not a verified identity; and a caller cannot
+    choose it (#180 stopped reading the `mcp-session-id` header), so it is
+    stronger than a correlation hint. Calling it any of the three would
+    have overstated or understated it.
+  - **The v1 corpus break, scoped exactly.** A v2 reader REJECTS every v1
+    `tool_call` line carrying a `guard` object: `deny_unknown_fields`
+    refuses `suppressed_count`. Accepted, and load-bearing — a reader that
+    took the line would have to invent a split for a number that cannot be
+    split after the fact. It rejects NOTHING ELSE: v1 `initialize`,
+    `audit_gap` and guard-less `tool_call` lines still parse, and parse
+    carrying `v: 1`, because the reader does not dispatch on `v`. So "v1
+    files are unreadable" is over-broad and "mostly compatible" is
+    under-broad; a consumer holding a mixed corpus must split on `v`
+    itself before assuming either version's semantics. Both halves are
+    tested, so widening the break is a deliberate edit.
+  - **Goldens across a bump.** Within a version the discipline is
+    unchanged: an added field updates the golden and pins the prior bytes
+    with a still-deserializes test, while an added kind has no prior
+    bytes to pin and simply gains a golden of its own. Across a bump it INVERTS — the
+    prior version's line stays pinned (`GOLDEN_TOOL_CALL_V1`) with a test
+    proving it is REJECTED, and v1's two pre-change constants and their
+    tests are deleted, their promise having expired with v1. New golden
+    bytes are derived BY HAND from the old ones BEFORE the structs change,
+    so a failure indicts the code; pasting serializer output into a golden
+    can only enshrine whatever the code does, bug included.
+  - **Retry duplicates: a documented property, no mechanism** (#34 §3(e)).
+    A client that loses a response and re-issues the call does so under a
+    new request id, and the re-issued call performs its upstream work
+    again — so two records is the true account of what reached Bugzilla.
+    Deduplicating would under-report real mutations, the one direction
+    this stream must not err in. Recorded on `RequestInfo::id`: records
+    are per-ATTEMPT, and `request.id` is a client-chosen correlation hint
+    and never an identity.
 - **Rule names the operator may not take (issue #84).** `Policy::validate`
   rejects a rule named `"default"`, `"min_bug_age_days"` or
   `"unavailable"`, a rule whose name ends in `":unreadable-metadata"`, a
@@ -1481,8 +1600,12 @@ Decisions, all deliberate:
   in the suffix and names are unique, so no generated
   `"<rule>:unreadable-metadata"` can ever equal a bare reserved name. The
   alternative, namespacing the synthetics in the record (a `rule_kind`
-  field, or a prefix), was rejected here: it is a record-schema change and
-  belongs to #34.
+  field, or a prefix), was carried to #34 and REJECTED there, permanently:
+  the SINGLE-SOURCED reservation above already disambiguates — the emit
+  sites and `RESERVED_RULE_NAMES` read the same constants, so no operator
+  name can collide with a synthetic one — and a second discriminator would
+  be a separate thing that can drift from the reservation it duplicates.
+  Schema v2 adds no `rule_kind`.
 
 ## OTLP export (crates/bugwarden/src/otel.rs)
 
@@ -2392,11 +2515,11 @@ wired, `server.rs` and `main.rs` are the reference.
   verdict `served_filtered`, while the served envelope carries not a
   byte of accounting and is byte-identical to the same window over an
   upstream where the hidden rows do not exist; with `suppressed_ids =
-  false` the scan counts and `suppressed_count` survive while the ids
-  are elided; a clean search records `scan.dropped == 0` under verdict
-  `served`; and a pre-#29 record line without `guard.scan`
-  deserializes with the scan absent (plus the cell-level note_scan
-  merge tests and the updated schema golden in audit.rs); and that
+  false` the scan counts and `suppressed_ids_count` survive while the
+  ids are elided; a clean search records `scan.dropped == 0` under
+  verdict `served` (plus the cell-level note_scan merge tests and the
+  schema golden in audit.rs — the pre-#29 still-deserializes test is
+  gone with v1, replaced by the v2 pins below); and that
   grouping (issue #143) reshapes the envelope and nothing else — a
   grouped and a flat call over the same window record an EQUAL
   `GuardInfo` (same scan, verdict, suppressed ids, no new
@@ -2407,31 +2530,55 @@ wired, `server.rs` and `main.rs` are the reference.
   allow side alike, while a CLEAN search (no drops, so nothing the scan
   merge could have cleared) records no rule at all even though a named
   rule granted every row it served, since absence means "no single rule
-  decided" and not "the default decided"; and what `suppressed_count`
-  totals (issue #68) — `bug_comments` AND `summarize_bug`, each on a
-  call that drops three private comments while scrubbing two
-  duplicate-marker ids in the SAME request, record
-  `suppressed_count == 5` over a two-element `suppressed_ids`, so the
-  count exceeds the id list rather than being the larger tally, and with
-  `suppressed_ids = false` the same call still records `5` with no id at
-  all — the operator's only signal. One of those three private comments
-  is itself a duplicate marker naming a third hidden bug, so the fixture
-  DEFENDS the disjointness the sum rests on: harvesting marker ids from
-  the pre-filter comment list counts that one comment in both tallies
-  and records `6` over three ids, and both tools' tests fail on the
-  number (plus the cell-level sum tests in audit.rs); and the counter's
+  decided" and not "the default decided"; and schema v2
+  (issue #34) — the three record goldens pin the v2 bytes, so a
+  `SCHEMA_VERSION` revert, a serde rename or reorder, and (2 against 3 in
+  the `tool_call` fixture) a swap of the two split counters each change
+  them; `GOLDEN_TOOL_CALL_V1` is pinned as REJECTED with the rejection
+  asserted to name `suppressed_count`, so dropping `deny_unknown_fields`
+  or adding an `alias`/`default` that read a v1 line into a zeroed
+  `suppressed_other_count` fails; each of the three v1 line shapes the
+  break spares — a guard-less `tool_call`, an `initialize`, an
+  `audit_gap` — still parses and still reads `v == 1`, pinning the exact
+  scope so widening it takes a deliberate edit; neither `principal` nor
+  `work_context` appears as a KEY in a record whose slots are `None`, so
+  dropping either `skip_serializing_if` fails; and one record written
+  through `AuditSink::record` is asserted to start with the literal
+  `"v":2` — the goldens stamp `v` from a fixture, so that is the only
+  test reaching `write_event`'s stamp; and the two suppression tallies
+  (issue #68 at v2) — `bug_comments` AND `summarize_bug`, each on a call
+  that drops three private comments while scrubbing two duplicate-marker
+  ids in the SAME request, record `suppressed_ids_count == 2` and
+  `suppressed_other_count == 3` over a two-element `suppressed_ids`, with
+  the id list asserted equal to its OWN tally and to neither the other;
+  the two numbers are unequal on purpose, so a swap of the fields fails
+  where a single summed field structurally could not; and with
+  `suppressed_ids = false` the same call still records `2` and `3` with
+  no id at all — the id count is then the operator's only statement that
+  two bugs were withheld, which a count re-derived from the emptied
+  vector would have zeroed. One of those three private comments is itself
+  a duplicate marker naming a third hidden bug, so the fixture DEFENDS
+  the disjointness the two fields rest on: harvesting marker ids from the
+  pre-filter comment list counts that one comment in both tallies and
+  records `suppressed_ids_count == 3` over three ids, and both tools'
+  tests fail on the number (plus the cell-level split tests in audit.rs,
+  over a third asymmetric pair — one named id against three id-less
+  suppressions noted in two calls — so a tally swap and a last-note-wins
+  accumulator fail separately, and a second test pins that
+  `suppressed_ids_count` comes from the id SET and not from the vector
+  the config empties); and the counter's
   zero guard (issue #87) — a `bug_comments` call whose private filter
-  dropped nothing records verdict `served`, `suppressed_count == 0` and
+  dropped nothing records verdict `served`, both counts `0` and
   the rule that decided it, so deleting `note_suppressed_count`'s
   `n == 0` early return, which would merge `served_filtered` (rule-less,
   clearing the rule) on EVERY call of the three tools that feed the
   counter, fails on the verdict rather than on a count that stays `0`
   either way; and `list_attachments`, the id-less site whose guard fields
   no record assertion had reached (the one-record-per-call test calls the
-  tool but reads only its envelope), records a non-zero count over an
-  EMPTY `suppressed_ids` when the I5 gate drops private attachment
-  metadata, and `served` with a zero count over a listing of PUBLIC
-  attachments the gate kept — a real "nothing was withheld" rather than
+  tool but reads only its envelope), records `suppressed_other_count == 2`
+  over an EMPTY `suppressed_ids` with `suppressed_ids_count == 0` when
+  the I5 gate drops private attachment metadata, and `served` with both
+  counts zero over a listing of PUBLIC attachments the gate kept — a real "nothing was withheld" rather than
   an empty list's "nothing to withhold". Between them: deleting that
   counter call, counting the whole list rather than the drop, and adding
   any unconditional note beside it (a `note_redacted`, a rule-less
@@ -2444,7 +2591,7 @@ wired, `server.rs` and `main.rs` are the reference.
   `suppressed_ids` on every call, and `note_redacted` does the same over
   a `redacted_fields` naming a view the client was never put into. A
   `summarize_bug` call whose comments are all public and name one
-  DISCLOSABLE bug records verdict `served`, `suppressed_count == 0`, no
+  DISCLOSABLE bug records verdict `served`, both counts `0`, no
   id and the rule that decided it — pinning that tool's id-set guard and
   giving the counter's third call site the clean-call record #87 left it
   without; a `bug_info` call over a bug served whole whose only link the
@@ -2469,7 +2616,7 @@ wired, `server.rs` and `main.rs` are the reference.
   the cell directly or serialised a hand-built `GuardInfo`. A `restrict`
   rule granting `summary` alone now drives a real summary view through
   each tool, and both records name `summary_view`. Neither fixture
-  withholds anything else — `suppressed_count == 0`, no id, and for the
+  withholds anything else — both counts `0`, no id, and for the
   search `scan.dropped == 0` — so the projection is the only thing the
   `served_filtered` verdict can have come from; and a field outside
   `SUMMARY_FIELDS` (a whiteboard, an `assigned_to` from the tool's default projection)
@@ -2480,9 +2627,10 @@ wired, `server.rs` and `main.rs` are the reference.
   verdict too. The same blind spot elsewhere in the record: `request.id`
   and the handshake identity on a TOOL-CALL record had been read only off
   the hand-built schema fixtures, and are now asserted for every routed
-  tool. `client.principal` is asserted absent deliberately, because
-  nothing self-declared is ever promoted into it, and is pinned with a
-  value only over the hand-built golden. The `upstream` block was the
+  tool. `client.principal` and `client.work_context` are asserted
+  absent on every routed tool of that walk, because nothing self-declared
+  is ever promoted into either; both are pinned with a VALUE only over
+  the hand-built golden, where an example binds no contract. The `upstream` block was the
   same blind spot until #118 gave it a production caller; the router
   walk now measures `upstream.requests` for every tool against what
   wiremock independently served, so a count that ignores its input dies
@@ -2528,8 +2676,8 @@ wired, `server.rs` and `main.rs` are the reference.
   asserted not to contain the key at all, so `Some(0)` and a dropped
   `skip_serializing_if` (a `null`) fail alike. On the export side the
   attribute is asserted present as an Int and absent when the record
-  carries no size, and a pre-#145 line without `response_bytes`
-  deserializes with it `None` against the pinned pre-change golden.
+  carries no size. The pre-#145 still-deserializes test is gone with v1,
+  for the reason the pre-#29 one is ("Schema v2" under "Audit stream").
 - Identity tests (#[cfg(test)] in crates/bugwarden/src/server.rs and
   crates/bugwarden-core/src/client.rs; crates/bugwarden/tests/
   http_transport_wiremock.rs, crates/bugwarden/tests/binary_user_agent.rs
@@ -2574,7 +2722,8 @@ wired, `server.rs` and `main.rs` are the reference.
   POST from a stranger is answered `401` by the gate and `413` only for a
   credentialed caller, which is what the 413-observability argument under
   "rmcp 3.1 usage notes" rests on; a scope-refused call leaves exactly ONE
-  audit record, with no guard verdict, no upstream leg and no `principal`;
+  audit record, with no guard verdict, no upstream leg and neither
+  `principal` nor `work_context`;
   scopes
   enforced with NO scope on the request serves an empty listing and refuses
   every name, the fail-closed branch `main` cannot reach; the constant-time

--- a/examples/audit.toml
+++ b/examples/audit.toml
@@ -12,7 +12,7 @@
 # export"); the stream is never exposed through any MCP surface, and it is
 # never mixed into the diagnostic stderr stream.
 #
-# Format: one JSON object per line (JSONL), schema version 1. Three record
+# Format: one JSON object per line (JSONL), schema version 2. Three record
 # kinds: `tool_call` (one MCP tool invocation, request through outcome,
 # with the guard's decision), `initialize` (a client opened a session),
 # and `audit_gap` (records were lost — see fail_mode below; the gap is
@@ -99,7 +99,9 @@ rotate_keep = 8
 
 # Whether records may name the bug ids the guard suppressed from a
 # response (`guard.suppressed_ids`). With `false`, records carry only the
-# count. The trade: the ids are precisely the hidden-bug numbers this
+# counts — `guard.suppressed_ids_count` still says how many bugs were
+# withheld, and `guard.suppressed_other_count` how many id-less items
+# were. The trade: the ids are precisely the hidden-bug numbers this
 # server exists to withhold from clients, so with `true` the audit file
 # is itself sensitive — anyone who can read it can enumerate hidden bugs.
 # Keep `true` (the default) when the file stays operator-only and you
@@ -107,6 +109,8 @@ rotate_keep = 8
 # when the stream is shipped into a broader log platform where readers
 # are less trusted than the operator. The ids the bugs_quicksearch
 # window scan dropped follow this same switch — there is no second knob
-# — while the scan's counts (`guard.scan.scanned` / `guard.scan.dropped`)
-# are always recorded: counts are not ids. Default: true.
+# — while every count (`guard.suppressed_ids_count`,
+# `guard.suppressed_other_count`, `guard.scan.scanned` /
+# `guard.scan.dropped`) is always recorded: counts are not ids.
+# Default: true.
 suppressed_ids = true


### PR DESCRIPTION
PR 1 of #34's stage-2 sequence. **One-way**: a shipped `SCHEMA_VERSION = 2` is a
permanent compatibility commitment, so the prose is most of the artifact.

## What v2 changes

- **`guard.suppressed_count` → `suppressed_ids_count` + `suppressed_other_count`**
  (#68's end state). v1 had already corrected this value from a max to a sum
  *without a wire change*, which left the correction invisible — the split is the
  re-encoding that makes it structural. The two are disjoint by construction:
  the tools feeding both harvest marker ids only from comments that **survived**
  the private filter, so the total withheld is exactly their sum.
- **`client.work_context`** reserved beside `principal`, absent in every record
  this build writes. Both are documented as *contracts*: server-verified facts,
  never filled from anything self-declared. Filling them later is a value change,
  not a v3.
- **Contract rustdoc** for `ClientInfo`, `principal`, `work_context`,
  `name`/`version`, `SessionInfo::id`, `RequestInfo::id`, `AuditEvent::v`.
- **A trust-tier table** — self-declared / server-verified / server-minted /
  correlation hint. The fourth tier extends #34's three: `session.id` fits none
  of them cleanly, since it is verified but verifies *grouping*, not identity.

**No total field.** Total-plus-parts can desync, the total is addition, and
losing the shared field name is what makes the break loud rather than silent.

## The v1 break, scoped exactly

v2 **rejects** every v1 `tool_call` line carrying a `guard` object — every v1
guard serialized `suppressed_count`, and `deny_unknown_fields` refuses it. That
is load-bearing: a reader that accepted it would have to invent a split for a
number that cannot be split after the fact.

v1 `initialize`, `audit_gap` and guard-less `tool_call` lines **still parse**,
carrying `v: 1` — the reader does not dispatch on `v`, so a consumer holding a
mixed corpus splits on that field itself. Both directions are tested.

## Decisions recorded as closed

`baggage`/`tracestate` skipped **permanently**, not capped — I15's no-secrets
guarantee is structural, and a capped copy is still a client-writable free-text
channel into an append-only operator file. Records are **per-attempt**: a
re-issued call performs its upstream work again, so deduplicating would
under-report real Bugzilla mutations. **#67**: `rule: "default"` kept — absence
already means "no single rule decided". **#84**: no `rule_kind` — the
single-sourced reservation already disambiguates.

**Growth rule** (Martin's call): within a version you may add an optional
absent-when-unset field *or* a new record kind — so #32's refusal record will not
cost a v3 — but **not** a closed-vocabulary variant, which every reader meets
inside a field it already reads with no `event` filter to decline. Made
normative after review found the loophole it left: an optional *modifier* field
(`guard.counts_are_floors`) is structurally additive and would silently redefine
a shipped field — #68's injury again.

## Review

Opus adversarial (NOT MERGE-SAFE, two doc blockers) then Fable final (NOT
MERGE-SAFE, one). All fixed. Every substantive check passed first time: goldens
hand-derived and verified against struct declaration order rather than serializer
output, disjointness confirmed at every call site, the break verified in all four
directions by independent deserialization, the closed-vocabulary carve-out
confirmed complete, twelve mutations killed.

**All three blockers were prose contradictions, and none was inside a changed
line.** The last one is the clearest: three sites said the reserved slots are
"absent in every **v2** record" while every other statement scoped the same fact
to the *build* — and if the version-scoped reading held, filling the slot would
force v3, exactly what the reservation exists to prevent. Two Opus passes read
each sentence and found each defensible in isolation; the contradiction is a
property of the document.

Two findings the implementer sharpened beyond the reviews: `request.params` falls
through the trust table's dichotomy (client-authored, and #34 §3(b) anticipates a
grouping key landing there), and the stdio session id collision is real but has a
remedy — `service.name` exists on the OTLP resource and defaults to the literal
`bugwarden`, so an operator aggregating deployments must set it.

Also fixed: an unbacked DESIGN.md booking ("`client.principal` is asserted absent
deliberately") with no such assertion outside one bearer-scope test. The
assertion was **added** to the router walk rather than the claim deleted, and
mutation-verified as able to fail.

## Verification

All eight AGENTS.md commands re-run independently on the final commit: green.
