### PR TITLE
test(server): trip on any authored x-mcp-header annotation

### DIFF
--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -5519,6 +5519,162 @@ mod tests {
         }
     }
 
+    /// SEP-2243's schema annotation, byte-exact as rmcp 3.1.4 reads it —
+    /// `schema.get("x-mcp-header")` in `transport/common/mcp_headers.rs`
+    /// (`param_header_annotations`, `validate_param_header_annotations`,
+    /// `reject_nested_annotations`). Upstream exports no constant for the
+    /// spelling, so this is our own copy: re-grep the vendored tree on every
+    /// rmcp bump.
+    const X_MCP_HEADER: &str = "x-mcp-header";
+
+    /// The forbidden annotation anywhere in a serialized tool definition, as
+    /// `Some(reason)`.
+    ///
+    /// A substring check, not a structural walk: rmcp's read is a byte-exact
+    /// map `get`, serde_json emits map keys verbatim, and no character of
+    /// this key is ever escaped — so substring-absence proves key-absence at
+    /// EVERY depth (`properties`, `items`, `$defs`, output schema, prose)
+    /// with no recursion arms to keep in lockstep, which is the maintenance
+    /// surface `schema_portability_error` above has to carry.
+    ///
+    /// Deliberately broader than rmcp's functional read, which in 3.1.4 is
+    /// top-level `properties` and string-valued only: the key is banned
+    /// everywhere, at any value type, because upstream's depth rules are
+    /// version-specific. It will also trip on the substring appearing in a
+    /// description or a property name — accepted; a tripwire fails loud and
+    /// a human looks.
+    fn x_mcp_header_smell(name: &str, tool_json: &Value) -> Option<String> {
+        let serialized = tool_json.to_string();
+        serialized.contains(X_MCP_HEADER).then(|| {
+            format!("{name}: a served tool definition authors {X_MCP_HEADER}: {serialized}")
+        })
+    }
+
+    #[test]
+    fn no_served_tool_authors_an_x_mcp_header_annotation() {
+        // `x-mcp-header` is not a server switch. The client transport
+        // promotes an annotated tool parameter into an `Mcp-Param-*` header
+        // and the server cross-checks it, so nothing happens unless WE
+        // author the key in our own schemas: "never enable" reduces to
+        // "never author". #34 calls it I10's mirror — I10 stops a request
+        // header reaching a result; this would let a tool argument reach the
+        // transport layer.
+        //
+        // Two dynamic loops, no hardcoded tool list. The raw router is the
+        // unpruned superset every deployment prunes FROM and takes no
+        // config, so it is immune to the ambient environment; the built
+        // server is re-read through `get_tool`, the exact door rmcp's
+        // `Mcp-Param-*` validation opens (`tower.rs::tool_schema`), and is
+        // the only loop that would see an annotation injected at
+        // construction.
+        let mut unpruned = Vec::new();
+        for tool in BugWarden::tool_router().list_all() {
+            let json = serde_json::to_value(&tool).expect("a Tool serializes");
+            if let Some(err) = x_mcp_header_smell(&tool.name, &json) {
+                panic!("{err}");
+            }
+            unpruned.push(tool.name.to_string());
+        }
+
+        let (cfg, guard, bz) = parts("[global]\nallow_discovery = true\n");
+        let server = BugWarden::new(cfg, guard, bz).expect("server builds");
+        let mut served = Vec::new();
+        for tool in server.tool_router.list_all() {
+            let definition = server
+                .get_tool(&tool.name)
+                .unwrap_or_else(|| panic!("{}: a listed tool has a definition", tool.name));
+            for json in [
+                serde_json::to_value(&tool).expect("a Tool serializes"),
+                serde_json::to_value(&definition).expect("a Tool serializes"),
+            ] {
+                if let Some(err) = x_mcp_header_smell(&tool.name, &json) {
+                    panic!("{err}");
+                }
+            }
+            served.push(tool.name.to_string());
+        }
+
+        // `list_all` sorts by name, so these compare as sets. Binding them
+        // makes a tool added later behind a new opt-in knob break loudly
+        // instead of being skipped by the maximal build.
+        assert_eq!(
+            unpruned, served,
+            "the maximal deployment must serve the whole unpruned router"
+        );
+        // A floor, so an empty enumeration is not a silent pass.
+        for required in ["bug_info", "create_bug"] {
+            assert!(
+                served.iter().any(|name| name == required),
+                "{required} must be among the walked tools: {served:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_x_mcp_header_tripwire_fires_at_every_planted_position() {
+        // The canary for the walk above, mirroring
+        // `mirror_walk_rejects_a_dirty_node_under_every_new_draft_position`:
+        // with zero annotations served, a gutted or inverted check would
+        // pass that walk forever. rmcp's real read site, a depth its own
+        // nested-reject never reaches, a position `portable_schema` never
+        // visits, and prose — the last pinning the over-trip as deliberate.
+        let planted = [
+            (
+                "top-level properties (rmcp's own read site)",
+                json!({
+                    "inputSchema": {
+                        "properties": { "p": { "type": "string", "x-mcp-header": "X-Canary" } }
+                    }
+                }),
+            ),
+            (
+                "nested under items -> properties",
+                json!({
+                    "inputSchema": {
+                        "properties": {
+                            "p": {
+                                "type": "array",
+                                "items": {
+                                    "properties": {
+                                        "q": { "type": "string", "x-mcp-header": "X-Canary" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }),
+            ),
+            (
+                "$defs",
+                json!({
+                    "inputSchema": {
+                        "$defs": {
+                            "Nested": {
+                                "properties": {
+                                    "p": { "type": "string", "x-mcp-header": "X-Canary" }
+                                }
+                            }
+                        }
+                    }
+                }),
+            ),
+            (
+                "a description",
+                json!({ "description": "set x-mcp-header to promote this parameter" }),
+            ),
+        ];
+        let missed: Vec<_> = planted
+            .iter()
+            .filter(|(_, tool)| x_mcp_header_smell("planted", tool).is_none())
+            .map(|(label, _)| *label)
+            .collect();
+        assert!(
+            missed.is_empty(),
+            "the tripwire missed {}; a planted annotation was not rejected",
+            missed.join(", ")
+        );
+    }
+
     /// Non-portable node planted under each newly covered keyword. Live
     /// `#[tool]` structs do not emit these positions today (the only
     /// `additionalProperties` in served schemas is boolean `true`), so a

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -1855,3 +1855,101 @@ async fn a_per_request_denial_is_uniform_with_a_nonexistent_bug_i2() {
         "a policy-denied bug and a nonexistent one must be indistinguishable (I2)"
     );
 }
+
+/// One per-request `tools/call` POST for `tool`, optionally carrying a stray
+/// SEP-2243 `Mcp-Param-*` header, as `(status, body)`.
+///
+/// Inlined rather than widening [`per_request_post`]: exactly one caller
+/// wants the extra header, and no other test should grow a parameter for it.
+async fn per_request_call_with_canary(
+    addr: SocketAddr,
+    tool: &str,
+    canary: bool,
+) -> (reqwest::StatusCode, String) {
+    let mut builder = mcp_post(addr, None)
+        .header("MCP-Protocol-Version", PER_REQUEST_REVISION)
+        .header("Mcp-Method", "tools/call")
+        .header("Mcp-Name", tool.to_owned());
+    if canary {
+        builder = builder.header("Mcp-Param-X-Bugwarden-Canary", "1");
+    }
+    let response = builder
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": tool,
+                "arguments": { "bug_ids": [7] },
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": PER_REQUEST_REVISION,
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                }
+            }
+        }))
+        .send()
+        .await
+        .expect("the per-request POST must reach the server");
+    let status = response.status();
+    (status, response.text().await.expect("a body"))
+}
+
+#[tokio::test]
+async fn a_stray_mcp_param_header_is_inert_on_the_per_request_path() {
+    // #116's validate-vs-skip oracle, pinned where adoption first makes it
+    // meaningful. rmcp's `validate_request_headers` iterates only the
+    // properties a served schema ANNOTATES with `x-mcp-header`; we author
+    // none — `no_served_tool_authors_an_x_mcp_header_annotation` in
+    // server.rs keeps it that way — so the loop has nothing to iterate and a
+    // stray `Mcp-Param-*` header changes NEITHER answer: each leg is
+    // byte-identical to itself with and without one, whether `get_tool`
+    // found the schema or not. (The two legs differ from each other, of
+    // course — one is served, one refused.) That per-leg invariance is what
+    // makes the missing `RequestContext` on `get_tool` a bounded leak rather
+    // than a live one.
+    //
+    // Honest caveat: the two EQUALITY oracles below pin the SDK, not our
+    // code — no bugwarden mutant is uniquely caught by them, and their
+    // failure mode is an rmcp bump that starts rejecting or promoting
+    // unannotated `Mcp-Param-*` headers, the same genre as
+    // `a_header_only_2026_declaration_is_refused_by_the_transport`. The
+    // liveness and refusal-shape guards around them do cross our code.
+    let mock = MockServer::start().await;
+    mount_bug_for_key(&mock, world_readable_bug(7), "srv-key").await;
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock, None).await;
+
+    // Schema found. Serving it is also the liveness guard: two identical
+    // refusals would prove nothing.
+    let plain = per_request_call_with_canary(addr, "bug_info", false).await;
+    let canaried = per_request_call_with_canary(addr, "bug_info", true).await;
+    assert!(
+        plain.1.contains("a plain bug"),
+        "the schema-found leg must really be served: {plain:?}"
+    );
+    assert_eq!(
+        plain, canaried,
+        "a stray Mcp-Param-* header must change nothing for a tool with a schema"
+    );
+
+    // Schema absent. Counting upstream requests rather than matching a path
+    // prefix: `bug_info` and `create_bug` both hit `/rest/bug` with no
+    // trailing segment, so a prefix match would pass vacuously.
+    let before = mock.received_requests().await.unwrap_or_default().len();
+    let missing = per_request_call_with_canary(addr, "no_such_tool_at_all", false).await;
+    let missing_canaried = per_request_call_with_canary(addr, "no_such_tool_at_all", true).await;
+    assert!(
+        missing.1.contains("\"error\""),
+        "the schema-absent leg must be refused, not served: {missing:?}"
+    );
+    assert_eq!(
+        missing, missing_canaried,
+        "a stray Mcp-Param-* header must change nothing for a tool without one"
+    );
+    assert_eq!(
+        mock.received_requests().await.unwrap_or_default().len(),
+        before,
+        "a refused call contacts no upstream, canary header or not"
+    );
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2076,6 +2076,62 @@ wired, `server.rs` and `main.rs` are the reference.
   `ToolRouter::map` and `ToolRoute::attr` are public fields of
   `#[non_exhaustive]` structs; an rmcp upgrade that reshapes either breaks
   the build loudly rather than silently skipping the pass.
+- **rmcp trap — `x-mcp-header` is ours to author, never theirs to enable.**
+  SEP-2243's `x-mcp-header` is a schema ANNOTATION, not a server switch. The
+  CLIENT transport reads it off a served tool's `input_schema` and promotes
+  the named parameter into an `Mcp-Param-*` header
+  (`transport/streamable_http_client.rs`); the server then cross-checks that
+  header against the body before any handler runs, `tower.rs` →
+  `validate_standard_headers` → `mcp_headers::validate_request_headers` →
+  `param_header_annotations`. There is nothing to switch off: the annotation
+  only exists if bugwarden writes the key into its own schemas, so "never
+  enable it" reduces to "never author it". This is I10's mirror — I10 stops a
+  request header reaching a result; an annotation here would let a tool
+  ARGUMENT reach the transport layer — and both sit under the general rule
+  recorded above: no `_meta` key and no `Mcp-*` header may carry a security
+  decision. `no_served_tool_authors_an_x_mcp_header_annotation` (server.rs)
+  makes that structural: a substring assertion over every serialized `Tool`,
+  from the unpruned `tool_router()` AND from a maximal built server re-read
+  through `get_tool`, with the two name sets bound equal so a tool added
+  behind a new knob cannot be skipped;
+  `the_x_mcp_header_tripwire_fires_at_every_planted_position` is its canary,
+  because a walk over zero annotations passes even when gutted. The check is
+  deliberately broader than rmcp's functional read, which in 3.1.4 is
+  top-level `properties`, string-valued only (`param_header_annotations`;
+  `validate_param_header_annotations` and `reject_nested_annotations` are the
+  client-side validation, and reject the key at ANY depth — but only down
+  chained `properties`, never through `items`, `$defs` or the other
+  applicators). Those depth rules are version-specific, so the key is banned
+  at any depth and any value type. There is no upstream constant for the
+  spelling — the test declares its own — so re-grep the vendored tree for
+  `x-mcp-header` on every rmcp bump.
+
+  **The #116 record, closed here rather than fixed.** `ServerHandler::get_tool`
+  is still `fn get_tool(&self, name: &str) -> Option<Tool>` in 3.1.4: no
+  `RequestContext`, so the schema cache `tower.rs` builds for `Mcp-Param-*`
+  validation answers per DEPLOYMENT — the I13-pruned instance router, pinned
+  by `get_tool_serves_the_pruned_instance_router_i13` — and never per
+  credential. The bearer gate fronts the whole router, so no `Mcp-Param-*`
+  validation runs for an unauthenticated request. What remains is a
+  validate-vs-skip oracle: a caller sending `Mcp-Param-*` headers could in
+  principle tell a name whose schema the cache found from one it did not, by
+  the validation those headers do or do not trigger. It cannot while zero
+  annotations are served — the validation loop iterates the annotated
+  properties, of which there are none, so the headers are inert either way —
+  which is what the tripwire above keeps true, and what
+  `a_stray_mcp_param_header_is_inert_on_the_per_request_path`
+  (http_transport_wiremock.rs) pins over real http: each leg byte-identical
+  to ITSELF with and without a stray header (the two legs differ from each
+  other — one is served, one refused). That test's EQUALITY oracles pin the
+  SDK, not this code — no bugwarden mutant is uniquely caught by them, and
+  their failure mode is an rmcp bump that starts rejecting or promoting
+  unannotated `Mcp-Param-*` headers. Its liveness and refusal-shape guards do
+  cross this repo: the served leg asserts the fixture summary as bugwarden
+  renders it, the refused leg an error shape and no upstream leg. No
+  read-scope variant is worth building — `get_tool` takes only a name, so the
+  vacuity is uniform across credentials by construction.
+  Accepted as a bounded leak (validate-vs-skip only, never bug data).
+  Revisit if `get_tool` ever grows a context parameter.
 - **Every `StreamableHttpServerConfig` field is accounted for below** — set by
   name or inherited for a stated reason. `BugWarden::http_server_config()`
   (server.rs) names two; main.rs adds a third at the call site. The struct is


### PR DESCRIPTION
PR 4, the last of #34's stage-2 sequence. Closes #116. Purely additive:
310 insertions, 0 deletions.

## What it defends

SEP-2243's `x-mcp-header` is a **schema annotation, not a server switch**: the
client transport promotes annotated tool parameters into `Mcp-Param-*` headers
and the server cross-checks them. bugwarden would have to *author* it in its own
schemas for anything to happen. #34 calls it I10's mirror — I10 stops a header
reaching a result; this would let a tool **argument** reach the transport layer.

So "never enable" reduces to "never author", and this makes that structural.
The string appears nowhere in the repo; the tripwire keeps it that way.

## The check

A substring assertion on the whole serialized `Tool`, not a structural walk.
rmcp's read is a byte-exact map `get`, serde_json escapes no byte of this key,
and `Tool`'s skipped fields are `Option`s that can hold no key — so
substring-absence proves key-absence at **every** depth (`properties`, `items`,
`$defs`, output schema, prose) with no recursion arms to keep in lockstep. A
structural walk would recreate exactly the missed-position surface that produced
PR 3's M12 hole.

Deliberately broader than rmcp's functional read (top-level `properties`,
string-valued): the key is banned everywhere, any value type, because rmcp's
depth rules are version-specific.

Two dynamic loops — the config-free `BugWarden::tool_router()` superset, and a
maximal built server walked via `list_all()` **and** re-read through
`get_tool(name)`, the exact door rmcp's validation uses. An `assert_eq!` binds
their name sets so a tool added later behind a new knob breaks loudly; a review
verified that empirically by simulating one.

## Proven, not assumed

Injecting the key after `portable_schema` on `bug_info.bug_ids` fails **exactly
one** test in the suite — the tripwire. (On `bug_comments.new_since` it fails
two, because that property carries an exact-equality pin; worth knowing before
re-running the injection as written.)

The realistic authoring path works too: `#[schemars(extend("x-mcp-header" =
"X-Canary"))]` on a param field compiles under schemars 1.2.2 and lands in the
emitted schema, killed by both loops (verified independently by muting the
first).

## A vacuous assertion found, filed as #193

Declining to copy an existing no-upstream predicate into the new test surfaced
that `a_per_request_call_cannot_reach_a_tool_the_deployment_pruned_i13` (shipped
in PR 3) asserts `path().contains("/rest/bug/")` — which **can never match**,
since wiremock records `/rest/bug` with the id in the query string. A leaked
`create_bug` would POST `/rest/bug` and slip through. Review swept every suite:
isolated, not a pattern.

## #116

Closed via its **own acceptance criterion 3** — the explicit alternative to
fixing criterion 1 upstream. `get_tool` remains context-free in rmcp 3.1.4, and
DESIGN.md records the accepted bounded leak in the criterion's own words:
validate-vs-skip only, never bug data. It answers per deployment (I13-pruned)
and never per credential — `get_tool` takes only a name, which is why no
read-scope test variant was built and the argument is recorded instead.

## Review

Two Fable lenses: mechanism MERGE-SAFE, prose NOT MERGE-SAFE on three, all fixed.
All three were false statements about rmcp or about the tests' own reach —
including one, "no bugwarden mutant can fail it", that came from my brief and
was disproved by the test's own liveness guard. The implementer then found a
**fourth** instance neither lens flagged, a paragraph from one of them.

Test C is labelled honestly as pinning the SDK rather than our code: its
equality oracles are the executable witness for the vacuity claim #116's closure
rests on, while its liveness and refusal-shape guards do cross this repo.

## Verification

All eight AGENTS.md commands re-run independently: green, 665 tests, 0 failed.
No `gen` leg needed — that feature gates only the `bugwarden-gen` bin and no
`feature = "gen"` cfg exists in any source file. The pre-existing `get_tool`
pin (`get_tool_serves_the_pruned_instance_router_i13`) was confirmed rather than
duplicated.
