### PR TITLE
test(server): make http_transport_wiremock's prose match the file

### DIFF
--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -1,11 +1,18 @@
-//! End-to-end tests of API key custody over REAL streamable HTTP.
+//! End-to-end tests of the streamable-HTTP transport: what holds only once
+//! a request has crossed a real socket. API key custody is one such
+//! property, not the file's subject — it also pins Host validation, the
+//! 2026-07-28 handshake-free lifecycle, the audit session anchor, the
+//! per-revision cache hints, `_meta` propagation into the audit record, the
+//! POST body cap, the identity `server/discover` answers with, and guard
+//! parity with stdio.
 //!
-//! Each test builds a [`BugWarden`] with `--transport http`, serves it over
-//! an actual TCP listener through `StreamableHttpService`, and connects an
-//! rmcp client through reqwest — the only harness in which the per-request
-//! key header physically exists. The wiremock upstream plays Bugzilla; the
-//! key reaches it as the `api_key` query parameter, so a `query_param`
-//! matcher proves WHICH key served a request.
+//! A test builds a [`BugWarden`] with `--transport http` and serves it over
+//! an actual TCP listener through `StreamableHttpService`, wiremock playing
+//! Bugzilla; the one startup-error leg stops at `http_server_config` and
+//! binds nothing. The client is whatever the property needs: an rmcp client
+//! through reqwest, raw reqwest where the wire shape is itself the point
+//! (the handshake-free lifecycle, the minted session id), or a raw TCP
+//! socket for the body cap, whose 413 lands mid-write.
 //!
 //! Coverage contract (each of these mutations must fail at least one test):
 //! - server-held mode falling back to the client's header when one is sent;
@@ -28,9 +35,12 @@
 //! - handing an unparsable `--allowed-hosts` entry (`*`, a URL) to rmcp
 //!   instead of refusing it at `http_server_config`;
 //! - the POST body cap going back to a fixed value, which refuses uploads
-//!   the operator's `global.max_attachment_bytes` permits, or losing its
-//!   4 MiB floor, which would let a policy shrink the transport's memory
-//!   bound (or remove it entirely at `0`);
+//!   the operator's `global.max_attachment_bytes` permits (losing the
+//!   4 MiB floor is NOT killed here: the default 2 MiB cap derives
+//!   3,844,780 bytes, still under the 5 MiB probe, so that leg's 413
+//!   stands with or without the clamp — the floor and its `0` case are
+//!   killed by the `max_request_body_bytes` unit tests in server.rs
+//!   instead);
 //! - `session_info` taking the audit `session.id` from the `mcp-session-id`
 //!   REQUEST header again, which leaves every `initialize` record without
 //!   the id that would join it to its own session and lets a stateless
@@ -147,6 +157,9 @@ async fn serve_http(
 /// Connect an MCP client to `addr` over streamable HTTP. With
 /// `header_value`, every request carries `ApiKey: <value>` (a reqwest
 /// default header); without, no key header exists anywhere in the session.
+/// That distinction is what the custody tests turn on, and only http can
+/// draw it: stdio resolves one key at startup and carries no per-request
+/// header at all.
 async fn connect(addr: SocketAddr, header_value: Option<&str>) -> RunningService<RoleClient, ()> {
     let mut builder = reqwest::Client::builder();
     if let Some(value) = header_value {
@@ -719,8 +732,10 @@ async fn discover_names_this_build_and_reaches_nothing_else() {
         "the SDK's discover serves cacheScope unconditionally: {body}"
     );
     // It answers `get_info` and nothing else: no tool, no guard, no
-    // upstream. That is what makes an unauthenticated pre-request surface
-    // acceptable while #32 is open.
+    // upstream. Says nothing about auth: this harness serves the bare
+    // router, while `main` wraps that router in the bearer gate — which
+    // `server/discover` needs like any other request (DESIGN.md, "HTTP
+    // bearer authentication"), and which http_auth_wiremock.rs pins.
     let upstream = mock.received_requests().await.unwrap_or_default();
     assert!(
         upstream.is_empty(),


### PR DESCRIPTION
Closes #174, #184, #179 — three stale claims in one test file's own
documentation. Prose only: stripping comments from both revisions yields
byte-identical code.

## What was false

**#184** — the header claimed every test "connects an rmcp client through
reqwest" for API-key custody. Recounted from the file: **29 tests, of which 5
are key custody**, and only **7** touch the rmcp client at all. The rest drive
raw reqwest or a raw TCP socket.

**#174** — a coverage bullet claimed the file guards against "losing its 4 MiB
floor". It cannot: default `max_attachment_bytes` is 2 MiB, so the derivation
yields 3,844,780 — below the 5 MiB probe — and the 413 stands either way.
Annotated as killed in `server.rs` instead, matching the neighbouring
`context.meta` bullet's existing form.

**#179** — called `server/discover` an unauthenticated pre-request surface
"while #32 is open". #32 closed; the gate wraps the whole router. The fact that
makes the fix truthful: `serve_http` never wires `guard_router` at all, so
nothing in this file could demonstrate either property.

## Three the issues did not know

- The note being relocated was **itself false**: `http_auth_wiremock.rs` also
  runs per-request custody, so this is not "the only harness where the header
  exists". Narrowed to the transport-level claim, which no future harness can
  re-falsify.
- A **fifth** false clause nobody had filed: "Each test … serves it over an
  actual TCP listener" — `an_unparsable_allowed_hosts_entry_is_a_startup_error`
  binds nothing.
- **#184's own inventory was stale** when picked up, since #189/#192/#205 added
  tests after it was filed — a small demonstration of the defect it describes.

## Deliberately not fixed

The coverage contract still omits about a third of the file. Its preamble is
one-directional — an omitted bullet asserts nothing — so this is incomplete
rather than false, and adding unverified bullets inside a prose-truth commit is
how #174's defect returns. Follow-up filed instead.

Review: MERGE-SAFE. Every replacement re-derived from the file, and each is
worded to resist the drift that falsified its predecessor — no counts in the
header, transport-level rather than harness-level uniqueness, elsewhere-kills
named by test family rather than by line number.
