### PR TITLE
feat(server): serve the 2026-07-28 per-request lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,19 +548,33 @@ authenticated `initialize` request from outside the container.
 
 ### MCP protocol revisions
 
-bugwarden serves four revisions of the Model Context Protocol —
-`2024-11-05`, `2025-03-26`, `2025-06-18` and `2025-11-25` — and offers
-`2025-11-25` when a client asks for something outside that set. The list is
-pinned rather than inherited from the SDK, so a dependency bump cannot
+bugwarden serves five revisions of the Model Context Protocol —
+`2024-11-05`, `2025-03-26`, `2025-06-18`, `2025-11-25` and `2026-07-28` — and
+offers `2025-11-25` when a client asks for something outside that set. The
+list is pinned rather than inherited from the SDK, so a dependency bump cannot
 quietly widen or narrow what a deployment speaks. In the handshake the
 server names itself and its version — `bugwarden` and the release it was
 built from — never the SDK's.
 
-Every session must complete the `initialize` handshake. A request that
-declares a protocol revision in its own `_meta` instead of negotiating one is
-refused whatever revision it names — some such requests skip the handshake
-outright, and a server that answered those would be talking to a client it
-never greeted, with no audit record able to say who that was.
+Two lifecycles are served side by side, and a request is placed by the
+revision it declares in its own `_meta`:
+
+- **no declaration** — the ordinary case. The session negotiated its revision
+  through the `initialize` handshake, and the client is the one that
+  handshake named.
+- **`2026-07-28`, or a later revision this build serves** — the
+  handshake-free lifecycle that revision defines. The request carries its own
+  revision and capabilities, and over HTTP there is no session at all: no
+  `mcp-session-id`, and each request stands alone. It may also carry its own
+  `clientInfo`, which is what an audit record then names; a request that
+  declares none is served, and the record names nobody rather than guessing.
+- **anything else** — refused. Below `2026-07-28` because those revisions
+  negotiate through the handshake, so a per-request declaration mixes two
+  contracts and a server that answered it could be talking to a client it
+  never greeted with no way to say who that was. At or above it, because a
+  revision is served only if it is on the list above — being newer is not
+  enough, and a client naming one gets the served list back from the server
+  before it ever reaches this decision.
 
 The advertised capability set is tools only: bugwarden registers no MCP
 prompts and no MCP resources. `summarize_bug` is a tool that returns prompt
@@ -851,9 +865,11 @@ are byte-identical.
 
 One JSON object per line, schema version 2, in three kinds:
 
-- **`initialize`** — a client opened a session; carries the client's
+- **`initialize`** — a client sent an `initialize`; carries the client's
   self-declared name and version and the *negotiated* protocol revision.
-  Written unconditionally, with no knob to suppress it.
+  Written unconditionally, with no knob to suppress it. Usually that opened
+  a session; a `2026-07-28` `initialize` over HTTP does not, so that record
+  carries no session id.
 - **`tool_call`** — exactly one per tool invocation, including calls that
   were denied, refused, or aimed at a tool name that does not exist. The
   tool listing is deliberately not recorded. One per *attempt*, precisely:
@@ -868,8 +884,9 @@ One JSON object per line, schema version 2, in three kinds:
 Every record carries `v`, a millisecond-precision UTC `ts`, a per-process
 monotonic `seq` (the ordering authority — file order equals `seq` order),
 and a `session` naming the transport, the peer address over http, and the
