### PR TITLE
test(server): make the I13 per-request no-upstream check falsifiable

### DIFF
--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -1771,13 +1771,29 @@ async fn a_per_request_call_cannot_reach_a_tool_the_deployment_pruned_i13() {
         "the read tool is served: {served}"
     );
 
+    // Count the delta, never match a path: both tools hit `/rest/bug` with no
+    // trailing segment, so the old `contains("/rest/bug/")` was vacuous (#193).
+    // A leak shows up as create_bug's refused-path padding classify
+    // (`GET /rest/bug?id=0`): drop that padding and only byte-identity still
+    // catches a prune regression.
+    let before = mock.received_requests().await.unwrap_or_default().len();
     let mut answers = Vec::new();
     for name in ["create_bug", "no_such_tool_at_all"] {
         let response = per_request_post(
             addr,
             None,
             "tools/call",
-            json!({ "name": name, "arguments": {} }),
+            // Schema-valid for `create_bug`, same literal for both names: with
+            // `{}` a leaked dispatch dies at parse and the count cannot move.
+            json!({
+                "name": name,
+                "arguments": {
+                    "product": "P",
+                    "component": "C",
+                    "summary": "S",
+                    "version": "V"
+                }
+            }),
             None,
         )
         .await;
@@ -1793,11 +1809,9 @@ async fn a_per_request_call_cannot_reach_a_tool_the_deployment_pruned_i13() {
         "and both must be REFUSED, not two identical successes: {:?}",
         answers[0]
     );
-    let upstream = mock.received_requests().await.unwrap_or_default();
-    assert!(
-        upstream
-            .iter()
-            .all(|r| !r.url.path().contains("/rest/bug/")),
+    assert_eq!(
+        mock.received_requests().await.unwrap_or_default().len(),
+        before,
         "no unrouted call may reach Bugzilla"
     );
 }
@@ -1842,13 +1856,15 @@ async fn a_per_request_denial_is_uniform_with_a_nonexistent_bug_i2() {
             None,
         )
         .await;
+        let status = response.status();
         let body = response.text().await.expect("a body");
         assert!(
             body.contains(&format!("Bug {id} is not accessible through this server")),
             "the uniform denial text, for bug {id}: {body}"
         );
-        // Only the id the caller already knows may differ.
-        answers.push(body.replace(&format!("Bug {id} "), "Bug _ "));
+        // Only the id the caller already knows may differ; status included so a
+        // status-only distinguisher cannot hide behind equal bodies.
+        answers.push((status, body.replace(&format!("Bug {id} "), "Bug _ ")));
     }
     assert_eq!(
         answers[0], answers[1],


### PR DESCRIPTION
Fixes #193. **Closes #34** — this completes its last acceptance criterion.

## Two defects, not one

`a_per_request_call_cannot_reach_a_tool_the_deployment_pruned_i13` asserted that
a refused call reached no upstream via `path().contains("/rest/bug/")`.

**(a) The predicate could never match.** wiremock records `/rest/bug` — the id
travels in the query string. Both tools the test exercises hit exactly that:
`bug_info` GETs `/rest/bug?id=7`, `create_bug` POSTs `/rest/bug`. Only id-in-path
endpoints would contain the trailing slash, and none is reachable here.

**(b) Found while planning the fix: the arguments made even a correct predicate
unfalsifiable.** The refusal loop sent `"arguments": {}`, and `CreateBugParams`
requires four fields with no serde defaults — so rmcp deserializes
`Parameters<CreateBugParams>` *before* the handler body and a leaked dispatch
dies at parse (-32602) without contacting anything. Fixing the predicate alone
would have shipped a second assertion that cannot fail.

## The fix

A before/after `received_requests().len()` delta, snapshotted after the served
liveness leg, plus schema-valid arguments — the same literal for both names, so
the tool name stays the only variable. `is_empty()` was unavailable: the served
leg has already cost three upstream requests, and removing it to make the mock
empty would destroy the guard that stops two identical failures proving nothing.

Counting beats matching either shape. Under read-only, a leaked `create_bug` is
refused by the guard and burns the **padding classify** `GET /rest/bug?id=0` —
not the POST anyone would predict. A count is blind to which.

Also tightens the I2 sibling to compare `(status, body)`. Declared honestly as
**defensive, not mutation-proven**: on this transport the SSE framing covaries
with the status, so equal bodies force equal statuses and no mutation fires the
status half alone.

## Proof, because a fix to an unfalsifiable assertion must not be one

With the read-only prune disabled in `BugWarden::new`:

| step | result |
|---|---|
| full test | fails at byte-identity (guard denial vs `tool_not_found`) |
| byte-identity suspended | **count assert dies alone, `left: 4, right: 3`** |
| same, with the old `arguments: {}` | count assert **survives** — the argument change is load-bearing |
| **HEAD's old predicate, same live leak** | **passes** — #193 demonstrated, not argued |

That last control was not in the plan. Without it the protocol shows only that
the new assert *can* fail, not that it beats what it replaced over the same leak.

Review then tried to break it, and could only do so with a **compound** mutation
(prune-disable *plus* removing the padding classify), where the count goes blind
but byte-identity still catches the leak. It established that no *single*
mutation reaches upstream without moving the count — wiremock records under the
state lock before responding, there is no retry layer, no background upstream
work, and every fetch is awaited. The two assertions have a real division of
labour: the count catches leaks that reach Bugzilla, byte-identity catches leaks
that do not.

That coupling — the count's visibility depends on the refused path issuing the
padding classify — is now noted in the test itself, not only here.

## Closing #34

Its seven acceptance criteria were re-verified against shipped code by an
independent review, not against PR bodies. Six were already discharged; criterion
7 ("I13 and I2 re-tested under the stateless lifecycle") was the one met partly
by argument, and is what this completes. The issue body carries the full walk.

That review also caught an error in my walk: the listing-path hole was closed by
**PR 3** (`80dda84`), not PR 4 — PR 4 only re-confirmed the pre-fix baseline.
Corrected in the issue.

Three items outlive the epic and have homes: **#204** (ask upstream whether rmcp
intends the pre-2026-plus-both-keys routing — filing it needs Martin's go-ahead),
**#182** (re-scoping now that v2 shipped undecided), and the
`stateless_protocol_metadata_required` revisit, which lives in DESIGN.md's config
inventory with its rationale and revisit criterion.

## Verification

All eight AGENTS.md commands re-run independently on the final commit: green.
