### PR TITLE
feat(server): version-gate the SEP-2549 cache hints on tools/list

### DIFF
--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -3950,16 +3950,13 @@ impl ServerHandler for BugWarden {
         request: InitializeRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<InitializeResult, McpError> {
-        // The default handler's peer bookkeeping, replicated: the
-        // handshake info is stored so later calls (and their audit
-        // records) can read it back through `peer_info`.
-        context.peer.set_peer_info(request.clone());
-        // Negotiate before recording: the record names the revision the
-        // session actually speaks, not the one the client asked for.
-        // Echo a requested revision this build serves, keep the server
-        // default otherwise — the same shape the SDK's own negotiation
-        // has, tested against `SUPPORTED_PROTOCOL_VERSIONS` rather than
-        // the wider set of revisions the SDK merely knows about.
+        // Negotiate before anything stores or records it: both the record
+        // and `peer_info` must name the revision the session SPEAKS, not
+        // the one the client asked for. Echo a requested revision this
+        // build serves, keep the server default otherwise — the same shape
+        // the SDK's own negotiation has, tested against
+        // `SUPPORTED_PROTOCOL_VERSIONS` rather than the wider set of
+        // revisions the SDK merely knows about.
         let mut info = self.get_info();
         if SUPPORTED_PROTOCOL_VERSIONS.contains(&request.protocol_version) {
             info.protocol_version = request.protocol_version.clone();
@@ -3970,6 +3967,19 @@ impl ServerHandler for BugWarden {
                 "client requested unsupported protocol version; falling back to server default"
             );
         }
+        // The default handler's peer bookkeeping, replicated — with the
+        // NEGOTIATED revision substituted. rmcp corrects `peer_info` to the
+        // negotiated value only on its own handshake path
+        // (`service/server.rs`, and `NegotiatingStatelessHttpService` for
+        // stateless http); a SECOND `initialize` mid-session reaches this
+        // handler through `serve_inner` with no correction behind it and no
+        // re-init gate in front of it. Storing the request verbatim let a
+        // stdio client raise its own session's `protocol_version()` to any
+        // string it liked — `ProtocolVersion` deserializes unknown values
+        // through — while the answer it was handed said otherwise.
+        let mut negotiated = request.clone();
+        negotiated.protocol_version = info.protocol_version.clone();
+        context.peer.set_peer_info(negotiated);
         if let Some(audit) = &self.audit {
             // Every session start is recorded, unconditionally — no
             // configuration knob: a stream that could omit session
@@ -6656,6 +6666,127 @@ mod tests {
             recorded,
             DEFAULT_PROTOCOL_VERSION.as_str(),
             "the record names the revision the session speaks, not the one requested"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_second_initialize_stores_only_what_the_server_answered() {
+        // rmcp corrects `peer_info` to the negotiated revision only on its
+        // own handshake path, and gates re-initialization nowhere: a second
+        // `initialize` lands in this handler through `serve_inner`, so
+        // whatever it stores is final. Storing the request verbatim let a
+        // client set its own session's `protocol_version()` — which the
+        // response shaping and, from #34 stage 2, per-request identity all
+        // read — to a revision this build refuses, or to a string no
+        // revision has ever had. The invariant is not that a second
+        // `initialize` cannot move the session (a supported one does, in
+        // the last row below): it is that it can only move it to what the
+        // server ANSWERED. Driven over a real duplex session because the
+        // defect is the SECOND request, not the handler in isolation.
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz).expect("server must build");
+        let (client_io, server_io) = tokio::io::duplex(1 << 16);
+        let serving = server.clone();
+        let server_task = tokio::spawn(async move { serving.serve(server_io).await });
+        let client = ().serve(client_io).await.expect("the handshake must succeed");
+        // Held, not dropped: this is the live session's own peer, and it is
+        // the only way to read back what the handler stored.
+        let running = server_task
+            .await
+            .expect("serve task must not panic")
+            .expect("server must serve");
+        let stored = || {
+            running
+                .peer()
+                .peer_info()
+                .expect("the handshake stores peer info")
+                .protocol_version
+                .clone()
+        };
+        assert_eq!(
+            stored(),
+            DEFAULT_PROTOCOL_VERSION,
+            "the session starts here"
+        );
+
+        // "9999-01-01" is not a typo: `ProtocolVersion` deserializes an
+        // unknown string through, and every version comparison in rmcp is
+        // lexical, so a fabricated future date outranks every real
+        // revision. It must be refused by the same arm 2026-07-28 is.
+        for probe in ["2026-07-28", "9999-01-01"] {
+            let asked: ProtocolVersion =
+                serde_json::from_value(json!(probe)).expect("a wire revision parses");
+            let answered = client
+                .peer()
+                .send_request(ClientRequest::InitializeRequest(InitializeRequest::new(
+                    ClientInfo::default().with_protocol_version(asked),
+                )))
+                .await
+                .expect("a second initialize is answered, not dropped");
+            let ServerResult::InitializeResult(answered) = answered else {
+                panic!("initialize answers with an InitializeResult")
+            };
+            assert_eq!(
+                answered.protocol_version, DEFAULT_PROTOCOL_VERSION,
+                "{probe}: the answer must name the negotiated revision"
+            );
+            // The half that was wrong: the answer already said 2025-11-25
+            // while the stored value said otherwise, so no client-visible
+            // assertion could catch it.
+            assert_eq!(
+                stored(),
+                DEFAULT_PROTOCOL_VERSION,
+                "{probe}: the stored revision must be the negotiated one, not the requested one"
+            );
+        }
+
+        // The other direction, and the only place the store is observable
+        // at all: rmcp overwrites whatever this handler put there on the
+        // FIRST handshake, so every assertion above would also hold with no
+        // store at all. A second `initialize` naming a DIFFERENT supported
+        // revision legitimately moves the session — that is what
+        // `set_peer_info` is for — and the failure to catch here is the
+        // mirror of the one fixed: stored disagreeing with answered.
+        let answered = client
+            .peer()
+            .send_request(ClientRequest::InitializeRequest(InitializeRequest::new(
+                InitializeRequestParams::new(
+                    ClientCapabilities::default(),
+                    Implementation::new("renegotiating-client", "9.9"),
+                )
+                .with_protocol_version(ProtocolVersion::V_2024_11_05),
+            )))
+            .await
+            .expect("a supported renegotiation is answered");
+        let ServerResult::InitializeResult(answered) = answered else {
+            panic!("initialize answers with an InitializeResult")
+        };
+        assert_eq!(
+            answered.protocol_version,
+            ProtocolVersion::V_2024_11_05,
+            "a supported revision is echoed, so the session really does move"
+        );
+        assert_eq!(
+            stored(),
+            answered.protocol_version,
+            "the stored revision must equal the one the server answered"
+        );
+        let stored_client = running
+            .peer()
+            .peer_info()
+            .expect("the handshake stores peer info")
+            .client_info
+            .clone();
+        // The identity is re-declared wholesale, so it must follow — and it
+        // must not be the SDK's own build identity, which is what
+        // `Implementation::default()` is and what #34 §3(c) calls the
+        // plausible wrong value an audit trail can least afford.
+        assert_eq!(stored_client.name, "renegotiating-client");
+        assert_eq!(stored_client.version, "9.9");
+        assert_ne!(
+            stored_client.name,
+            Implementation::default().name,
+            "the stored client must never degrade to the SDK placeholder"
         );
     }
 

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -4280,24 +4280,26 @@ impl ServerHandler for BugWarden {
             Reach::ReadOnly => tools.retain(|tool| read_scope_serves(&tool.name)),
             Reach::Nothing => tools.clear(),
         }
+        // The SEP-2549 hints are ours to gate: rmcp 3.1.4 strips
+        // `resultType` for a legacy peer and leaves these two alone. The
+        // predicate is HAND-COPIED from its `sep_2322_supported` — no shared
+        // constant, no test pinning the agreement — so re-read both on an
+        // rmcp bump. `None`, meaning no request revision and no session, is
+        // legacy.
+        let serves_cache_hints = context
+            .protocol_version()
+            .is_some_and(|v| v.as_str() >= ProtocolVersion::V_2026_07_28.as_str());
         Ok(ListToolsResult {
             tools,
             result_type: Some(ResultType::COMPLETE),
             meta: None,
             next_cursor: None,
-            // The 2026-07-28 cache hints stay absent, exactly as they
-            // were before this SDK had the fields: no revision this
-            // build serves defines them, and emitting them anyway would
-            // add fields to responses no peer asked for. When the
-            // revision is adopted, `cache_scope` is `Private` — the
-            // listing is pruned per deployment by policy and by
-            // read-only mode (I13), and per CREDENTIAL by the bearer
-            // scope above, so a shared cache must never serve one
-            // deployment's list to another, nor a write list to a read
-            // token. `CacheScope::default()` is `Public`; this field is
-            // always written by name.
-            ttl_ms: None,
-            cache_scope: None,
+            // `Private`/immediately stale because this listing is pruned
+            // per deployment (I13) and per credential (the bearer scope
+            // above), and `CacheScope::default()` is `Public`. Both
+            // fields stay written by name.
+            ttl_ms: serves_cache_hints.then_some(0),
+            cache_scope: serves_cache_hints.then_some(CacheScope::Private),
         })
     }
 
@@ -6596,6 +6598,110 @@ mod tests {
         let calls = tool_calls(&events);
         assert_eq!(calls.len(), 1, "exactly the direct call is recorded");
         assert_trace_is_canonical(calls[0].trace.as_ref());
+    }
+
+    #[tokio::test]
+    async fn a_2026_request_gets_private_immediately_stale_cache_hints() {
+        // The enabled half of the gate. Unreachable over any transport
+        // while `2026-07-28` is off `SUPPORTED_PROTOCOL_VERSIONS`: no
+        // request may declare it and no session may negotiate it. The
+        // enabler here is therefore the HAND-BUILT peer, not the direct
+        // call — `Service::handle_request` would dispatch this same context
+        // and serve the hints; it is bypassed only because routing through
+        // it would test rmcp rather than the gate.
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz).expect("server must build");
+        let peer = peer_of(&server).await;
+        peer.set_peer_info(
+            ClientInfo::default().with_protocol_version(ProtocolVersion::V_2026_07_28),
+        );
+        // Empty meta is mandatory: any `_meta` revision, 2026-07-28
+        // included, is refused by `skips_the_handshake` above the gate.
+        let context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer);
+        assert!(
+            context.meta.protocol_version().is_none(),
+            "the session's revision, not the request's, must open the gate here"
+        );
+
+        let listed = ServerHandler::list_tools(&server, None, context)
+            .await
+            .expect("a 2026 session lists tools");
+        // On the JSON, not the enum: the wire spelling is what a caching
+        // intermediary reads, and `CacheScope` renames lowercase.
+        let json = serde_json::to_value(&listed).expect("the listing must serialize");
+        assert_eq!(
+            json["cacheScope"],
+            json!("private"),
+            "a per-deployment, per-credential listing is never publicly cacheable"
+        );
+        assert_eq!(
+            json["ttlMs"],
+            json!(0),
+            "a memory-served listing is stale on arrival"
+        );
+        assert!(
+            !listed.tools.is_empty(),
+            "the hints must ride a real listing, not a refusal or an empty one"
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_hints_stay_absent_below_2026_and_with_no_peer_info() {
+        // `skip_serializing_if` makes absence the only observable. The
+        // first row is every client alive today. The second is the `None`
+        // arm, which a production stdio session really can produce —
+        // rmcp's handshake-free lifecycle builds its peer with no info
+        // (`service/server.rs`) — but never at this line: that lifecycle
+        // mandates per-request `_meta`, so `protocol_version()` is `Some`
+        // and `skips_the_handshake` refuses the request above the gate.
+        // Pinned anyway: a handler with no revision to read must fail
+        // toward the legacy wire shape, never toward emission.
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz).expect("server must build");
+
+        let negotiated = peer_of(&server).await;
+        assert_eq!(
+            negotiated
+                .peer_info()
+                .expect("the duplex handshake stores peer info")
+                .protocol_version,
+            DEFAULT_PROTOCOL_VERSION,
+            "the negotiated row must actually be pre-2026"
+        );
+
+        // No handshake, so no peer info at all — the shape rmcp hands a
+        // handler when it cannot name the caller's revision.
+        let (client_io, _server_io) = tokio::io::duplex(1 << 16);
+        let running: RunningService<RoleServer, BugWarden> =
+            rmcp::service::serve_directly(server.clone(), client_io, None);
+        let bare = running.peer().clone();
+        assert!(
+            bare.peer_info().is_none(),
+            "the bare row must carry no revision at all"
+        );
+
+        for (row, peer) in [
+            ("negotiated 2025-11-25", negotiated),
+            ("no peer info", bare),
+        ] {
+            let context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer);
+            let listed = ServerHandler::list_tools(&server, None, context)
+                .await
+                .expect("a legacy listing is served, not refused");
+            let json = serde_json::to_value(&listed).expect("the listing must serialize");
+            assert!(
+                json.get("ttlMs").is_none(),
+                "{row}: ttlMs must be absent from the wire"
+            );
+            assert!(
+                json.get("cacheScope").is_none(),
+                "{row}: cacheScope must be absent from the wire"
+            );
+            assert!(
+                !listed.tools.is_empty(),
+                "{row}: absence must be read off a real listing"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -695,6 +695,21 @@ async fn discover_names_this_build_and_reaches_nothing_else() {
         json!({ "name": "bugwarden", "version": env!("CARGO_PKG_VERSION") }),
         "discover must name this build, and nothing else: {body}"
     );
+    // rmcp's `DiscoverResult` hard-codes both SEP-2549 hints as non-Option
+    // fields, so this pre-2026 request carries them however `tools/list` is
+    // gated. Pinned because the gate's rationale is scoped to *this
+    // handler's listings* on the strength of it, and prose that overreached
+    // here is exactly what the sequence has been blocked on.
+    assert_eq!(
+        payload["result"]["ttlMs"],
+        json!(0),
+        "the SDK's discover serves ttlMs unconditionally: {body}"
+    );
+    assert_eq!(
+        payload["result"]["cacheScope"],
+        json!("private"),
+        "the SDK's discover serves cacheScope unconditionally: {body}"
+    );
     // It answers `get_info` and nothing else: no tool, no guard, no
     // upstream. That is what makes an unauthenticated pre-request surface
     // acceptable while #32 is open.
@@ -703,6 +718,45 @@ async fn discover_names_this_build_and_reaches_nothing_else() {
         upstream.is_empty(),
         "discover must contact no upstream: {} request(s)",
         upstream.len()
+    );
+}
+
+#[tokio::test]
+async fn a_legacy_session_listing_carries_no_cache_hints() {
+    // The regression guard for every client alive today, at the only place
+    // it is the real thing: the in-process rows serialize what the handler
+    // RETURNS, this reads what a client is actually handed once rmcp has
+    // post-processed the result. A gate inversion fails the in-process rows
+    // too — what is unique here is the wire, not the inversion. Substring
+    // assertions hold because no served schema, description or annotation
+    // spells either field; pin that if one ever does.
+    let mock = MockServer::start().await;
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock, None).await;
+
+    let session = raw_initialize(addr, "legacy-client").await;
+    let response = mcp_post(addr, Some(&session))
+        .header("MCP-Protocol-Version", "2025-11-25")
+        .json(&json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {} }))
+        .send()
+        .await
+        .expect("the listing request must reach the server");
+    let body = response.text().await.expect("a body");
+
+    assert!(
+        body.contains("\"bug_info\""),
+        // A named tool, not the `"tools"` key: that key is present even
+        // for an empty listing or a scope that reaches nothing.
+        "the session must be served a real listing: {body}"
+    );
+    assert!(
+        !body.contains("ttlMs"),
+        "a legacy session must see no cache ttl: {body}"
+    );
+    assert!(
+        !body.contains("cacheScope"),
+        "a legacy session must see no cache scope: {body}"
     );
 }
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1952,10 +1952,42 @@ wired, `server.rs` and `main.rs` are the reference.
   even when the caller innocently echoed one, because a forgeable id is worse
   than none (#34).
 - `list_tools` names every `ListToolsResult` field: `result_type` is
-  `COMPLETE`, and the 2026-07-28 cache hints stay absent while that revision
-  is unserved. When it is adopted, `cache_scope` is `Private` — the listing is
-  pruned per deployment (I13), so a shared cache must never serve one
-  deployment's list to another — and `CacheScope::default()` is `Public`.
+  `COMPLETE`, and the SEP-2549 cache hints are gated on the request's
+  revision. **rmcp trap — the only version-shaped edit the SDK makes to a
+  served result is stripping `resultType`.** In rmcp 3.1.4
+  `ServerResult::strip_result_type_for_legacy_peer` (`model.rs`) edits that
+  one field and nothing else; the same `handle_request` version-gates other
+  things (`InputRequiredResult`, the SEP-2164 error-code swap, ping and
+  subscribe availability), but it never touches `ttl_ms`/`cache_scope`, so
+  written unconditionally they would reach every pre-2026 peer. The gate is
+  ours: `RequestContext::protocol_version()` — the request's own `_meta`
+  revision, else the session's negotiated one, `None` when neither — at least
+  `2026-07-28`, and `None` fails toward the legacy wire shape rather than
+  toward emission. That expression is a hand-copy of the one rmcp 3.1.4
+  computes `sep_2322_supported` from (`handler/server.rs`): the two agree
+  today by inspection, share no constant, and no test pins the agreement.
+  Re-read both on every rmcp bump — if upstream's predicate moves, this build
+  will keep answering the old one and nothing will fail.
+  Served, the pair is `cache_scope: Private`, `ttl_ms: 0`: the listing is
+  pruned per deployment by policy and by `--read-only` (I13) **and** per
+  credential by the bearer scope, so a shared intermediary caching one
+  context's list and serving it to another is a policy leak — and
+  `CacheScope::default()` is `Public`. A listing served from memory has
+  nothing worth caching. The exact claim, which is about listings and not
+  about peers: **no `tools/list` response this handler constructs carries the
+  SEP-2549 pair unless the request's revision is at least 2026-07-28.** Not
+  about peers because in rmcp 3.1.4 `DiscoverResult` (`model.rs`) declares
+  `ttl_ms: u64` and `cache_scope: CacheScope` as non-`Option` fields with no
+  `skip_serializing_if`, hard-coded to `0`/`Private` by both constructors,
+  and this build keeps rmcp's default `server/discover` — so a legacy peer
+  naming 2025-11-25 gets the pair from *that* surface today, whatever
+  `tools/list` does. `2026-07-28` is off `SUPPORTED_PROTOCOL_VERSIONS`, so
+  the served branch is unreachable end to end — but only because
+  `initialize` stores the NEGOTIATED revision (above): while it stored the
+  requested one, a second `initialize` reopened this branch on a live stdio
+  session. It is therefore tested in-process against a hand-built
+  `RequestContext`; the legacy branch is live and tested over real
+  streamable HTTP.
 - **rmcp trap — `input_schema` is schemars' rendering, unfiltered by rmcp.**
   `SchemaSettings::draft2020_12()` (`handler/server/common.rs`) runs zero
   transforms, so whatever schemars 1.x emits for a `#[tool]` param struct is

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1845,7 +1845,28 @@ wired, `server.rs` and `main.rs` are the reference.
   The hand-written `initialize` tests the same list — the SDK negotiates
   again afterwards using the handler's answer as its fallback, so a handler
   that echoed an unsupported request would make the SDK echo it too — and
-  records the negotiated revision, never the requested one. `get_info` pins
+  records the negotiated revision, never the requested one. It also **stores**
+  the negotiated revision in `peer_info`, which is not the same statement:
+  in rmcp 3.1.4 that second negotiation runs only on the FIRST, handshake
+  `initialize` (`service/server.rs`; `NegotiatingStatelessHttpService` in
+  `tower.rs` for stateless http), while a second `initialize` mid-session
+  reaches this handler through `serve_inner` with no correction after it and
+  no re-init gate before it — so storing the request verbatim let a client
+  set its own session's `RequestContext::protocol_version()` to a revision
+  this build refuses, or to a string no revision has ever had
+  (`ProtocolVersion` deserializes unknown values through, and every rmcp
+  version comparison is lexical, so `"9999-01-01"` outranks all of them).
+  Both transports carried it, with different reach: stdio unrestricted,
+  while over http only a SUB-2026 fabrication rides a live session — it is
+  classified legacy and reaches the handler on that session's own stream —
+  because `2026-07-28` and above is routed statelessly and mints no session
+  to poison. So http could move a session's revision but never past the
+  2026-07-28 threshold every version-gated reader compares against.
+  The handler is gate-agnostic about this: if a future rmcp refuses or drops
+  a second `initialize`, it is simply never reached and stores nothing. Its
+  TEST is not — that test asserts the second `initialize` is answered, so a
+  bump gating re-init fails it loudly, and it should then be re-scoped or
+  retired rather than taught to accept a refusal. `get_info` pins
   `DEFAULT_PROTOCOL_VERSION` rather than inheriting `ProtocolVersion::default()`,
   which moves with the SDK.
 - **rmcp trap — `Implementation::from_build_env()` names the SDK, not this


### PR DESCRIPTION
PR 2 of #34's stage-2 sequence. Two commits, each independently green.

## Commit 1 — `peer_info` stored the requested revision, not the negotiated one

Found while proving PR 2's own unreachability claim, and it is a real defect.

`initialize` stored the client's *requested* protocol version via
`set_peer_info(request.clone())`. rmcp corrects `peer_info` to the negotiated
version **only on the handshake path**, and it has no re-init gate — so a
**second `initialize` mid-session** reaches our handler and the requested value
sticks, while the response correctly reports the downgrade. Nothing
client-visible contradicted it, which is why no test caught it.

Reproduced before fixing, over the same stdio path `main.rs` uses:

```
handshake at 2025-11-25             -> OK
re-init asking 2026-07-28           -> response says 2025-11-25
next tools/list                     -> "ttlMs":0,"cacheScope":"private"  SERVED
re-init asking "9999-01-01"         -> same
```

A fabricated string works because `ProtocolVersion`'s deserializer passes
unknown values through. And this was **not** stdio-only: a fabricated *sub-2026*
revision is classified legacy and rides a live `mcp-session-id` into the handler
— probed, answered 200 on that session's own SSE stream, writing an `initialize`
record under the handshake's session id. HTTP escaped observable harm only
because every version-gated reader thresholds at 2026-07-28, which no sub-2026
string reaches.

Fix: negotiate first, store the negotiated revision. The narrow true invariant —
a second `initialize` can still legitimately re-negotiate within
`SUPPORTED_PROTOCOL_VERSIONS`; what it can no longer do is move a session **off
what the server answered**.

This matters beyond cache hints: PR 3 keys identity decisions off
`protocol_version()`.

## Commit 2 — the gate

`ttl_ms: Some(0)`, `cache_scope: Some(CacheScope::Private)` when
`context.protocol_version()` is >= 2026-07-28; both absent otherwise, with
`None` meaning legacy — fail toward the old wire shape, never toward emission.

`private` because the listing is pruned **per deployment** (I13) and **per
credential** (bearer scope), so a shared cache serving one context's list to
another is a policy leak — and `CacheScope::default()` is `Public`. `ttl_ms: 0`
because a memory-served list has nothing worth caching.

The gate is ours because **the SDK gates these fields nowhere**:
`strip_result_type_for_legacy_peer` edits only `result_type`. The predicate is a
**hand copy** of rmcp 3.1.4's `sep_2322_supported` — no shared source, no test
pinning the agreement, so both need re-reading on an rmcp bump.

The exact claim, scoped deliberately:

> No `tools/list` response this handler constructs carries the SEP-2549 pair
> unless the request's revision — its own `_meta`, else the session's negotiated
> one — is at least 2026-07-28.

Not "never shown to a legacy peer": the SDK's default `server/discover`, which
this build keeps, hard-codes `ttlMs: 0`/`cacheScope: "private"` as non-`Option`
fields and serves them unconditionally. A new assertion on the discover test
pins that, so the prose cannot go stale silently.

The enabled branch is unreachable end to end until PR 3 — **and only because of
commit 1**, recorded on both sides so a revert cannot silently reopen it.

## Review

Three Fable lenses (mechanism, prose, then both commits), all NOT MERGE-SAFE,
all findings fixed. Every blocking finding was prose; the code was confirmed
correct each time.

The record was wrong in both directions here. **The implementer** attributed a
`-32602` to rmcp's handler wrapper; review proved it is the transport
(`validate_request_protocol_version_meta`) — and that it is the *sole* barrier,
since the wrapper would have served the request with peer_info synthesized at
2026-07-28. **I** claimed HTTP sessions escaped the peer_info defect "by
accident of routing"; review demonstrated live that they did not.

Two mutants survive by design and are noted rather than contorted around:
`>=`→`==` (structural — no revision above 2026-07-28 exists in rmcp 3.1.4) and
dropping the `_meta` arm (shielded by `skips_the_handshake` until PR 3 makes
that predicate three-way).

## Verification

All eight AGENTS.md commands re-run independently on the final tip and on commit
1 alone: green.
