### PR TITLE
ci: lint the workflows with actionlint

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,55 @@
+---
+name: actionlint
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs, but let main runs finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  actionlint:
+    # Workflow syntax, expression and `run:` shell checks over
+    # .github/workflows/. Its own workflow, not a ci.yml job: a malformed
+    # ci.yml is one of the things this has to report, and GitHub runs no job
+    # from a workflow it cannot parse. No .github/actionlint.yaml: the
+    # defaults pass on every workflow here as it stands.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install actionlint
+        # Upstream ships no action, so the pin is the release tarball's
+        # digest (from actionlint_<version>_checksums.txt) rather than a
+        # commit SHA — it binds the binary, which a pinned download script
+        # would not. Dependabot cannot see this pin: bump both env values
+        # together, by hand.
+        shell: bash
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  # linux_amd64
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP"
+          curl -fsSL --retry 3 -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
+      - name: Lint workflows
+        # actionlint drops a rule whose external tool is missing and still
+        # exits 0. Its embedded shellcheck is most of the value here, so
+        # assert the binary rather than trust the runner image to keep it.
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$RUNNER_TEMP/actionlint" -version
+          shellcheck --version
+          "$RUNNER_TEMP/actionlint" -color


### PR DESCRIPTION
Closes #195. One new workflow file.

## Why

`Analyze (actions)` scans workflows for security anti-patterns, not YAML
validity or shell correctness. A malformed `ci.yml` self-blocks harmlessly.
**`release.yml` has no such net** — ~16K of YAML and bash, running only on a tag
push, which AGENTS.md calls irreversible.

Honest limit: the three workflow defects this repo actually shipped (#137, #160,
#102) were semantic. actionlint would have caught none. What it buys is tag-time
bash safety, currently zero.

## Two design choices that differ from the issue

**Digest-pinned tarball, not the suggested download-script-by-commit.** Pinning
the script does not bind the binary — the script fetches from the same release
endpoint at runtime, so a compromised release serves both. Upstream ships no
action to SHA-pin (`action.yml` 404s at the tag). Cost, recorded at the pin site:
Dependabot cannot see it and it needs manual bumps. Reviewed and endorsed — rot
here is self-limiting (an old actionlint misses checks, forcing the bump), an
unbound binary is silent.

**Separate workflow, not a `ci.yml` job.** GitHub runs no job from a workflow it
cannot parse, so a job inside `ci.yml` could never report on a PR that malforms
`ci.yml`. No `paths:` filter, deliberately — one would make the context
permanently pending once required, the failure mode that keeps bare `CodeQL` out
of branch protection.

## shellcheck silently no-ops, so the step asserts it

With shellcheck off `PATH`, actionlint finds **zero** issues in a tree that has
one and **exits 0**. The step runs `shellcheck --version` first under
`set -euo pipefail`; verified to exit 127 before the lint.

## Verified

Four injected defects each reported and exit 1: SC2086 in a `release.yml` run
block (the tag-costing class, caught only via shellcheck), unparsable YAML, an
undefined `github.event_nam`, an unknown runner label. Pristine tree: exit 0
across all six workflows, no config, no suppressions added.

No `continue-on-error`, no `if: always()`, no `|| true` — a finding reddens the
check. That matters because #160 shipped an inert leg, which is the class this
helps catch.

## Two things it surfaced

- `release.yml`'s pre-existing `# shellcheck disable=SC2046` was hand-audit
  documentation; this change makes it **load-bearing** — deleting it now fails
  the lint.
- `release.yml:3` carries `# yamllint disable-line rule:truthy` for a linter
  wired in nowhere. Vestigial; left for a follow-up rather than smuggled in.

Not in branch protection — Martin adds the context.
