### PR TITLE
docs: name the container image in AGENTS.md's releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,11 @@ A release is one push of an annotated tag; nothing is released by hand.
   finally the crates.io publish — `bugwarden-core` before `bugwarden`,
   because the binary crate resolves its dependency from the index and cannot
   be packaged before core is there.
+- The same tag also ships the multi-arch container image
+  `ghcr.io/plusky/bugwarden` (jobs `container`, `container-manifest`).
+  `container` is a sibling of `publish`, not upstream of it — a broken image
+  build must not hold back the crates.io release of a tag whose binaries
+  already shipped.
 - The `.deb`/`.rpm` come from `cargo-deb` and `cargo-generate-rpm`, both
   pinned to an exact version and installed `--locked`, reading
   `[package.metadata.deb]` / `[package.metadata.generate-rpm]` in


### PR DESCRIPTION
Closes #172.

AGENTS.md said `release.yml` "does everything:" and listed everything except the
container build. `grep -i 'ghcr\|container\|image' AGENTS.md` returned nothing —
the contract file agents are told to follow did not mention a shipped, publicly
consumable artifact.

Five lines naming `ghcr.io/plusky/bugwarden` and the one non-obvious fact the
job graph encodes: `container` is a **sibling** of `publish`, not upstream of
it, so a broken image build must not hold back the crates.io release of a tag
whose binaries already shipped.

Verified against `release.yml`, not the issue text — image name, the amd64/arm64
matrix, and the `needs:` graph (`container` needs `[release, toolchain-drift]`,
`publish` needs `[release]`; neither depends on the other).

Scope deliberately narrow per the issue's 2026-08-30 amendment: no tag
semantics, no manifest mechanics, no container section.

The pre-existing "and finally the crates.io publish" is left alone. It stays
true of the leg it enumerates, and the new bullet's "The same tag *also*
ships…" cures the exhaustiveness misreading that was the actual complaint.

Review: MERGE-SAFE, no findings.