-session id where the transport opened a session at all — a call refused on
-the handshake-free path opened none, and carries no id. A `tool_call` adds the client, the request (tool name, request
+session id where the transport opened a session at all — a call on the
+handshake-free path over HTTP opened none, served or refused, and carries no
+id; over stdio it keeps the process-scoped one. A `tool_call` adds the client, the request (tool name, request
 id, parameters), the `outcome` — class, duration and, when there was a
 result to measure, `response_bytes`: the serialized size of the content
 the server produced — the compact JSON of the result's content array,
@@ -939,8 +956,13 @@ identities. `client.principal` and `client.work_context` are the opposite,
 nothing self-declared may be promoted into either, and both are reserved —
 no verifier exists, so neither appears in a record this build writes.
 `session.id` is *server-minted*: records sharing one passed through a single
-transport session and join that session's `initialize` record, which proves
-grouping and says nothing about who was at the other end. Everything else
+transport session — and where that session began with a handshake, they join
+its `initialize` record. It proves grouping and says nothing about who was at
+the other end. The anchor is not promised: a 2026-07-28 stdio client may open
+with an ordinary request and never send `initialize`, leaving a whole
+session's records sharing an id nothing anchors. They are still truthful — the
+id is minted, not client-supplied, so an unanchored group cannot join the
+wrong session, it simply has nothing to join. Everything else
 that looks like an identifier — `trace`, `request.id`, `session.remote` — is
 a *correlation hint*, client-chosen or path-dependent: useful for joining
 records, evidence of nothing. The normative version of that list lives with

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -45,7 +45,7 @@
 //! |---|---|---|
 //! | Self-declared | `client.name`, `client.version` | Whatever the client said about itself. Never verified, by anything: a label, never an identity. |
 //! | Server-verified | `client.principal`, `client.work_context` | Only a validator this server trusts may mint one, and nothing self-declared may be promoted into either. Reserved: no verifier exists, so neither appears in a record THIS BUILD writes — a later build that can prove a caller fills them without moving `v`. |
-//! | Server-minted | `session.id` | Within one deployment's stream, proves that records sharing it passed through one transport session, and joins them to that session's `initialize`. Says nothing about WHO was on the other end. |
+//! | Server-minted | `session.id` | Within one deployment's stream, proves that records sharing it passed through one transport session — and, where that session began with a handshake, joins them to its `initialize`. Says nothing about WHO was on the other end. |
 //! | Correlation hint | `trace`, `request.id`, `session.remote` | Client-chosen or path-dependent — a `traceparent` any caller may stamp, an id the client picked, a peer address that is the last proxy's behind one. Useful for joining records; evidence of nothing. |
 //!
 //! This table is normative and versioned with the schema: a new field
@@ -523,11 +523,22 @@ pub struct ToolCallEvent {
     pub outcome: OutcomeInfo,
 }
 
-/// Payload of an `initialize` record: a client opened an MCP session.
+/// Payload of an `initialize` record: a client sent an `initialize`.
+///
+/// Usually that opened a session, and [`SessionInfo::id`] then joins this
+/// anchor to the records it anchors. A `2026-07-28` `initialize` over http
+/// is the exception: rmcp routes it down the handshake-free path, so it is
+/// answered and recorded but opens nothing, and the record carries no id.
+/// It is written anyway: recording every handshake unconditionally is the
+/// invariant, and joins are on id equality, so an anchor with no id anchors
+/// nothing and gathers nothing that belongs elsewhere either. Over stdio the
+/// same request is an ordinary handshake and does open a session.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct InitializeEvent {
-    /// The client as it introduced itself in the handshake.
+    /// The client as it introduced itself in the handshake — the
+    /// REQUEST's own `clientInfo`, never a peer identity the transport
+    /// synthesised.
     pub client: ClientInfo,
     /// The MCP protocol version the session negotiated — the revision
     /// actually spoken, which is not always the one the client asked for:
@@ -572,9 +583,19 @@ pub struct SessionInfo {
     /// `mcp-session-id` request header is not read (#180).
     ///
     /// What it GUARANTEES is grouping WITHIN ONE DEPLOYMENT'S STREAM:
-    /// records sharing an id passed through one transport session, and
-    /// that session's `initialize` record carries the same id, so a tool
-    /// record can be joined to the handshake that anchors it.
+    /// records sharing an id passed through one transport session. Where
+    /// that session began with a handshake, its `initialize` record carries
+    /// the same id, so a tool record joins the handshake that anchors it.
+    ///
+    /// The anchor is not guaranteed, and the gap is not the http one. A
+    /// 2026-07-28 client over STDIO may open with an ordinary request and
+    /// never send `initialize` at all — rmcp serves that first message and
+    /// keeps the connection — while this id, minted from the process, is
+    /// stamped on every record regardless. A whole session of records can
+    /// therefore share an id no `initialize` names. They stay truthful: the
+    /// id is unforgeable and no other session shares it, so an unanchored
+    /// group is never joined to the WRONG session — it simply has nothing to
+    /// join to.
     ///
     /// That scope is load-bearing, not boilerplate. Over stdio the id is
     /// `<pid>-<startup epoch seconds>`, unique on a host and not beyond
@@ -587,11 +608,13 @@ pub struct SessionInfo {
     /// What it does NOT: it is not an identity. A session is a
     /// connection, and nothing about who was on the other end of it
     /// follows from the id. Nor does it exist on the handshake-free
-    /// per-request path, which opens no session — there the only
-    /// candidate is the `mcp-session-id` header, unvalidated client text
-    /// that any caller could stamp with a live session's id, and a
-    /// forgeable id is worse than none. Grouping there is
-    /// [`SessionInfo::remote`] plus nothing.
+    /// per-request path OVER HTTP, which opens no session — there the
+    /// only candidate is the `mcp-session-id` request header, unvalidated
+    /// client text that any caller could stamp with a live session's id,
+    /// and a forgeable id is worse than none. Grouping there is
+    /// [`SessionInfo::remote`] plus nothing. Over stdio the same
+    /// lifecycle keeps its id: that one is minted from the process, not
+    /// read off a request, so there is nothing to forge.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// Which transport carried the session.
@@ -626,10 +649,14 @@ pub enum TransportKind {
 #[serde(deny_unknown_fields)]
 pub struct ClientInfo {
     /// Client name as the client declared it: the `initialize`
-    /// handshake, and per-request `_meta` on a handshake-free revision
-    /// should this build ever serve one — the same trust level either
-    /// way. Self-declared and therefore untrusted: treat it as a label,
-    /// never as an identity.
+    /// handshake, or the request's own `_meta` on the handshake-free
+    /// 2026-07-28 lifecycle this build serves — the same trust level
+    /// either way. Self-declared and therefore untrusted: treat it as a
+    /// label, never as an identity. Absent when the caller declared
+    /// nothing, which the per-request lifecycle permits (`clientInfo` is
+    /// optional there) — absent is the honest answer, and never the
+    /// SDK's own build identity, which is what the transport synthesises
+    /// for a peer that never handshook.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// Client version, from the same source and at the same trust level
@@ -1636,9 +1663,17 @@ pub struct AuditState {
     /// policy applies (there is no file to hash).
     pub policy_hash: Option<String>,
     /// Session id stamped into stdio records. One process is one stdio
-    /// session, so `<pid>-<unix epoch secs at startup>` anchors those
-    /// records the way the transport-minted id anchors http ones (see
+    /// session, so `<pid>-<unix epoch secs at startup>` groups those
+    /// records the way the transport-minted id groups http ones (see
     /// [`crate::http_session`] — never the request header, #180).
+    ///
+    /// Stamped UNCONDITIONALLY, including on the 2026-07-28 per-request
+    /// lifecycle, where the http path records no id at all: there the only
+    /// candidate is a forgeable request header, here the value is minted
+    /// from the process and cannot be forged. The consequence is that a
+    /// stdio client which never sends `initialize` produces a run of
+    /// records sharing an id that no `initialize` anchors — see
+    /// [`SessionInfo::id`], which is where that limit is stated.
     pub stdio_session_id: String,
 }
 

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -34,18 +34,24 @@ use crate::http_auth::{self, Scope};
 /// The MCP revisions this build actually implements, newest last.
 ///
 /// Deliberately not `ProtocolVersion::KNOWN_VERSIONS`: the SDK knows more
-/// revisions than it can serve through this handler, and both the rmcp
-/// default for `supported_protocol_versions` and the handshake below
-/// would otherwise accept `2026-07-28` — a revision whose stateless
-/// requests carry no handshake, so audit records would name a client the
-/// server never spoke to (issue #34). A client asking for it gets the
-/// server default instead, and every rmcp bump has to widen this list
-/// deliberately, never by inheriting a longer one.
+/// revisions than this handler serves, so every rmcp bump has to widen
+/// this list deliberately rather than by inheriting a longer one. What
+/// the list bounds is precisely which DECLARED revisions `initialize`,
+/// per-request `_meta` and `server/discover` may agree to; it does not
+/// decide which request lifecycle the transport routes to — see
+/// [`lifecycle_of`].
+///
+/// `2026-07-28` is served as of issue #34 stage 2. Its handshake-free
+/// requests carry the calling client in their own `_meta`, which
+/// [`client_of`] reads, so a record on that path names the caller or names
+/// nobody — never the SDK placeholder rmcp synthesises for a peer that
+/// never handshook (#34 §3c).
 const SUPPORTED_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
     ProtocolVersion::V_2024_11_05,
     ProtocolVersion::V_2025_03_26,
     ProtocolVersion::V_2025_06_18,
     ProtocolVersion::V_2025_11_25,
+    ProtocolVersion::V_2026_07_28,
 ];
 
 /// The revision offered when a client asks for one this build cannot
@@ -328,6 +334,20 @@ fn truncated(value: &Value) -> Value {
     }
 }
 
+/// `value` truncated to [`PARAM_VALUE_MAX_CHARS`] characters — the cap
+/// [`truncated`] applies to an audited parameter, applied to a recorded
+/// client identity. The single helper is the discipline: every site that
+/// writes `ClientInfo::name`/`version` goes through it.
+fn capped(value: String) -> String {
+    // A string of at most 1024 BYTES has at most 1024 chars; the cheap
+    // length check skips the char walk for the common case.
+    if value.len() > PARAM_VALUE_MAX_CHARS {
+        value.chars().take(PARAM_VALUE_MAX_CHARS).collect()
+    } else {
+        value
+    }
+}
+
 /// Project a tool call's arguments through [`PARAM_ALLOWLIST`] into the
 /// audit record's `params` map.
 fn allowlisted(params: Option<&JsonObject>) -> BTreeMap<String, Value> {
@@ -348,15 +368,46 @@ fn allowlisted(params: Option<&JsonObject>) -> BTreeMap<String, Value> {
         .collect()
 }
 
-/// The calling client as it introduced itself in the handshake, for an
-/// audit record. Self-declared, therefore untrusted; `principal` and
-/// `work_context` stay `None` — both are server-verified slots and this
-/// build has no verifier to fill either.
+/// The calling client as it declared itself, for an audit record.
+/// Self-declared at every source and therefore untrusted; `principal` and
+/// `work_context` stay `None` — both are server-verified slots, this build
+/// has no verifier to fill either, and nothing carried in `_meta` is ever
+/// promoted into them.
+///
+/// The source is the request's [`Lifecycle`], read here rather than passed
+/// in, so identity cannot diverge from routing by call-site ordering:
+///
+/// * [`Lifecycle::PerRequest`] — the request's own `_meta`. **Never
+///   `ctx.client_info()`**: that convenience accessor falls back to
+///   `peer_info().client_info` unless `request_metadata_required()`, which
+///   rmcp 3.1.4 sets only on the stdio handshake-free path
+///   (`service/server.rs`), so over streamable http it IS the
+///   `{"name":"rmcp",…}` placeholder rmcp synthesises for a peer that
+///   never handshook (`peer_info_for_stateless_request`, #34 §3c) — and
+///   never `peer_info()` here for the same reason. `ctx.meta.client_info()`
+///   decodes all-or-nothing, so a `clientInfo` missing `version`, or not an
+///   object at all, yields nothing rather than half an identity:
+///   fail-to-absent comes free.
+/// * [`Lifecycle::Handshake`] — the peer rmcp populated at `initialize`.
+///   The client this server actually greeted.
+/// * [`Lifecycle::OutOfContract`] — nobody; the call is refused anyway.
+///
+/// Both fields are [`capped`]: per-request sourcing repeats a
+/// client-controlled string into EVERY record where the handshake wrote it
+/// once per session.
 fn client_of(ctx: &RequestContext<RoleServer>) -> audit::ClientInfo {
-    let peer = ctx.peer.peer_info();
+    let declared = match lifecycle_of(ctx) {
+        Lifecycle::PerRequest => ctx.meta.client_info().map(|i| (i.name, i.version)),
+        Lifecycle::Handshake => ctx
+            .peer
+            .peer_info()
+            .map(|p| (p.client_info.name.clone(), p.client_info.version.clone())),
+        Lifecycle::OutOfContract => None,
+    };
+    let (name, version) = declared.unzip();
     audit::ClientInfo {
-        name: peer.as_ref().map(|p| p.client_info.name.clone()),
-        version: peer.as_ref().map(|p| p.client_info.version.clone()),
+        name: name.map(capped),
+        version: version.map(capped),
         principal: None,
         work_context: None,
     }
@@ -422,39 +473,86 @@ fn max_request_body_bytes(max_attachment_bytes: u64) -> usize {
         .clamp(MAX_REQUEST_BODY_FLOOR, MAX_REQUEST_BODY_CEILING)
 }
 
-/// Whether this request declares its own protocol revision in `_meta`.
+/// Which lifecycle a request belongs to.
 ///
-/// rmcp 3.1.4 routes on `_meta` shape, not on the negotiated revision and
-/// not on [`SUPPORTED_PROTOCOL_VERSIONS`]: the stateless path takes a
-/// request naming `2026-07-28` or newer, or one carrying BOTH
-/// `io.modelcontextprotocol/protocolVersion` and `…/clientCapabilities`.
-/// So excluding `2026-07-28` does not keep a request off that path — a
-/// client naming a revision this build does serve, with both keys, reaches
-/// the handler with no `initialize` behind it, and rmcp synthesises its peer
-/// with the SDK's own build identity as `client_info`. Served, such a call
-/// would put a client the server never spoke to into the audit stream, with
-/// no session record anchoring it — a plausible wrong attribution, which is
-/// the one an audit trail can least afford.
-///
-/// No revision this build serves defines that lifecycle, so the declaration
-/// is out of contract and is refused wherever it arrives. Broader than the
-/// routing on purpose: a sub-2026 declaration lacking `clientCapabilities`
-/// takes the session path, so this also fires on requests that did complete a
-/// handshake. Separately, the routing reads more than `_meta` — the
-/// `MCP-Protocol-Version` header, and `initialize`'s own `protocolVersion` —
-/// but neither needs cover here: a header-only `2026-07-28` is refused by the
-/// transport before any handler, and an `initialize` naming it does take the
-/// stateless path but is recorded from `request.client_info`, never from the
-/// synthesized peer.
-fn skips_the_handshake(ctx: &RequestContext<RoleServer>) -> bool {
-    ctx.meta.protocol_version().is_some()
+/// Decided on the revision the request DECLARES in its own `_meta`, never
+/// on the session's negotiated one: a 2026-07-28 session's ordinary
+/// requests carry no `_meta` at all and belong to [`Lifecycle::Handshake`],
+/// where their peer identity is the real one.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Lifecycle {
+    /// No per-request declaration. Usually an `initialize` handshake stands
+    /// behind the request, and `peer_info` then names the client this server
+    /// greeted. A session served directly lands here too, with no
+    /// `peer_info` at all — nothing was greeted, so the identity is absent
+    /// rather than wrong.
+    Handshake,
+    /// The 2026-07-28 handshake-free lifecycle: the request carries its own
+    /// revision and client capabilities, optionally its own identity, and
+    /// over http no session exists to carry them instead.
+    PerRequest,
+    /// A per-request declaration this build will not serve on that
+    /// lifecycle: a revision below `2026-07-28`, which negotiates through
+    /// the handshake instead and so mixes two contracts, or one at or above
+    /// it that this build does not serve at all. Refused either way, and
+    /// nothing in such a request can be attributed.
+    OutOfContract,
 }
 
-/// The uniform refusal for a request that skipped the handshake. Names no
-/// tool, bug or policy — it is a statement about the request's shape.
-fn handshake_required() -> McpError {
+/// The [`Lifecycle`] of `ctx`.
+///
+/// One decision shared by `call_tool`, `list_tools` and [`client_of`], so
+/// what gets served and who gets recorded cannot diverge by call-site
+/// ordering.
+///
+/// rmcp 3.1.4 routes on `_meta` shape, not on the negotiated revision and
+/// not on [`SUPPORTED_PROTOCOL_VERSIONS`]: `is_legacy_request`
+/// (`transport/streamable_http_server/tower.rs`) sends a POST down the
+/// stateless path when the request's revision is `2026-07-28` or newer, or
+/// when a non-`initialize` request carries BOTH
+/// `io.modelcontextprotocol/protocolVersion` and `…/clientCapabilities`.
+/// That second shape is why the refusal arm still exists after adoption: a
+/// pre-2026 revision sent with both keys reaches the handler with no
+/// `initialize` behind it, and rmcp synthesises its peer with the SDK's own
+/// build identity as `client_info` — a client the server never spoke to.
+/// The arm is broader than the routing on purpose: a sub-2026 declaration
+/// lacking `clientCapabilities` takes the session path, so it fires on
+/// requests that DID complete a handshake too.
+///
+/// The `contains` clause is defence in depth: rmcp refuses a `_meta`
+/// revision outside `supported_protocol_versions()` first
+/// (`handler/server.rs`, -32022), but every rmcp version comparison is
+/// lexical and this repo has already been bitten by a fabricated
+/// `"9999-01-01"` outranking every real revision.
+fn lifecycle_of(ctx: &RequestContext<RoleServer>) -> Lifecycle {
+    match ctx.meta.protocol_version() {
+        None => Lifecycle::Handshake,
+        Some(v)
+            if v.as_str() >= ProtocolVersion::V_2026_07_28.as_str()
+                && SUPPORTED_PROTOCOL_VERSIONS.contains(&v) =>
+        {
+            Lifecycle::PerRequest
+        }
+        Some(_) => Lifecycle::OutOfContract,
+    }
+}
+
+/// The uniform refusal for a [`Lifecycle::OutOfContract`] request. Names no
+/// tool, bug or policy — it states which declarations this build serves on
+/// that lifecycle, and both halves of that are public anyway:
+/// `server/discover` advertises the served list and rmcp's own -32022 quotes
+/// it back.
+///
+/// Covers BOTH arms the predicate refuses, which an earlier wording did not:
+/// a revision below the threshold, and one at or above it that this build
+/// does not serve — the `"9999-01-01"` case, reachable here only if rmcp's
+/// -32022 ever stops running first, which is the scenario the `contains`
+/// clause exists for.
+fn mixed_lifecycle_refused() -> McpError {
     McpError::invalid_request(
-        "this server requires the initialize handshake; per-request protocol negotiation is not served",
+        "a per-request protocol declaration is served only for a revision this \
+         server serves at 2026-07-28 or later; earlier revisions negotiate \
+         through the initialize handshake",
         None,
     )
 }
@@ -3981,13 +4079,18 @@ impl ServerHandler for BugWarden {
         negotiated.protocol_version = info.protocol_version.clone();
         context.peer.set_peer_info(negotiated);
         if let Some(audit) = &self.audit {
-            // Every session start is recorded, unconditionally — no
+            // Every `initialize` is recorded, unconditionally — no
             // configuration knob: a stream that could omit session
-            // starts could not anchor its tool records to a client.
+            // starts could not anchor its tool records to a client. Over
+            // http a 2026-07-28 `initialize` takes the stateless route
+            // and opens no session, so the anchor is written with no id;
+            // unconditional is still the invariant, and joins are on id
+            // equality, so a record with no id matches nothing rather than
+            // the wrong thing.
             let event = audit::AuditEventKind::Initialize(audit::InitializeEvent {
                 client: audit::ClientInfo {
-                    name: Some(request.client_info.name.clone()),
-                    version: Some(request.client_info.version.clone()),
+                    name: Some(capped(request.client_info.name.clone())),
+                    version: Some(capped(request.client_info.version.clone())),
                     principal: None,
                     work_context: None,
                 },
@@ -4021,7 +4124,7 @@ impl ServerHandler for BugWarden {
         mut context: RequestContext<RoleServer>,
     ) -> Result<CallToolResponse, McpError> {
         let started = Instant::now();
-        if skips_the_handshake(&context) {
+        if lifecycle_of(&context) == Lifecycle::OutOfContract {
             // Recorded before it is refused, like every other turned-away
             // call: a stream that went quiet for a whole request class
             // could not be read as a complete account. `client` is absent
@@ -4030,7 +4133,7 @@ impl ServerHandler for BugWarden {
             // identity, and one refusal class must not be recorded two
             // ways. `session.id` is still present when there is one:
             // this refusal is broader than rmcp's stateless routing (see
-            // `skips_the_handshake`), so a declaration that took the
+            // `lifecycle_of`), so a declaration that took the
             // session branch arrives with its real id stamped, while a
             // stateless one had no session to stamp (#180).
             if let Some(audit) = self.audit.clone() {
@@ -4059,7 +4162,7 @@ impl ServerHandler for BugWarden {
                 let session = self.session_info(&context, &audit);
                 let _ = record_event(&audit, event, session).await;
             }
-            return Err(handshake_required());
+            return Err(mixed_lifecycle_refused());
         }
         // Bearer scope gate (issue #32): a tool this credential does not
         // reach is refused as unrouted, so the read scope hides the write
@@ -4268,8 +4371,8 @@ impl ServerHandler for BugWarden {
         // per deployment (I13), so answering one of these would disclose
         // which tools this policy removed. Unrecorded, as
         // every listing is — the schema has no event kind for one.
-        if skips_the_handshake(&context) {
-            return Err(handshake_required());
+        if lifecycle_of(&context) == Lifecycle::OutOfContract {
+            return Err(mixed_lifecycle_refused());
         }
         // Filtered, not listed-then-refused: the write tools are simply not
         // there for a read-scope credential, which is I13's shape applied to
@@ -4812,9 +4915,10 @@ mod tests {
             "the handler must advertise this build's list, never inherit the SDK's"
         );
         assert!(
-            !SUPPORTED_PROTOCOL_VERSIONS.contains(&ProtocolVersion::V_2026_07_28),
-            "2026-07-28 requests carry no handshake, so their records could not \
-             name the calling client (issue #34)"
+            SUPPORTED_PROTOCOL_VERSIONS.contains(&ProtocolVersion::V_2026_07_28),
+            "the handshake-free revision is served: its records name the calling \
+             client from the request's own `_meta`, never rmcp's synthesised \
+             peer (issue #34 stage 2)"
         );
         assert!(
             SUPPORTED_PROTOCOL_VERSIONS.contains(&DEFAULT_PROTOCOL_VERSION),
@@ -6451,6 +6555,343 @@ mod tests {
             .clone()
     }
 
+    /// The `_meta` a 2026-07-28 request carries: the two keys rmcp's
+    /// `missing_required_keys` demands, plus a `clientInfo` when one is
+    /// declared. The identity goes in as raw JSON under the literal wire
+    /// key, so a MALFORMED declaration is expressible — the shape no rmcp
+    /// client builds and the one `client_of` must fail to absent on.
+    fn per_request_meta(version: ProtocolVersion, client: Option<Value>) -> RequestMetaObject {
+        let mut meta = RequestMetaObject::new();
+        meta.set_protocol_version(version);
+        meta.set_client_capabilities(ClientCapabilities::default());
+        if let Some(client) = client {
+            meta.insert("io.modelcontextprotocol/clientInfo".to_string(), client);
+        }
+        meta
+    }
+
+    /// `bug_url` for bug 7 — the one tool that contacts nothing, so a
+    /// direct call needs no upstream and records exactly one event.
+    fn local_call() -> CallToolRequestParams {
+        let Value::Object(args) = json!({ "bug_id": 7 }) else {
+            panic!("tool arguments must be a JSON object");
+        };
+        CallToolRequestParams::new("bug_url".to_string()).with_arguments(args)
+    }
+
+    #[tokio::test]
+    async fn a_per_request_identity_comes_from_meta_and_never_from_the_peer() {
+        // The trap #34 §3(c) names, sharpened to the line that decides it.
+        // The peer here is a REAL handshaken one whose stored `client_info`
+        // IS `Implementation::default()` — rmcp's own crate name and
+        // version, exactly the value the http handshake-free path
+        // synthesises (`peer_info_for_stateless_request`). So `client_of`
+        // reaching for `peer_info()`, or for the convenience
+        // `ctx.client_info()` — which falls back to it unless
+        // `request_metadata_required()`, never set over streamable http —
+        // records `rmcp` on every row below. The precondition is asserted,
+        // not assumed: were rmcp to stop seeding that value, this test
+        // would go on passing while proving nothing.
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz)
+            .expect("server must build")
+            .with_audit(Arc::clone(&audit));
+        let peer = peer_of(&server).await;
+        assert_eq!(
+            peer.peer_info()
+                .expect("the duplex handshake stores peer info")
+                .client_info
+                .name,
+            Implementation::default().name,
+            "the sharpener needs a peer whose stored identity is the placeholder"
+        );
+
+        // (row, the declared `clientInfo`, the name the record must carry)
+        let rows: [(&str, Option<Value>, Option<&str>); 4] = [
+            ("no clientInfo at all", None, None),
+            ("a malformed clientInfo", Some(json!("banana")), None),
+            (
+                "a clientInfo missing its version",
+                Some(json!({ "name": "half" })),
+                None,
+            ),
+            (
+                "a well-formed clientInfo",
+                Some(json!({ "name": "wire-client", "version": "9.9" })),
+                Some("wire-client"),
+            ),
+        ];
+        for (row, client, _) in &rows {
+            let mut context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer.clone());
+            context.meta = per_request_meta(ProtocolVersion::V_2026_07_28, client.clone());
+            ServerHandler::call_tool(&server, local_call(), context)
+                .await
+                .unwrap_or_else(|e| panic!("{row}: a per-request call is served: {e}"));
+        }
+
+        let events = read_audit_events(&audit_path);
+        let calls = tool_calls(&events);
+        assert_eq!(
+            calls.len(),
+            rows.len(),
+            "one record per call, in call order"
+        );
+        for (call, (row, _, expected)) in calls.iter().zip(rows) {
+            assert_eq!(
+                call.client.name.as_deref(),
+                expected,
+                "{row}: the record must name the request's own client, or nobody"
+            );
+            // All-or-nothing: `decode_value` yields neither field or both,
+            // so a half-declared identity is never half-recorded.
+            assert_eq!(
+                call.client.version.is_some(),
+                expected.is_some(),
+                "{row}: name and version must be absent or present together"
+            );
+        }
+    }
+
+    /// A peer from a real handshake in which the client called itself
+    /// `name`, so a recorded identity can be told apart from the SDK's
+    /// placeholder AND from anything the request smuggled.
+    async fn peer_greeted_as(server: &BugWarden, name: &str) -> rmcp::service::Peer<RoleServer> {
+        let (client_io, server_io) = tokio::io::duplex(1 << 16);
+        let serving = server.clone();
+        let task = tokio::spawn(async move { serving.serve(server_io).await });
+        let _client = InitializeRequestParams::new(
+            ClientCapabilities::default(),
+            Implementation::new(name.to_owned(), "1"),
+        )
+        .serve(client_io)
+        .await
+        .expect("MCP handshake must succeed");
+        task.await
+            .expect("serve task must not panic")
+            .expect("server must serve")
+            .peer()
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn a_handshake_identity_is_never_displaced_by_a_smuggled_meta_client() {
+        // The other side of the same trap, and the one a per-request test
+        // cannot reach. `_meta` carrying `clientInfo` but NO
+        // `protocolVersion` stays on the handshake arm — `lifecycle_of`
+        // reads the version key alone — yet it is a shape rmcp will happily
+        // deliver over the wire. `ctx.client_info()` prefers `_meta` before
+        // falling back to the peer, so a handshake arm written with the
+        // convenience accessor records the SMUGGLED identity while every
+        // ordinary session keeps working: it survives the whole suite
+        // otherwise. The peer is greeted under a distinct name so the two
+        // candidate answers cannot be confused.
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz)
+            .expect("server must build")
+            .with_audit(Arc::clone(&audit));
+        let peer = peer_greeted_as(&server, "greeted-client").await;
+
+        let mut context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer);
+        let mut meta = RequestMetaObject::new();
+        meta.insert(
+            "io.modelcontextprotocol/clientInfo".to_string(),
+            json!({ "name": "smuggled-client", "version": "9.9" }),
+        );
+        context.meta = meta;
+        assert!(
+            context.meta.protocol_version().is_none(),
+            "no version key, so this request belongs to the handshake arm"
+        );
+
+        ServerHandler::call_tool(&server, local_call(), context)
+            .await
+            .expect("an ordinary in-session call is served");
+
+        let events = read_audit_events(&audit_path);
+        let calls = tool_calls(&events);
+        assert_eq!(calls.len(), 1, "exactly the direct call is recorded");
+        assert_eq!(
+            calls[0].client.name.as_deref(),
+            Some("greeted-client"),
+            "the handshake arm names the client the server GREETED, never one \
+             the request smuggled into `_meta`"
+        );
+        assert_eq!(calls[0].client.version.as_deref(), Some("1"));
+    }
+
+    #[tokio::test]
+    async fn a_stdio_per_request_call_keeps_the_process_session_id() {
+        // The deliberate stdio/http asymmetry, which was documented and
+        // pinned by nothing. Over http the per-request path records no
+        // `session.id` because the only candidate is a forgeable request
+        // header; over stdio the id is minted from the process, so there is
+        // nothing to forge and the record keeps it. Scoping the absence to
+        // http is the whole decision, and dropping the id here — the
+        // obvious "make both paths agree" edit — survived the entire suite
+        // before this row.
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
+        let (cfg, guard, bz) = parts("");
+        assert_eq!(
+            cfg.transport,
+            Transport::Stdio,
+            "the asymmetry only exists on a stdio deployment"
+        );
+        let server = BugWarden::new(cfg, guard, bz)
+            .expect("server must build")
+            .with_audit(Arc::clone(&audit));
+        let peer = peer_of(&server).await;
+
+        let mut context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer);
+        context.meta = per_request_meta(
+            ProtocolVersion::V_2026_07_28,
+            Some(json!({ "name": "stdio-client", "version": "1" })),
+        );
+        ServerHandler::call_tool(&server, local_call(), context)
+            .await
+            .expect("a per-request call is served over stdio too");
+
+        let events = read_audit_events(&audit_path);
+        let calls: Vec<&AuditEvent> = events
+            .iter()
+            .filter(|e| matches!(e.kind, AuditEventKind::ToolCall(_)))
+            .collect();
+        assert_eq!(calls.len(), 1, "exactly the direct call is recorded");
+        assert_eq!(
+            calls[0].session.transport,
+            audit::TransportKind::Stdio,
+            "the row is only meaningful on the stdio transport"
+        );
+        assert_eq!(
+            calls[0].session.id.as_deref(),
+            Some(audit.stdio_session_id.as_str()),
+            "a stdio per-request call keeps the process-scoped id: it is minted, \
+             not read off a request, so the http rationale does not apply"
+        );
+    }
+
+    #[tokio::test]
+    async fn both_recording_sites_cap_a_declared_client_identity() {
+        // A client name is client-controlled text headed for an append-only
+        // file, so it is capped exactly like an audited parameter value.
+        // Both sites, because one helper covers both and because the
+        // per-request one is the reason the cap is needed at all: the
+        // handshake wrote its string once per session, `_meta` repeats it
+        // into every record of every call.
+        let long_name = "n".repeat(PARAM_VALUE_MAX_CHARS * 3);
+        let long_version = "v".repeat(PARAM_VALUE_MAX_CHARS + 1);
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz)
+            .expect("server must build")
+            .with_audit(Arc::clone(&audit));
+
+        let (client_io, server_io) = tokio::io::duplex(1 << 16);
+        let serving = server.clone();
+        let task = tokio::spawn(async move { serving.serve(server_io).await });
+        let _client = InitializeRequestParams::new(
+            ClientCapabilities::default(),
+            Implementation::new(long_name.clone(), long_version.clone()),
+        )
+        .serve(client_io)
+        .await
+        .expect("MCP handshake must succeed");
+        let peer = task
+            .await
+            .expect("serve task must not panic")
+            .expect("server must serve")
+            .peer()
+            .clone();
+
+        let mut context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer);
+        context.meta = per_request_meta(
+            ProtocolVersion::V_2026_07_28,
+            Some(json!({ "name": long_name, "version": long_version })),
+        );
+        ServerHandler::call_tool(&server, local_call(), context)
+            .await
+            .expect("a per-request call is served");
+
+        let events = read_audit_events(&audit_path);
+        let recorded: Vec<&audit::ClientInfo> = events
+            .iter()
+            .map(|e| match &e.kind {
+                AuditEventKind::Initialize(ev) => &ev.client,
+                AuditEventKind::ToolCall(ev) => &ev.client,
+                AuditEventKind::AuditGap(_) => panic!("no gap may occur here"),
+            })
+            .collect();
+        assert_eq!(recorded.len(), 2, "the handshake and the call are recorded");
+        for client in recorded {
+            assert_eq!(
+                client.name.as_deref().map(|n| n.chars().count()),
+                Some(PARAM_VALUE_MAX_CHARS),
+                "an over-long name is truncated to the cap, not stored whole"
+            );
+            assert_eq!(
+                client.version.as_deref().map(|v| v.chars().count()),
+                Some(PARAM_VALUE_MAX_CHARS),
+                "the version is capped too — it is client text on the same terms"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_meta_declaration_is_served_only_at_a_revision_this_build_serves() {
+        // The three-way predicate, at the handler, on one axis: the
+        // declared revision. BOTH conjuncts are load-bearing, and the name
+        // says so because an earlier one ("only a sub-2026 declaration is
+        // refused") was disproved by this test's own second row. A blanket
+        // refusal fails the served row, a blanket serve fails the refused
+        // ones, and dropping the `contains` guard fails the fabricated one
+        // — `"9999-01-01"` outranks 2026-07-28 lexically, which is how a
+        // version comparison alone lets an unserved revision through.
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz).expect("server must build");
+        let peer = peer_of(&server).await;
+
+        // (declared revision, whether the call is served)
+        let rows = [
+            ("2025-11-25", false),
+            ("9999-01-01", false),
+            ("2026-07-28", true),
+        ];
+        for (declared, served) in rows {
+            let version: ProtocolVersion =
+                serde_json::from_value(json!(declared)).expect("a wire revision parses");
+            let mut context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer.clone());
+            context.meta = per_request_meta(version, None);
+            let answer = ServerHandler::call_tool(&server, local_call(), context).await;
+            assert_eq!(
+                answer.is_ok(),
+                served,
+                "{declared}: served={served}, got {answer:?}"
+            );
+            if let Err(error) = answer {
+                // One text for both refused rows: it must describe the
+                // fabricated-future one as well as the sub-2026 one, which
+                // a "below 2026-07-28" wording did not.
+                assert!(
+                    error.message.contains("2026-07-28")
+                        && error.message.contains("a revision this server serves"),
+                    "{declared}: the refusal must fit this row too: {error:?}"
+                );
+            }
+        }
+
+        // And a request declaring nothing keeps the handshake arm: the
+        // session's own revision never routes a request per-request.
+        let context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer);
+        ServerHandler::call_tool(&server, local_call(), context)
+            .await
+            .expect("an ordinary in-session call is served");
+    }
+
     #[tokio::test]
     async fn a_failing_sink_never_tells_a_read_scope_which_names_this_build_routes() {
         // The audit gate answers a refused call with that TOOL's own failure
@@ -6602,60 +7043,80 @@ mod tests {
 
     #[tokio::test]
     async fn a_2026_request_gets_private_immediately_stale_cache_hints() {
-        // The enabled half of the gate. Unreachable over any transport
-        // while `2026-07-28` is off `SUPPORTED_PROTOCOL_VERSIONS`: no
-        // request may declare it and no session may negotiate it. The
-        // enabler here is therefore the HAND-BUILT peer, not the direct
-        // call — `Service::handle_request` would dispatch this same context
-        // and serve the hints; it is bypassed only because routing through
-        // it would test rmcp rather than the gate.
+        // The enabled half of the gate, from BOTH of its two sources —
+        // `RequestContext::protocol_version()` reads the request's own
+        // `_meta` first and the session's negotiated revision second.
+        //
+        // The second row is the one that carries weight. A mutant reading
+        // only `peer_info().protocol_version` survives every wire test:
+        // over http the handshake-free path's SYNTHESISED peer is stamped
+        // with the same 2026-07-28 the `_meta` names
+        // (`peer_info_for_stateless_request`), so the two sources agree
+        // there and the request half is never observed alone. A bare peer
+        // with no `peer_info` at all is the only shape that separates
+        // them, and rmcp really does hand one out — its stdio
+        // handshake-free lifecycle builds the peer with `None`
+        // (`service/server.rs`). Its wire-level companion is
+        // `a_per_request_listing_carries_the_cache_hints` in
+        // http_transport_wiremock.
         let (cfg, guard, bz) = parts("");
         let server = BugWarden::new(cfg, guard, bz).expect("server must build");
-        let peer = peer_of(&server).await;
-        peer.set_peer_info(
+
+        let negotiated = peer_of(&server).await;
+        negotiated.set_peer_info(
             ClientInfo::default().with_protocol_version(ProtocolVersion::V_2026_07_28),
         );
-        // Empty meta is mandatory: any `_meta` revision, 2026-07-28
-        // included, is refused by `skips_the_handshake` above the gate.
-        let context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer);
+        let session_row = RequestContext::<RoleServer>::new(RequestId::Number(1), negotiated);
         assert!(
-            context.meta.protocol_version().is_none(),
+            session_row.meta.protocol_version().is_none(),
             "the session's revision, not the request's, must open the gate here"
         );
 
-        let listed = ServerHandler::list_tools(&server, None, context)
-            .await
-            .expect("a 2026 session lists tools");
-        // On the JSON, not the enum: the wire spelling is what a caching
-        // intermediary reads, and `CacheScope` renames lowercase.
-        let json = serde_json::to_value(&listed).expect("the listing must serialize");
-        assert_eq!(
-            json["cacheScope"],
-            json!("private"),
-            "a per-deployment, per-credential listing is never publicly cacheable"
-        );
-        assert_eq!(
-            json["ttlMs"],
-            json!(0),
-            "a memory-served listing is stale on arrival"
-        );
+        let (client_io, _server_io) = tokio::io::duplex(1 << 16);
+        let running: RunningService<RoleServer, BugWarden> =
+            rmcp::service::serve_directly(server.clone(), client_io, None);
+        let bare = running.peer().clone();
         assert!(
-            !listed.tools.is_empty(),
-            "the hints must ride a real listing, not a refusal or an empty one"
+            bare.peer_info().is_none(),
+            "the request row must have no session revision to fall back to"
         );
+        let mut request_row = RequestContext::<RoleServer>::new(RequestId::Number(1), bare);
+        request_row.meta = per_request_meta(ProtocolVersion::V_2026_07_28, None);
+
+        for (row, context) in [("negotiated session", session_row), ("_meta", request_row)] {
+            let listed = ServerHandler::list_tools(&server, None, context)
+                .await
+                .expect("a 2026 listing is served");
+            // On the JSON, not the enum: the wire spelling is what a caching
+            // intermediary reads, and `CacheScope` renames lowercase.
+            let json = serde_json::to_value(&listed).expect("the listing must serialize");
+            assert_eq!(
+                json["cacheScope"],
+                json!("private"),
+                "{row}: a per-deployment, per-credential listing is never publicly cacheable"
+            );
+            assert_eq!(
+                json["ttlMs"],
+                json!(0),
+                "{row}: a memory-served listing is stale on arrival"
+            );
+            assert!(
+                !listed.tools.is_empty(),
+                "{row}: the hints must ride a real listing, not a refusal or an empty one"
+            );
+        }
     }
 
     #[tokio::test]
     async fn cache_hints_stay_absent_below_2026_and_with_no_peer_info() {
         // `skip_serializing_if` makes absence the only observable. The
         // first row is every client alive today. The second is the `None`
-        // arm, which a production stdio session really can produce —
-        // rmcp's handshake-free lifecycle builds its peer with no info
-        // (`service/server.rs`) — but never at this line: that lifecycle
-        // mandates per-request `_meta`, so `protocol_version()` is `Some`
-        // and `skips_the_handshake` refuses the request above the gate.
-        // Pinned anyway: a handler with no revision to read must fail
-        // toward the legacy wire shape, never toward emission.
+        // arm — no `_meta` revision and no session revision either, which
+        // rmcp's handshake-free lifecycle really does build
+        // (`service/server.rs`), though its own contract then mandates
+        // per-request `_meta` on every request that follows. Pinned
+        // anyway: a handler with no revision to read must fail toward the
+        // legacy wire shape, never toward emission.
         let (cfg, guard, bz) = parts("");
         let server = BugWarden::new(cfg, guard, bz).expect("server must build");
 
@@ -6705,14 +7166,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn initialize_never_echoes_a_revision_this_build_cannot_serve() {
-        // A dual-revision client probing for 2026-07-28 must be handed
-        // the server default instead. Both halves of the negotiation are
-        // exercised here: this handler's own test against
-        // `SUPPORTED_PROTOCOL_VERSIONS`, and the SDK's, which runs after
-        // the handler returns and takes the handler's value as its
-        // fallback — so a handler that echoed the request would make the
-        // SDK echo it too.
+    async fn initialize_echoes_exactly_the_revisions_this_build_serves() {
+        // Both halves of the negotiation, in both directions. This
+        // handler tests the request against `SUPPORTED_PROTOCOL_VERSIONS`;
+        // the SDK negotiates again after the handler returns, taking the
+        // handler's value as its fallback — so a handler that echoed an
+        // unsupported request would make the SDK echo it too, and a
+        // handler that refused a supported one would silently downgrade
+        // every modern client.
+        //
+        // `"9999-01-01"` carries the refusing row because widening the
+        // list left no KNOWN-but-unserved revision: rmcp's
+        // `KNOWN_VERSIONS` now equals what this build serves. It is not a
+        // typo — `ProtocolVersion` deserializes an unknown string through
+        // and every rmcp comparison is lexical, so a fabricated future
+        // date outranks every real revision.
         use clap::Parser as _;
         let mock = MockServer::start().await;
         let dir = tempfile::tempdir().unwrap();
@@ -6737,42 +7205,67 @@ mod tests {
             .expect("server must build")
             .with_audit(Arc::clone(&audit));
 
-        let (client_io, server_io) = tokio::io::duplex(1 << 16);
-        tokio::spawn(async move {
-            if let Ok(running) = server.serve(server_io).await {
-                let _ = running.waiting().await;
-            }
-        });
-        // rmcp serves a `ClientInfo` as its own handler, so this value is
-        // what the client asks for on the wire.
-        let probe = ClientInfo::default().with_protocol_version(ProtocolVersion::V_2026_07_28);
-        let client = probe
-            .serve(client_io)
-            .await
-            .expect("the handshake must succeed");
+        // (client name, requested revision, the revision the session must speak)
+        let rows = [
+            (
+                "fabricating-client",
+                "9999-01-01",
+                DEFAULT_PROTOCOL_VERSION.as_str(),
+            ),
+            (
+                "modern-client",
+                ProtocolVersion::V_2026_07_28.as_str(),
+                ProtocolVersion::V_2026_07_28.as_str(),
+            ),
+        ];
+        for (name, requested, expected) in rows {
+            let (client_io, server_io) = tokio::io::duplex(1 << 16);
+            let serving = server.clone();
+            tokio::spawn(async move {
+                if let Ok(running) = serving.serve(server_io).await {
+                    let _ = running.waiting().await;
+                }
+            });
+            let asked: ProtocolVersion =
+                serde_json::from_value(json!(requested)).expect("a wire revision parses");
+            // rmcp serves a `ClientInfo` as its own handler, so this value
+            // is what the client asks for on the wire.
+            let probe = InitializeRequestParams::new(
+                ClientCapabilities::default(),
+                Implementation::new(name, "1"),
+            )
+            .with_protocol_version(asked);
+            let client = probe
+                .serve(client_io)
+                .await
+                .expect("the handshake must succeed");
 
-        assert_eq!(
-            client
-                .peer_info()
-                .expect("the server answers initialize")
-                .protocol_version,
-            DEFAULT_PROTOCOL_VERSION,
-            "a revision this build cannot serve must not be echoed back"
-        );
+            assert_eq!(
+                client
+                    .peer_info()
+                    .expect("the server answers initialize")
+                    .protocol_version
+                    .as_str(),
+                expected,
+                "{requested}: the session must speak the negotiated revision"
+            );
 
-        let events = read_audit_events(&audit_path);
-        let recorded = events
-            .iter()
-            .find_map(|e| match &e.kind {
-                AuditEventKind::Initialize(ev) => ev.protocol_version.clone(),
-                AuditEventKind::ToolCall(_) | AuditEventKind::AuditGap(_) => None,
-            })
-            .expect("the handshake is recorded");
-        assert_eq!(
-            recorded,
-            DEFAULT_PROTOCOL_VERSION.as_str(),
-            "the record names the revision the session speaks, not the one requested"
-        );
+            let events = read_audit_events(&audit_path);
+            let recorded = events
+                .iter()
+                .find_map(|e| match &e.kind {
+                    AuditEventKind::Initialize(ev) if ev.client.name.as_deref() == Some(name) => {
+                        ev.protocol_version.clone()
+                    }
+                    _ => None,
+                })
+                .unwrap_or_else(|| panic!("{requested}: the handshake is recorded"));
+            assert_eq!(
+                recorded, expected,
+                "{requested}: the record names the revision the session speaks, \
+                 not the one requested"
+            );
+        }
     }
 
     #[tokio::test]
@@ -6818,33 +7311,32 @@ mod tests {
         // "9999-01-01" is not a typo: `ProtocolVersion` deserializes an
         // unknown string through, and every version comparison in rmcp is
         // lexical, so a fabricated future date outranks every real
-        // revision. It must be refused by the same arm 2026-07-28 is.
-        for probe in ["2026-07-28", "9999-01-01"] {
-            let asked: ProtocolVersion =
-                serde_json::from_value(json!(probe)).expect("a wire revision parses");
-            let answered = client
-                .peer()
-                .send_request(ClientRequest::InitializeRequest(InitializeRequest::new(
-                    ClientInfo::default().with_protocol_version(asked),
-                )))
-                .await
-                .expect("a second initialize is answered, not dropped");
-            let ServerResult::InitializeResult(answered) = answered else {
-                panic!("initialize answers with an InitializeResult")
-            };
-            assert_eq!(
-                answered.protocol_version, DEFAULT_PROTOCOL_VERSION,
-                "{probe}: the answer must name the negotiated revision"
-            );
-            // The half that was wrong: the answer already said 2025-11-25
-            // while the stored value said otherwise, so no client-visible
-            // assertion could catch it.
-            assert_eq!(
-                stored(),
-                DEFAULT_PROTOCOL_VERSION,
-                "{probe}: the stored revision must be the negotiated one, not the requested one"
-            );
-        }
+        // revision. Since #34 stage 2 it is the ONLY refusable probe left —
+        // 2026-07-28 is served, and moves the session in the last row.
+        let asked: ProtocolVersion =
+            serde_json::from_value(json!("9999-01-01")).expect("a wire revision parses");
+        let answered = client
+            .peer()
+            .send_request(ClientRequest::InitializeRequest(InitializeRequest::new(
+                ClientInfo::default().with_protocol_version(asked),
+            )))
+            .await
+            .expect("a second initialize is answered, not dropped");
+        let ServerResult::InitializeResult(answered) = answered else {
+            panic!("initialize answers with an InitializeResult")
+        };
+        assert_eq!(
+            answered.protocol_version, DEFAULT_PROTOCOL_VERSION,
+            "a fabricated revision must be answered with the negotiated one"
+        );
+        // The half that was wrong: the answer already said 2025-11-25
+        // while the stored value said otherwise, so no client-visible
+        // assertion could catch it.
+        assert_eq!(
+            stored(),
+            DEFAULT_PROTOCOL_VERSION,
+            "the stored revision must be the negotiated one, not the requested one"
+        );
 
         // The other direction, and the only place the store is observable
         // at all: rmcp overwrites whatever this handler put there on the
@@ -6852,48 +7344,50 @@ mod tests {
         // store at all. A second `initialize` naming a DIFFERENT supported
         // revision legitimately moves the session — that is what
         // `set_peer_info` is for — and the failure to catch here is the
-        // mirror of the one fixed: stored disagreeing with answered.
-        let answered = client
-            .peer()
-            .send_request(ClientRequest::InitializeRequest(InitializeRequest::new(
-                InitializeRequestParams::new(
-                    ClientCapabilities::default(),
-                    Implementation::new("renegotiating-client", "9.9"),
-                )
-                .with_protocol_version(ProtocolVersion::V_2024_11_05),
-            )))
-            .await
-            .expect("a supported renegotiation is answered");
-        let ServerResult::InitializeResult(answered) = answered else {
-            panic!("initialize answers with an InitializeResult")
-        };
-        assert_eq!(
-            answered.protocol_version,
-            ProtocolVersion::V_2024_11_05,
-            "a supported revision is echoed, so the session really does move"
-        );
-        assert_eq!(
-            stored(),
-            answered.protocol_version,
-            "the stored revision must equal the one the server answered"
-        );
-        let stored_client = running
-            .peer()
-            .peer_info()
-            .expect("the handshake stores peer info")
-            .client_info
-            .clone();
-        // The identity is re-declared wholesale, so it must follow — and it
-        // must not be the SDK's own build identity, which is what
-        // `Implementation::default()` is and what #34 §3(c) calls the
-        // plausible wrong value an audit trail can least afford.
-        assert_eq!(stored_client.name, "renegotiating-client");
-        assert_eq!(stored_client.version, "9.9");
-        assert_ne!(
-            stored_client.name,
-            Implementation::default().name,
-            "the stored client must never degrade to the SDK placeholder"
-        );
+        // mirror of the one fixed: stored disagreeing with answered. Both
+        // ends of the served range, so a list that lost either end fails.
+        for probe in [ProtocolVersion::V_2024_11_05, ProtocolVersion::V_2026_07_28] {
+            let answered = client
+                .peer()
+                .send_request(ClientRequest::InitializeRequest(InitializeRequest::new(
+                    InitializeRequestParams::new(
+                        ClientCapabilities::default(),
+                        Implementation::new("renegotiating-client", "9.9"),
+                    )
+                    .with_protocol_version(probe.clone()),
+                )))
+                .await
+                .expect("a supported renegotiation is answered");
+            let ServerResult::InitializeResult(answered) = answered else {
+                panic!("initialize answers with an InitializeResult")
+            };
+            assert_eq!(
+                answered.protocol_version, probe,
+                "{probe}: a supported revision is echoed, so the session really does move"
+            );
+            assert_eq!(
+                stored(),
+                answered.protocol_version,
+                "{probe}: the stored revision must equal the one the server answered"
+            );
+            let stored_client = running
+                .peer()
+                .peer_info()
+                .expect("the handshake stores peer info")
+                .client_info
+                .clone();
+            // The identity is re-declared wholesale, so it must follow — and
+            // it must not be the SDK's own build identity, which is what
+            // `Implementation::default()` is and what #34 §3(c) calls the
+            // plausible wrong value an audit trail can least afford.
+            assert_eq!(stored_client.name, "renegotiating-client");
+            assert_eq!(stored_client.version, "9.9");
+            assert_ne!(
+                stored_client.name,
+                Implementation::default().name,
+                "{probe}: the stored client must never degrade to the SDK placeholder"
+            );
+        }
     }
 
     #[test]

--- a/crates/bugwarden/tests/http_auth_wiremock.rs
+++ b/crates/bugwarden/tests/http_auth_wiremock.rs
@@ -169,8 +169,15 @@ async fn serve_guarded(mock: &MockServer, env: &HttpEnv, insecure: bool) -> Sock
         .await
         .expect("bind an ephemeral port");
     let addr = listener.local_addr().expect("bound address");
+    // `into_make_service_with_connect_info`, as main.rs serves it: a harness
+    // that drops it serves a listener no deployment runs, and every record
+    // it writes silently loses `session.remote`.
     tokio::spawn(async move {
-        let _ = axum::serve(listener, router).await;
+        let _ = axum::serve(
+            listener,
+            router.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await;
     });
     addr
 }
@@ -509,6 +516,140 @@ async fn a_read_scope_write_call_is_refused_as_unrouted_and_reaches_no_bugzilla(
         unknown.to_string(),
         "a write tool must look exactly like a tool that does not exist"
     );
+}
+
+// ---------- the handshake-free lifecycle behind the gate (#34) ----------
+
+/// The revision whose requests carry their own context instead of
+/// negotiating one.
+const PER_REQUEST_REVISION: &str = "2026-07-28";
+
+/// One raw 2026-07-28 per-request POST, presenting `token` when given.
+///
+/// Raw rather than an rmcp client because no rmcp client sends this shape
+/// with `ClientLifecycleMode::Initialize`, which is what `serve` uses.
+/// Every header is refused-before-any-handler load-bearing:
+/// `MCP-Protocol-Version` must equal the `_meta` revision, and SEP-2243
+/// makes `Mcp-Method` — plus `Mcp-Name` for a `tools/call` — mandatory once
+/// that header names 2026-07-28 or newer.
+async fn per_request_post(
+    addr: SocketAddr,
+    token: Option<&str>,
+    method: &str,
+    mut params: Value,
+) -> reqwest::Response {
+    params["_meta"] = json!({
+        "io.modelcontextprotocol/protocolVersion": PER_REQUEST_REVISION,
+        "io.modelcontextprotocol/clientCapabilities": {},
+    });
+    let mut builder = reqwest::Client::new()
+        .post(format!("http://{addr}/mcp"))
+        .header("Accept", "application/json, text/event-stream")
+        .header("Content-Type", "application/json")
+        .header("ApiKey", "test-key")
+        .header("MCP-Protocol-Version", PER_REQUEST_REVISION)
+        .header("Mcp-Method", method.to_owned());
+    if let Some(name) = params.get("name").and_then(Value::as_str) {
+        builder = builder.header("Mcp-Name", name.to_owned());
+    }
+    if let Some(token) = token {
+        builder = builder.header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"));
+    }
+    builder
+        .json(&json!({ "jsonrpc": "2.0", "id": 1, "method": method, "params": params }))
+        .send()
+        .await
+        .expect("the server must answer")
+}
+
+#[tokio::test]
+async fn the_gate_and_its_scopes_cover_the_handshake_free_path() {
+    // The gate wraps the whole router, so it runs before rmcp decides which
+    // lifecycle a POST belongs to — and the scope split lives in the
+    // handler, which the handshake-free path reaches by a different route
+    // than a session does. Neither was pinned for a request that carries no
+    // handshake. Three rows, in the order a caller would try them:
+    // unauthenticated, read-scope write, read-scope listing.
+    let mock = MockServer::start().await;
+    mount_bug(&mock, 7).await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .named("a scope-refused write call must POST nothing")
+        .mount(&mock)
+        .await;
+    let addr = serve_guarded(&mock, &both_tokens(), false).await;
+
+    let stranger = per_request_post(
+        addr,
+        None,
+        "tools/call",
+        json!({ "name": "bug_info", "arguments": { "bug_ids": [7] } }),
+    )
+    .await;
+    assert_eq!(
+        stranger.status(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "the gate precedes the lifecycle routing, so a handshake-free \
+         request from a stranger is refused like any other"
+    );
+
+    // The read scope really does reach this path, so the refusal below is
+    // about the scope and not about the request shape being broken.
+    let served = per_request_post(
+        addr,
+        Some(READ_TOKEN),
+        "tools/call",
+        json!({ "name": "bug_info", "arguments": { "bug_ids": [7] } }),
+    )
+    .await
+    .text()
+    .await
+    .expect("a body");
+    assert!(
+        served.contains("a plain bug"),
+        "the read scope must reach a read tool here too: {served}"
+    );
+
+    let refused = per_request_post(
+        addr,
+        Some(READ_TOKEN),
+        "tools/call",
+        json!({ "name": "add_comment", "arguments": { "bug_id": 7, "comment": "hi" } }),
+    )
+    .await;
+    let refused = (refused.status(), refused.text().await.expect("a body"));
+    // Against the router's OWN answer for a name it does not route, not a
+    // literal: a scope-hidden tool must be indistinguishable from one that
+    // does not exist, and that stays true across rmcp bumps.
+    let unknown = per_request_post(
+        addr,
+        Some(READ_TOKEN),
+        "tools/call",
+        json!({ "name": "no_such_tool_at_all", "arguments": {} }),
+    )
+    .await;
+    let unknown = (unknown.status(), unknown.text().await.expect("a body"));
+    assert_eq!(
+        refused, unknown,
+        "a write tool must look exactly like a tool that does not exist"
+    );
+
+    let listing = per_request_post(addr, Some(READ_TOKEN), "tools/list", json!({}))
+        .await
+        .text()
+        .await
+        .expect("a body");
+    assert!(
+        listing.contains("\"bug_info\""),
+        "the read scope is offered the read tools: {listing}"
+    );
+    for write_tool in ["add_comment", "create_bug", "update_bug_status"] {
+        assert!(
+            !listing.contains(write_tool),
+            "{write_tool} must not appear in a read-scope listing: {listing}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -131,8 +131,15 @@ async fn serve_http(
         .await
         .expect("bind an ephemeral port");
     let addr = listener.local_addr().expect("bound address");
+    // `into_make_service_with_connect_info`, as main.rs serves it: without
+    // it no record carries `session.remote`, which is the whole of
+    // cross-call grouping on the handshake-free path.
     tokio::spawn(async move {
-        let _ = axum::serve(listener, router).await;
+        let _ = axum::serve(
+            listener,
+            router.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await;
     });
     addr
 }
@@ -552,14 +559,15 @@ async fn a_handshake_free_call_is_refused_and_never_names_a_client() {
     // rmcp 3.1.4 routes to its handshake-free lifecycle when the request's
     // revision is 2026-07-28 or newer, or `_meta` carries BOTH
     // `protocolVersion` and `clientCapabilities`, synthesising the peer with
-    // the SDK's own build
-    // identity. The body below sends both keys at 2025-11-25 deliberately:
-    // that is the one shape still reachable on a revision this build serves
-    // — a tool with no `initialize` behind it, recorded as `rmcp`/<sdk
-    // version>, a client the server never spoke to. Drop `clientCapabilities`
-    // and it takes the session path instead, proving nothing.
-    // Narrowing SUPPORTED_PROTOCOL_VERSIONS cannot close it either, the
-    // routing never consults it, so the handler refuses the request.
+    // the SDK's own build identity. The body below sends both keys at
+    // 2025-11-25 deliberately: serving 2026-07-28 did not close that second
+    // shape — a PRE-2026 revision with both keys still reaches a handler with
+    // no `initialize` behind it and a peer named `rmcp`/<sdk version>, a
+    // client the server never spoke to, and it declares a lifecycle its own
+    // revision does not define. Drop `clientCapabilities` and it takes the
+    // session path instead, proving nothing. Narrowing
+    // SUPPORTED_PROTOCOL_VERSIONS cannot close it either, the routing never
+    // consults it, so the handler refuses the request.
     let mock = MockServer::start().await;
     mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
 
@@ -1188,9 +1196,11 @@ async fn a_forged_session_id_is_not_copied_into_a_refusal_record() {
 
     let victim = raw_initialize(addr, "real-client").await;
 
-    // The one handshake-free shape still reachable on a revision this build
-    // serves (see `a_handshake_free_call_is_refused_and_never_names_a_client`),
-    // wearing the live session's id.
+    // The refused half of the forgery pair; the served half is
+    // `a_forged_session_id_is_not_copied_into_a_served_record`. This shape
+    // — a sub-2026 revision with both keys (see
+    // `a_handshake_free_call_is_refused_and_never_names_a_client`) — wears
+    // the live session's id.
     let response = mcp_post(addr, Some(&victim))
         .header("MCP-Protocol-Version", "2025-11-25")
         .json(&json!({
@@ -1237,9 +1247,9 @@ async fn a_forged_session_id_is_not_copied_into_a_refusal_record() {
 #[tokio::test]
 async fn a_refused_call_in_a_session_keeps_its_session_anchor() {
     // The refused class spans BOTH arrivals, and only this one has a
-    // session to name. `skips_the_handshake` fires on any `_meta` protocol
+    // session to name. `lifecycle_of` refuses any sub-2026 `_meta` protocol
     // declaration, which is deliberately broader than rmcp's stateless
-    // routing: a sub-2026 declaration without `clientCapabilities` stays on
+    // routing: such a declaration without `clientCapabilities` stays on
     // the session branch (see that function's rustdoc), so the refusal is
     // recorded with the real minted id and joins its own `initialize` —
     // the join #180 newly makes possible, since that anchor had no id
@@ -1277,7 +1287,7 @@ async fn a_refused_call_in_a_session_keeps_its_session_anchor() {
         .expect("the declaring call must reach the server");
     let body = response.text().await.expect("a body");
     assert!(
-        body.contains("requires the initialize handshake"),
+        body.contains("served only for a revision this server serves at 2026-07-28 or later"),
         "the declaration must be refused by the handler, not served or \
          turned away by the transport: {body}"
     );
@@ -1310,5 +1320,538 @@ async fn a_refused_call_in_a_session_keeps_its_session_anchor() {
     assert_eq!(
         record.session.id, anchor.session.id,
         "and so joins the initialize that anchors it"
+    );
+}
+
+// ---------- the 2026-07-28 per-request lifecycle (#34 stage 2) ----------
+
+/// The revision whose requests carry their own context instead of
+/// negotiating one.
+const PER_REQUEST_REVISION: &str = "2026-07-28";
+
+/// One raw 2026-07-28 per-request POST, answered as the server answers it.
+///
+/// Every header is load-bearing and rmcp refuses the request before any
+/// handler without it: `MCP-Protocol-Version` must be present AND equal the
+/// `_meta` revision (-32020 otherwise), and SEP-2243 makes `Mcp-Method` —
+/// plus `Mcp-Name` naming the tool, for a `tools/call` — mandatory as soon
+/// as that header names 2026-07-28 or newer. `initialize` is exempt from
+/// the second pair and declares its revision in the body instead.
+///
+/// `clientInfo` is deliberately NOT among the keys the protocol requires,
+/// which is what makes "a request naming no client at all" a servable
+/// shape — and the shape no rmcp client can be made to send.
+async fn per_request_post(
+    addr: SocketAddr,
+    session: Option<&str>,
+    method: &str,
+    mut params: Value,
+    client: Option<Value>,
+) -> reqwest::Response {
+    if method != "initialize" {
+        let mut meta = json!({
+            "io.modelcontextprotocol/protocolVersion": PER_REQUEST_REVISION,
+            "io.modelcontextprotocol/clientCapabilities": {},
+        });
+        if let Some(client) = client {
+            meta["io.modelcontextprotocol/clientInfo"] = client;
+        }
+        params["_meta"] = meta;
+    }
+    let mut builder = mcp_post(addr, session)
+        .header("MCP-Protocol-Version", PER_REQUEST_REVISION)
+        .header("Mcp-Method", method.to_owned());
+    if let Some(name) = params.get("name").and_then(Value::as_str) {
+        builder = builder.header("Mcp-Name", name.to_owned());
+    }
+    builder
+        .json(&json!({ "jsonrpc": "2.0", "id": 1, "method": method, "params": params }))
+        .send()
+        .await
+        .expect("the per-request POST must reach the server")
+}
+
+/// A per-request `bug_info` for bug 7, as body text.
+async fn per_request_bug_7(addr: SocketAddr, client: Option<Value>) -> String {
+    per_request_post(
+        addr,
+        None,
+        "tools/call",
+        json!({ "name": "bug_info", "arguments": { "bug_ids": [7] } }),
+        client,
+    )
+    .await
+    .text()
+    .await
+    .expect("a body")
+}
+
+/// Serve an audited deployment against `mock` with bug 7 mounted, and
+/// return its address plus the audit file.
+async fn served_with_audit(
+    mock: &MockServer,
+    dir: &tempfile::TempDir,
+    key: &tempfile::NamedTempFile,
+) -> (SocketAddr, std::path::PathBuf) {
+    mount_bug_for_key(mock, world_readable_bug(7), "srv-key").await;
+    let audit_path = dir.path().join("audit.jsonl");
+    let cli = http_cli(mock, Some(key.path()));
+    let addr = serve_http(cli, "", mock, Some(audit_to(&audit_path))).await;
+    (addr, audit_path)
+}
+
+#[tokio::test]
+async fn a_per_request_call_naming_no_client_is_served_and_names_no_placeholder() {
+    // The acceptance criterion of #34, at the only level that can state it:
+    // a tools/call with no `clientInfo` ANYWHERE — no handshake behind it
+    // and none in `_meta` — is served, and the record names nobody rather
+    // than rmcp. No rmcp client builds this request, so raw HTTP is the
+    // only harness in which it exists.
+    //
+    // The mutation this kills is `client_of` reading `ctx.client_info()` or
+    // `peer_info()` on this path: rmcp synthesises the stateless peer with
+    // `Implementation::default()`, so either would put
+    // `{"name":"rmcp","version":"3.1.4"}` into the record — not a missing
+    // field but a plausible wrong one. The whole file is checked for the
+    // string, not just this record's field, because a placeholder that
+    // leaked into any other record would be the same defect.
+    let mock = MockServer::start().await;
+    let dir = tempfile::tempdir().expect("audit temp dir");
+    let file = key_file("srv-key\n");
+    let (addr, audit_path) = served_with_audit(&mock, &dir, &file).await;
+
+    let body = per_request_bug_7(addr, None).await;
+    assert!(
+        body.contains("a plain bug"),
+        "a 2026-07-28 per-request call is served: {body}"
+    );
+
+    let raw = std::fs::read_to_string(&audit_path).expect("audit file must be readable");
+    assert!(
+        !raw.contains("\"rmcp\""),
+        "no record may name the SDK as the calling client: {raw}"
+    );
+    let events = audit_events(&audit_path);
+    let calls: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e.kind, AuditEventKind::ToolCall(_)))
+        .collect();
+    assert_eq!(calls.len(), 1, "a served call is recorded exactly once");
+    let AuditEventKind::ToolCall(event) = &calls[0].kind else {
+        unreachable!("filtered above")
+    };
+    assert_eq!(event.client.name, None, "the request declared no client");
+    assert_eq!(event.client.version, None, "and so declared no version");
+    assert!(
+        event.guard.is_some(),
+        "the call really reached the guard, so absence is not just a refusal"
+    );
+    // No handshake, so no session: the id would have to come from the
+    // forgeable request header, and a forgeable id is worse than none.
+    assert_eq!(calls[0].session.id, None, "the path opens no session");
+    assert!(
+        calls[0].session.remote.is_some(),
+        "`remote` plus nothing is the whole of grouping here"
+    );
+    // Nothing else opened a session either: no anchor exists to join to.
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e.kind, AuditEventKind::Initialize(_))),
+        "a per-request call performs no handshake"
+    );
+}
+
+#[tokio::test]
+async fn a_per_request_call_records_the_client_it_declares() {
+    // The other half, and the one the test above cannot see: an
+    // unconditional `(None, None)` in the per-request arm passes there and
+    // fails here. Recorded verbatim, capped but not otherwise touched —
+    // self-declared at the same trust level as a handshake identity.
+    let mock = MockServer::start().await;
+    let dir = tempfile::tempdir().expect("audit temp dir");
+    let file = key_file("srv-key\n");
+    let (addr, audit_path) = served_with_audit(&mock, &dir, &file).await;
+
+    let body = per_request_bug_7(
+        addr,
+        Some(json!({ "name": "wire-client", "version": "9.9" })),
+    )
+    .await;
+    assert!(
+        body.contains("a plain bug"),
+        "a declaring per-request call is served too: {body}"
+    );
+
+    let events = audit_events(&audit_path);
+    let record = tool_call_of(&events, "wire-client");
+    let AuditEventKind::ToolCall(event) = &record.kind else {
+        unreachable!("selected by kind")
+    };
+    assert_eq!(
+        event.client.version.as_deref(),
+        Some("9.9"),
+        "the declared version rides with the declared name"
+    );
+    assert_eq!(
+        event.client.principal, None,
+        "nothing self-declared is ever promoted into the verified slot"
+    );
+    assert_eq!(event.client.work_context, None);
+    assert_eq!(
+        record.session.id, None,
+        "declaring a client mints no session"
+    );
+}
+
+#[tokio::test]
+async fn a_forged_session_id_is_not_copied_into_a_served_record() {
+    // The C3 hazard, widened by adoption from refusals to SERVED calls: on
+    // the stateless branch rmcp validates `mcp-session-id` nowhere
+    // (`has_session` runs only on the session branch) and injects the
+    // request Parts verbatim, so the header is client free text. A caller
+    // that never handshook could otherwise file its own served calls under
+    // a live session's id — which is worse than the refusal case, because
+    // the forged records now describe work that actually happened.
+    let mock = MockServer::start().await;
+    let dir = tempfile::tempdir().expect("audit temp dir");
+    let file = key_file("srv-key\n");
+    let (addr, audit_path) = served_with_audit(&mock, &dir, &file).await;
+
+    let victim = raw_initialize(addr, "real-client").await;
+    let served = raw_call_in_session(addr, &victim, "bug_info", json!({ "bug_ids": [7] })).await;
+    assert!(
+        served.contains("a plain bug"),
+        "the victim's own session must really be live: {served}"
+    );
+
+    let response = per_request_post(
+        addr,
+        Some(&victim),
+        "tools/call",
+        json!({ "name": "bug_info", "arguments": { "bug_ids": [7] } }),
+        Some(json!({ "name": "forging-client", "version": "1" })),
+    )
+    .await;
+    let body = response.text().await.expect("a body");
+    assert!(
+        body.contains("a plain bug"),
+        "the forged call is SERVED — this is not the refusal case: {body}"
+    );
+
+    let events = audit_events(&audit_path);
+    let forged = tool_call_of(&events, "forging-client");
+    assert_eq!(
+        forged.session.id, None,
+        "a client-supplied session id must never become a record's id; \
+         the forged value was {victim}"
+    );
+    // The victim's own records are untouched: only the forger loses an id.
+    assert_eq!(
+        initialize_of(&events, "real-client").session.id.as_deref(),
+        Some(victim.as_str()),
+        "the handshake that really happened keeps its anchor"
+    );
+    assert_eq!(
+        tool_call_of(&events, "real-client").session.id.as_deref(),
+        Some(victim.as_str()),
+        "and so does the call that really ran inside it"
+    );
+}
+
+#[tokio::test]
+async fn an_out_of_contract_listing_is_refused_and_discloses_no_tool() {
+    // `list_tools` refuses the same shape `call_tool` does, and for its own
+    // reason: the listing is pruned per deployment (I13) and per credential,
+    // so answering a caller with no handshake behind it would disclose which
+    // tools this policy removed. Unrecorded, as every listing is — the
+    // schema has no event kind for one — which is why nothing else in the
+    // suite could notice the arm being deleted.
+    let mock = MockServer::start().await;
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock, None).await;
+
+    // The same reachable pre-2026 shape the call-side test uses: both
+    // `_meta` keys at a revision this build serves.
+    let body = mcp_post(addr, None)
+        .header("MCP-Protocol-Version", "2025-11-25")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2025-11-25",
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                }
+            }
+        }))
+        .send()
+        .await
+        .expect("the listing request must reach the server")
+        .text()
+        .await
+        .expect("a body");
+
+    assert!(
+        body.contains("served only for a revision this server serves at 2026-07-28 or later"),
+        "the declaration must be refused by the handler: {body}"
+    );
+    assert!(
+        !body.contains("bug_info"),
+        "a refused listing must name no tool at all: {body}"
+    );
+}
+
+#[tokio::test]
+async fn a_per_request_listing_carries_the_cache_hints() {
+    // The wire companion to the in-process rows in server.rs: end to end,
+    // a 2026-07-28 request really does reach the enabled half of the
+    // SEP-2549 gate. Substring assertions hold because no served schema,
+    // description or annotation spells either field.
+    let mock = MockServer::start().await;
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock, None).await;
+
+    let body = per_request_post(addr, None, "tools/list", json!({}), None)
+        .await
+        .text()
+        .await
+        .expect("a body");
+    assert!(
+        body.contains("\"bug_info\""),
+        // A named tool, not the `"tools"` key: that key is present even for
+        // an empty listing or a scope that reaches nothing.
+        "the per-request caller must be served a real listing: {body}"
+    );
+    assert!(
+        body.contains("\"ttlMs\":0"),
+        "a memory-served listing is stale on arrival: {body}"
+    );
+    assert!(
+        body.contains("\"cacheScope\":\"private\""),
+        "a per-deployment, per-credential listing is never publicly cacheable: {body}"
+    );
+}
+
+#[tokio::test]
+async fn a_per_request_initialize_is_answered_without_minting_a_session() {
+    // The asymmetry adoption creates, pinned where it is observable: rmcp
+    // routes a 2026-07-28 `initialize` down the STATELESS path, so over
+    // http it is answered and audited but opens nothing — no
+    // `mcp-session-id` on the response, no id in the record. (Over stdio
+    // the same request is an ordinary handshake and does open a session.)
+    // The record is written anyway: recording every handshake
+    // unconditionally is the invariant, and joins are on id equality — an
+    // anchor with no id anchors nothing, and gathers nothing belonging to
+    // another session either.
+    let mock = MockServer::start().await;
+    let dir = tempfile::tempdir().expect("audit temp dir");
+    let file = key_file("srv-key\n");
+    let (addr, audit_path) = served_with_audit(&mock, &dir, &file).await;
+
+    let response = per_request_post(
+        addr,
+        None,
+        "initialize",
+        json!({
+            "protocolVersion": PER_REQUEST_REVISION,
+            "capabilities": {},
+            "clientInfo": { "name": "modern-client", "version": "2" }
+        }),
+        None,
+    )
+    .await;
+    assert!(
+        response.status().is_success(),
+        "the per-request initialize must be answered, got {}",
+        response.status()
+    );
+    assert!(
+        response.headers().get("mcp-session-id").is_none(),
+        "the stateless path mints no session id"
+    );
+    let body = response.text().await.expect("a body");
+    assert!(
+        body.contains(&format!("\"protocolVersion\":\"{PER_REQUEST_REVISION}\"")),
+        "the revision this build now serves must be echoed: {body}"
+    );
+
+    let events = audit_events(&audit_path);
+    let anchor = initialize_of(&events, "modern-client");
+    let AuditEventKind::Initialize(event) = &anchor.kind else {
+        unreachable!("selected by kind")
+    };
+    assert_eq!(
+        event.protocol_version.as_deref(),
+        Some(PER_REQUEST_REVISION),
+        "the record names the revision the exchange spoke"
+    );
+    assert_eq!(
+        event.client.version.as_deref(),
+        Some("2"),
+        "the record names the REQUEST's client, never the synthesised peer"
+    );
+    assert_eq!(
+        anchor.session.id, None,
+        "there is no session for the anchor to name"
+    );
+}
+
+#[tokio::test]
+async fn a_header_only_2026_declaration_is_refused_by_the_transport() {
+    // The `Handshake` arm leans on this being the sole barrier: a request
+    // that names 2026-07-28 in the HTTP header alone carries no `_meta`, so
+    // `lifecycle_of` would read it as an ordinary in-session request and
+    // `client_of` would fall back to a peer that never handshook. rmcp
+    // refuses it first (-32602, `validate_request_protocol_version_meta`),
+    // before any handler — pinned here because nothing else does, and
+    // because the day it stops being true the identity source silently
+    // changes.
+    let mock = MockServer::start().await;
+    let dir = tempfile::tempdir().expect("audit temp dir");
+    let file = key_file("srv-key\n");
+    let (addr, audit_path) = served_with_audit(&mock, &dir, &file).await;
+
+    let response = mcp_post(addr, None)
+        .header("MCP-Protocol-Version", PER_REQUEST_REVISION)
+        .header("Mcp-Method", "tools/call")
+        .header("Mcp-Name", "bug_info")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": "bug_info", "arguments": { "bug_ids": [7] } }
+        }))
+        .send()
+        .await
+        .expect("the header-only request must reach the server");
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "the transport refuses before any handler"
+    );
+    let body = response.text().await.expect("a body");
+    assert!(
+        body.contains("-32602"),
+        "refused as missing required request metadata: {body}"
+    );
+    assert!(
+        !std::path::Path::new(&audit_path).exists() || audit_events(&audit_path).is_empty(),
+        "a request the handler never saw records nothing"
+    );
+    let upstream = mock.received_requests().await.unwrap_or_default();
+    assert!(upstream.is_empty(), "and contacts no upstream");
+}
+
+#[tokio::test]
+async fn a_per_request_call_cannot_reach_a_tool_the_deployment_pruned_i13() {
+    // I13 under the handshake-free lifecycle: the pruned INSTANCE router is
+    // what dispatch goes through on this path too, so a write tool
+    // `--read-only` removed and a name that never existed must be
+    // indistinguishable — byte-identical status and body, since anything
+    // that differed would enumerate the deployment's policy.
+    let mock = MockServer::start().await;
+    mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    // Read-only through the POLICY, which is where `BugWarden::new` reads
+    // it: main folds `--read-only` in there (I9 — the flag may only tighten
+    // the policy, never loosen it), so a harness setting the Cli field
+    // alone would serve a deployment no operator can configure.
+    let addr = serve_http(cli, "[global]\nread_only = true\n", &mock, None).await;
+
+    // Served first, so the deployment is demonstrably alive and reachable
+    // on this path — otherwise two identical failures prove nothing.
+    let served = per_request_bug_7(addr, None).await;
+    assert!(
+        served.contains("a plain bug"),
+        "the read tool is served: {served}"
+    );
+
+    let mut answers = Vec::new();
+    for name in ["create_bug", "no_such_tool_at_all"] {
+        let response = per_request_post(
+            addr,
+            None,
+            "tools/call",
+            json!({ "name": name, "arguments": {} }),
+            None,
+        )
+        .await;
+        let status = response.status();
+        answers.push((status, response.text().await.expect("a body")));
+    }
+    assert_eq!(
+        answers[0], answers[1],
+        "a pruned tool and a nonexistent one must be byte-identical (I13)"
+    );
+    assert!(
+        answers[0].1.contains("\"error\""),
+        "and both must be REFUSED, not two identical successes: {:?}",
+        answers[0]
+    );
+    let upstream = mock.received_requests().await.unwrap_or_default();
+    assert!(
+        upstream
+            .iter()
+            .all(|r| !r.url.path().contains("/rest/bug/")),
+        "no unrouted call may reach Bugzilla"
+    );
+}
+
+#[tokio::test]
+async fn a_per_request_denial_is_uniform_with_a_nonexistent_bug_i2() {
+    // I2 under the handshake-free lifecycle: with no session to attribute a
+    // refusal to, the refusal text must still not say which of the two
+    // reasons applied. Bug 7 is hidden by policy; bug 8 does not exist.
+    let mock = MockServer::start().await;
+    let mut secret = world_readable_bug(7);
+    secret["product"] = json!("SecretSauce");
+    mount_bug_for_key(&mock, secret, "srv-key").await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .and(query_param("id", "8"))
+        .and(query_param("api_key", "srv-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .mount(&mock)
+        .await;
+
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(
+        cli,
+        concat!(
+            "[[rule]]\nname = \"hide-secret\"\naction = \"deny\"\n",
+            "[rule.match]\nproducts = [\"Secret*\"]\n",
+        ),
+        &mock,
+        None,
+    )
+    .await;
+
+    let mut answers = Vec::new();
+    for id in [7, 8] {
+        let response = per_request_post(
+            addr,
+            None,
+            "tools/call",
+            json!({ "name": "bug_comments", "arguments": { "id": id } }),
+            None,
+        )
+        .await;
+        let body = response.text().await.expect("a body");
+        assert!(
+            body.contains(&format!("Bug {id} is not accessible through this server")),
+            "the uniform denial text, for bug {id}: {body}"
+        );
+        // Only the id the caller already knows may differ.
+        answers.push(body.replace(&format!("Bug {id} "), "Bug _ "));
+    }
+    assert_eq!(
+        answers[0], answers[1],
+        "a policy-denied bug and a nonexistent one must be indistinguishable (I2)"
     );
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -953,11 +953,12 @@ Decisions, all deliberate:
   whether a mandatory *unauthenticated* pre-request surface should survive the
   arrival of auth. It does not: the gate wraps the whole router, so
   `server/discover` needs a token like any other request. Decided rather than
-  inherited, and the cheap direction — no revision this build serves defines
-  that surface (`2026-07-28` is unadopted, #34), so nothing needs it today,
-  and opening a pre-request identity surface ahead of the revision that gives
-  it a purpose would hand out the deployed version to strangers for nothing.
-  Reopening it is a one-line route exemption if #34 ever needs one.
+  inherited: opening a pre-request identity surface to strangers would hand
+  out the deployed version for nothing, and the callers that need it are
+  exactly the ones a deployment authenticates anyway. Unchanged by #34 stage
+  2 adopting `2026-07-28`, the revision that makes the surface mandatory —
+  a handshake-free caller presents its bearer token like any other.
+  Reopening it is a one-line route exemption if one is ever needed.
 - **What this deliberately does NOT do.** No caller identity: `principal` stays
   `None`, and a deployment credential must never fill it (#32). No per-caller
   policy: one operator policy per process (I1) is unchanged, and a token
@@ -1194,8 +1195,21 @@ Decisions, all deliberate:
   `SessionManager` wrapper in `http_session`, never read from the
   `mcp-session-id` request header (issue #180) — with the remote address
   when the listener provides connect-info. The `initialize` record carries
-  it too, so the anchor joins to what it anchors; a handshake-free
-  stateless request opens no session and its record carries no id.
+  it too, so where a handshake happened the anchor joins to what it anchors.
+  It is not promised to exist: a 2026-07-28 STDIO client may open with an
+  ordinary request and never send `initialize` (rmcp serves that first
+  message and keeps the connection), while the process-scoped id is stamped
+  on every record regardless — a run of records sharing an id nothing
+  anchors. Truthful rather than misleading: no other session holds that id,
+  so those records are never gathered under the wrong one — they simply have
+  nothing to join to. A handshake-free http
+  request opens no session and its record carries no id, served or refused —
+  including a `2026-07-28` `initialize`, which rmcp routes statelessly, so
+  that anchor names no session either; grouping there is `remote` and nothing
+  else. Over stdio the same lifecycle keeps the process-scoped id, which is
+  minted rather than read off a request. The client on a per-request record
+  is the one the request itself declared in `_meta`, absent when it declared
+  none, and capped at 1024 characters like an audited parameter value.
 - **Trace enrichment (issue #28).** When a tool call's `params._meta`
   carries a `traceparent` (SEP-414), its trace and span ids are copied
   into the record's `trace` field — the pre-dispatch fail-closed gate
@@ -1840,8 +1854,16 @@ wired, `server.rs` and `main.rs` are the reference.
   the SDK default of every revision it knows. What that override bounds is
   precisely which **declared** revisions `initialize`, per-request `_meta` and
   `server/discover` may agree to; it does not decide which request *lifecycle*
-  the transport routes to (see the `_meta`-shape trap below). `2026-07-28` is excluded
-  because this build has not adopted it (issue #34, stage 2).
+  the transport routes to (see the `_meta`-shape trap below). `2026-07-28` is
+  SERVED as of issue #34 stage 2: its handshake-free requests carry the calling
+  client in their own `_meta`, which `client_of` reads, so a record on that path
+  names the caller or names nobody. Adoption ADDED it — `2024-11-05` through
+  `2025-11-25` keep their handshakes and their sessions — so the two lifecycles
+  are served side by side and `DEFAULT_PROTOCOL_VERSION` stays `2025-11-25`.
+  One consequence worth stating because nothing enforces it: rmcp's
+  `KNOWN_VERSIONS` now equals this list, so there is no known-but-unserved
+  revision left to test the fallback with, and the negotiation tests use a
+  fabricated `"9999-01-01"` instead.
   The hand-written `initialize` tests the same list — the SDK negotiates
   again afterwards using the handler's answer as its fallback, so a handler
   that echoed an unsupported request would make the SDK echo it too — and
@@ -1917,11 +1939,33 @@ wired, `server.rs` and `main.rs` are the reference.
   covers a revision this build *does* serve sent with both keys. That still
   reaches `serve_negotiated_request_directly`, whose synthesised peer carries
   `client_info = Implementation::default()` — the SDK's own crate name and
-  version. Served, it would reach a tool with no `initialize` behind it and
-  land in the audit stream as a client the server never spoke to. So
-  `call_tool` and `list_tools` refuse any request carrying the version key
-  (`skips_the_handshake`), and a refused call is recorded with `client` absent
-  rather than with the placeholder. Grep misleads here:
+  version. So the handler decides for itself, three ways (`lifecycle_of`,
+  server.rs), on the revision the request DECLARES and never on the session's
+  negotiated one: no declaration is the handshake lifecycle, `>= 2026-07-28`
+  AND on `SUPPORTED_PROTOCOL_VERSIONS` is the per-request one, anything else
+  is out of contract and refused by `call_tool` and `list_tools`
+  (`mixed_lifecycle_refused`; the refusal is recorded with `client` absent).
+  The `contains` half of the middle arm is defence in depth behind rmcp's own
+  -32022 — every rmcp comparison is lexical, and a fabricated `"9999-01-01"`
+  outranks every real revision.
+  The refusal arm survives adoption precisely because the second routing shape
+  does: a PRE-2026 revision with both keys still arrives with no `initialize`
+  behind it. It is broader than the routing on purpose — such a declaration
+  without `clientCapabilities` takes the session path — so it fires on requests
+  that did complete a handshake too.
+  **rmcp trap within the trap — `RequestContext::client_info()` is not a safe
+  accessor.** It falls back to `peer_info().client_info` unless
+  `peer.request_metadata_required()`, which rmcp 3.1.4 sets on exactly one path
+  (`service/server.rs`, the stdio first-message-is-not-`initialize` case) and
+  never over streamable http. So on the http handshake-free path that
+  convenience accessor IS the placeholder, silently. `client_of` therefore
+  reads `ctx.meta.client_info()` directly on the per-request arm and
+  `peer.peer_info()` only on the handshake arm — never the accessor, never the
+  peer on the per-request arm. `ctx.meta.client_info()` decodes
+  all-or-nothing, so a half-declared identity records as nothing at all. Both
+  recorded fields are capped at `PARAM_VALUE_MAX_CHARS`, the audited-parameter
+  cap: per-request sourcing repeats a client-controlled string into every
+  record where the handshake wrote it once per session. Grep misleads here:
   `message_has_per_request_protocol_version` tests presence alone, and inside
   the stateless arm that presence does pick a route — but nothing it decides
   gets a request INTO that arm; everywhere else it only feeds header
@@ -1931,6 +1975,15 @@ wired, `server.rs` and `main.rs` are the reference.
   `get_info` only and reaches no tool, guard or router. General rule: **no
   `_meta` key and no `Mcp-*` header may carry a security decision** — like
   `KNOWN_VERSIONS`, they are the SDK's vocabulary, not this build's contract.
+  Two more things to re-check on an rmcp bump, both load-bearing for the
+  handshake arm: that a POST naming `2026-07-28` in the `MCP-Protocol-Version`
+  header ALONE, with no `_meta`, is still refused by the transport
+  (`validate_request_protocol_version_meta`, -32602) — otherwise such a request
+  reaches the handler looking like an ordinary in-session one while its peer
+  never handshook — and that `request_metadata_required()` is still set on no
+  http path. The first has a test
+  (`a_header_only_2026_declaration_is_refused_by_the_transport`); the second
+  does not, and is why `client_of` never uses the convenience accessor.
 - **rmcp trap — `mcp-session-id` is a validated header on only one of the two
   routes.** In rmcp 3.1.4 the session branch of `handle_post`
   (`transport/streamable_http_server/tower.rs`) checks the header against
@@ -1948,9 +2001,13 @@ wired, `server.rs` and `main.rs` are the reference.
   `SessionRestoreMarker`, message extensions reaching `RequestContext`
   verbatim. Re-check both halves on every rmcp bump: that `SessionManager`
   still receives the message, and that the stateless branch still validates no
-  session. Deliberate consequence: a stateless refusal records no session id
+  session. Deliberate consequence: a stateless request records no session id
   even when the caller innocently echoed one, because a forgeable id is worse
-  than none (#34).
+  than none (#34). Since stage 2 that covers SERVED calls as well as refused
+  ones — the hazard widened with the lifecycle, and the served half is the
+  worse one, since those forged records would describe work that actually
+  happened. Over stdio the same lifecycle keeps its id: it is minted from the
+  process, not read off a request, so there is nothing to forge.
 - `list_tools` names every `ListToolsResult` field: `result_type` is
   `COMPLETE`, and the SEP-2549 cache hints are gated on the request's
   revision. **rmcp trap — the only version-shaped edit the SDK makes to a
@@ -1981,13 +2038,15 @@ wired, `server.rs` and `main.rs` are the reference.
   `skip_serializing_if`, hard-coded to `0`/`Private` by both constructors,
   and this build keeps rmcp's default `server/discover` — so a legacy peer
   naming 2025-11-25 gets the pair from *that* surface today, whatever
-  `tools/list` does. `2026-07-28` is off `SUPPORTED_PROTOCOL_VERSIONS`, so
-  the served branch is unreachable end to end — but only because
-  `initialize` stores the NEGOTIATED revision (above): while it stored the
-  requested one, a second `initialize` reopened this branch on a live stdio
-  session. It is therefore tested in-process against a hand-built
-  `RequestContext`; the legacy branch is live and tested over real
-  streamable HTTP.
+  `tools/list` does. Since stage 2 the served branch is reachable end to end —
+  a 2026-07-28 request, or a session that negotiated it — and is tested over
+  real streamable HTTP as well as in-process. The in-process rows are still the
+  sharp ones: `RequestContext::protocol_version()` reads the request's `_meta`
+  first and the session's revision second, and over http the handshake-free
+  path's SYNTHESISED peer carries the same revision the `_meta` names, so the
+  two sources agree there and a gate reading only the peer survives every wire
+  test. Only a hand-built context with a peer carrying no info at all separates
+  them.
 - **rmcp trap — `input_schema` is schemars' rendering, unfiltered by rmcp.**
   `SchemaSettings::draft2020_12()` (`handler/server/common.rs`) runs zero
   transforms, so whatever schemars 1.x emits for a `#[tool]` param struct is
@@ -2031,8 +2090,8 @@ wired, `server.rs` and `main.rs` are the reference.
   | `max_request_body_bytes` | 4 MiB | **set** — derived from `global.max_attachment_bytes`, floored at that same 4 MiB (see below) |
   | `cancellation_token` | fresh token | **set** (main.rs) — a child of the process token |
   | `allowed_origins` | `[]`, i.e. validation off | inherited, deliberately |
-  | `stateless_protocol_metadata_required` | `false` | inherited; #34 decides it |
-  | `legacy_session_mode` | `true` | inherited |
+  | `stateless_protocol_metadata_required` | `false` | inherited, deliberately — #34 decided it (see below) |
+  | `legacy_session_mode` | `true` | inherited — sessions for the legacy revisions; 2026-07-28 routes statelessly regardless |
   | `session_store` | `None` | inherited |
   | `json_response` | `false` | inherited |
   | `sse_keep_alive` / `sse_retry` | 15 s / 3 s | inherited |
@@ -2158,22 +2217,27 @@ wired, `server.rs` and `main.rs` are the reference.
   below `2026-07-28` do not attach that metadata, so enabling it refuses their
   ordinary requests, and the field's own rustdoc says a server using it should
   advertise only `2026-07-28` and later. Adopting the revision (#34) therefore
-  has to pick one — enforce at the transport and drop `2024-11-05` through
+  had to pick one — enforce at the transport and drop `2024-11-05` through
   `2025-11-25`, or keep them and enforce in the handler. **DECIDED 2026-08-05:
   keep the legacy revisions and enforce in the handler**, so this field stays
-  `false` and #34 adds `2026-07-28` to the existing list rather than replacing
-  it. Flipping it to `true` is not a tuning knob: it silently drops every
-  revision this build serves. The rejected alternative is rejected on timing,
-  not on cleanliness — transport-level enforcement is the tidier mechanism, but
-  `2026-07-28` is not yet even rmcp's own `LATEST` (upstream PR #1105 is open),
-  so taking it now would strand every current client to gain validation the
-  handler can do itself, in a handler that already polices this exact request
-  class. Revisit when the ecosystem has moved and dropping the legacy revisions
-  costs little. Moot until then: `skips_the_handshake` refuses the whole
-  request class before it reaches a tool. `legacy_session_mode` is inherited
-  `true`, so sessions exist for the revisions served; per SEP-2567 rmcp serves
+  `false` and #34 stage 2 ADDED `2026-07-28` to the existing list rather than
+  replacing it. Flipping it to `true` is not a tuning knob: it silently drops
+  every revision this build served before. The rejected alternative is rejected
+  on timing, not on cleanliness — transport-level enforcement is the tidier
+  mechanism, but `2026-07-28` is not yet even rmcp's own `LATEST` (upstream PR
+  #1105 is open), so taking it now would strand every current client to gain
+  validation the handler can do itself, in a handler that already polices this
+  exact request class. Revisit when the ecosystem has moved and dropping the
+  legacy revisions costs little. What the handler does instead is `lifecycle_of`
+  (above): the per-request `_meta` is validated where a refusal can be recorded
+  and where the identity it carries is read, rather than at a layer that sees
+  neither. `legacy_session_mode` is inherited
+  `true`, so sessions exist for the legacy revisions; per SEP-2567 rmcp serves
   `2026-07-28` requests statelessly whatever this flag says, which #34 inherits
-  rather than configures. `session_store` stays `None`: the client's
+  rather than configures. **That is the asymmetry to hold onto: a `2026-07-28`
+  `initialize` mints a session over stdio and nothing over http** — both are
+  rmcp's routing, not a bugwarden choice, and both are audited, so over http
+  the `initialize` record is written with no `session.id` at all. `session_store` stays `None`: the client's
   `initialize` parameters remain in-process, and there is one process here and
   no cross-instance recovery to do. `json_response`, `sse_keep_alive` and
   `sse_retry` set response framing and SSE liveness — client-visible timing,
@@ -2503,12 +2567,45 @@ wired, `server.rs` and `main.rs` are the reference.
   and returned on the RESPONSE, and a tool call in that session carries
   the same one at a later `seq`; two sessions each join their own
   `initialize` rather than the nearest; a handshake-free request wearing
-  a live session's `mcp-session-id` is refused with NO id recorded, never
-  that session's; and — because the handshake refusal is deliberately
-  broader than rmcp's stateless routing — a declaration that stayed on
-  the session branch is refused WITH its real id and joins its own
-  `initialize`. That last arm is the only test pinning it, and the
-  comment asserting it has been wrong once.
+  a live session's `mcp-session-id` records NO id, never that session's,
+  in both the refused and the SERVED shape (the served one is the C3
+  hazard adoption widened, and the worse half — those records would
+  describe work that actually happened); and — because the out-of-contract
+  refusal is deliberately broader than rmcp's stateless routing — a
+  declaration that stayed on the session branch is refused WITH its real
+  id and joins its own `initialize`. That last arm is the only test
+  pinning it, and the comment asserting it has been wrong once.
+  The per-request lifecycle (#34 stage 2) is driven from the same raw
+  harness, since no rmcp client sends the shape at all: a `tools/call`
+  declaring `2026-07-28` and NO `clientInfo` anywhere is served, recorded
+  once, names no client — the whole audit file is asserted free of
+  `"rmcp"` — and carries `remote` but no session id; the same call
+  declaring one records it verbatim (the row an unconditional `(None,
+  None)` passes the first test on); a `tools/list` really does reach the
+  enabled half of the SEP-2549 gate end to end; a `2026-07-28`
+  `initialize` is answered with that revision, mints no `mcp-session-id`,
+  and is recorded from the REQUEST's `clientInfo` with no id; a header-only
+  `2026-07-28` with no `_meta` is refused by the transport (-32602) with
+  nothing recorded, which is the barrier the handshake arm leans on; and
+  I13 and I2 are re-run on the path — a `--read-only`-pruned tool and a
+  nonexistent name answer byte-identically, a policy-denied bug and a
+  nonexistent one answer with the same uniform text. `list_tools` has its own
+  refusal row — an out-of-contract declaration is refused and the answer names
+  no tool at all — because listings are unrecorded, so deleting that arm is
+  invisible to every record-based test and it was a surviving mutant until the
+  row existed. Two in-process rows pin what no wire test could: the
+  handshake arm answering with the client the server GREETED when a request
+  smuggles a `clientInfo` into `_meta` WITHOUT a `protocolVersion` (that shape
+  stays on the handshake arm, and `RequestContext::client_info()` would prefer
+  the smuggled value while leaving every ordinary session working — it
+  survived the whole suite), and a stdio per-request call KEEPING its
+  process-scoped `session.id`, which is the deliberate asymmetry with http and
+  was likewise pinned by nothing. The bearer gate and
+  its scope split are re-run there too
+  (crates/bugwarden/tests/http_auth_wiremock.rs): a per-request POST with no
+  token is the same `401`, the read scope reaches a read tool but sees a
+  write tool exactly as it sees a name that does not exist, and a read-scope
+  listing carries no write tools.
 - Configuration tests (crates/bugwarden/tests/env_config.rs, the REAL
   process environment): every flag is settable from the environment, which
   is what a container deployment configures through (#31/#32). ONE test by
@@ -2725,7 +2822,7 @@ wired, `server.rs` and `main.rs` are the reference.
   body, is strictly larger than the same denial alone, pinning that the
   verdict does not bound the size; and the three unmeasured sites record
   the field ABSENT rather than zero — the protocol error, the
-  handshake-skip refusal, and the pre-dispatch gate, whose line is
+  out-of-contract refusal, and the pre-dispatch gate, whose line is
   asserted not to contain the key at all, so `Some(0)` and a dropped
   `skip_serializing_if` (a `null`) fail alike. On the export side the
   attribute is asserted present as an Int and absent when the record

--- a/examples/audit.toml
+++ b/examples/audit.toml
@@ -14,9 +14,11 @@
 #
 # Format: one JSON object per line (JSONL), schema version 2. Three record
 # kinds: `tool_call` (one MCP tool invocation, request through outcome,
-# with the guard's decision), `initialize` (a client opened a session),
-# and `audit_gap` (records were lost — see fail_mode below; the gap is
-# reported in the stream itself, so silent loss is impossible to miss).
+# with the guard's decision), `initialize` (a client sent an `initialize` —
+# usually opening a session, though a 2026-07-28 `initialize` over http
+# opens none and its record then carries no session id), and `audit_gap`
+# (records were lost — see fail_mode below; the gap is reported in the
+# stream itself, so silent loss is impossible to miss).
 #
 # The schema is closed: fixed structs, fixed vocabularies, and no
 # dedicated field for the Bugzilla API key, request headers, or free-text


### PR DESCRIPTION
PR 3 of #34's stage-2 sequence, and the one the ordering existed for. Adds
`2026-07-28` to `SUPPORTED_PROTOCOL_VERSIONS` and serves the handshake-free
lifecycle that was previously refused — **with per-request identity in the same
commit**.

## Why identity could not land later

With the path served and `client_of` unchanged, every record on it would carry
`{"name":"rmcp","version":"3.1.4"}` — rmcp's own build identity, synthesized for
stateless peers. Not a missing field but a plausible wrong one that still
validates, which is the failure an audit trail can least afford (#34 §3c).

The trap is that the obvious accessor is the wrong one: `ctx.client_info()`
falls back to `peer_info().client_info` unless `request_metadata_required()`,
which streamable HTTP never sets. So the per-request arm reads
`ctx.meta.client_info()` **strictly** — never the convenience accessor, never
`peer_info()` on that path. It fails to absent for free: `Implementation`
requires both fields, so a malformed `clientInfo` records neither.

A reviewer tried seven constructions to reach a recorded placeholder and closed
every one.

## The predicate

`lifecycle_of` is three-way on the request's own `_meta` revision — never the
session's negotiated one, so a 2026-07-28 **stdio** session's ordinary requests
stay on the handshake arm with real peer identity:

- absent → `Handshake`, unchanged;
- `>= 2026-07-28` **and** in the served list → `PerRequest`;
- anything else → `OutOfContract`, refused.

`call_tool`, `list_tools` **and** `client_of` all consume it, so routing and
identity cannot diverge by call-site ordering — this repo already carries one
ordering-only contract too many.

The `contains` guard is defence in depth: rmcp refuses unsupported `_meta`
versions first, but its comparisons are lexical and `"9999-01-01"` has bitten
this repo once already.

Recorded client identity is now capped at 1024 chars at **both** sites —
per-request sourcing repeats an unbounded client string into every record where
the handshake wrote it once per session.

## A pre-existing hole, found by mutation

Deleting the out-of-contract arm from `list_tools` **failed nothing** on
`d56fd7c` — confirmed by running the full suite under that mutation. Listings
are unrecorded, so no record-based test could observe it, and serving that shape
would hand a caller with no handshake behind it a per-deployment-pruned listing
(the I13 disclosure the arm exists to prevent). Now closed, and the mutant's
failure output shows it serving the complete listing.

## `session.id`: HTTP records none, stdio keeps its own

Deliberate, and it deviates from #34's literal acceptance text — the rule's
whole rationale is the forgeable HTTP header, while the stdio id is
`<pid>-<epoch>`, minted by this process. Recording `None` there would also
contradict schema v2's shipped `SessionInfo::id` contract. #34's body is amended
to say so.

The consequence, found in review and worth its four doc fixes: a 2026-07-28
stdio client has no reason to send `initialize` at all, so an entire session of
served calls can carry one id with **no anchor** — ordinary client behaviour,
not an edge case. The records stay truthful (the id is unforgeable and cannot
*mis*-join, having nothing to join to), but the "every id joins its `initialize`"
guarantee was too strong and is now scoped to handshake-begun sessions. Over
HTTP the replacement for cross-call grouping is `remote` plus nothing; over
stdio the id still groups and nothing anchors.

## Review

Two Fable lenses. Mechanism **MERGE-SAFE** — no placeholder path constructible,
M12's baseline confirmed empirically, and the cache-hint mutant's isolation
verified (only a bare-peer shape kills it; every wire path's synthesized peer
carries the same version and masks it). Prose **NOT MERGE-SAFE** on three
findings, all fixed.

Two of the three traced to my own decisions: the `contains` guard made README's
"2026-07-28 **or later**" false, and the stdio `session.id` carve-out is what
broke the join guarantee.

Two survivors closed. **S1** is the one worth naming: `client_of`'s handshake arm
mutated to the convenience accessor survived the entire suite, and it is
wire-reachable — a session request carrying `_meta.clientInfo` *without* a
`protocolVersion` key stays on that arm, so the mutant would record a
**client-smuggled** identity in place of the handshake one. Same failure shape as
the placeholder, arriving from the other direction.

Also fixed: `serve_http` used bare `axum::serve`, so `session.remote` was always
`None` — the harness was testing a server no deployment runs. Both HTTP harnesses
now match `main.rs`.

## Verification

All eight AGENTS.md commands re-run independently: green, 662 tests, 0 failed.
I13 and I2 are re-tested under the new lifecycle with byte-identical comparisons;
bearer and read-scope are pinned on the served path.

Tracked separately: #190 (the `http_cli()` harness does not clear `read_only`
despite its doc comment) and #191 (`capped()` and `truncated()` carry the same
1024 rule in two places).
