### PR TITLE
build: scan the gen-only deps with cargo-deny

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,8 @@ jobs:
         with:
           manifest-path: Cargo.toml
           command: check
-          # Empty arguments: do not force --all-features.
+          # Empty arguments: the action defaults to --all-features;
+          # deny.toml's [graph] owns feature selection instead.
           arguments: ""
 
   rust-msrv:

--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,9 @@
 # workspace Cargo.toml.
 
 [graph]
-all-features = false
+# `gen` is off by default but its output (man page, completions) ships in the
+# .deb/.rpm, so the gen-only deps must be scanned too.
+all-features = true
 no-default-features = false
 
 [advisories]


### PR DESCRIPTION
Closes #199.

`deny.toml` had `all-features = false`, so `clap_complete` and `clap_mangen` sat
outside advisory, licence, bans and sources scanning — while the `gen` tool runs
in CI and its output (man page, completions) **ships inside the `.deb` and
`.rpm`**. bugwarden distributed artifacts built by dependencies its own
supply-chain gate never inspected.

Clean flip: advisories/bans/licenses/sources all ok, no exception needed. The
graph gains three crates, not two — `roff` comes along as clap_mangen's
dependency.

## Verified by probe, not by reading the config

`cargo deny list` **ignores** `[graph].all-features` — it reports the same crate
set either way, and only the `--all-features` CLI flag moves it. `check` honours
the config. So `list` is not a valid way to confirm this change, and anyone
re-checking it that way will wrongly conclude the flip is inert.

The A/B probe that does work: temporarily ban `clap_mangen`. Before, `bans ok`.
After, `error[banned]: crate 'clap_mangen = 0.3.3' is explicitly banned`. Both
probe edits reverted; committed `deny = []` unchanged.

## The ci.yml comment was hiding an asymmetry

It read "Empty arguments: do not force `--all-features`". The action's
`arguments` input **defaults to** `--all-features` (confirmed at the pinned
SHA), so the empty value was the only thing keeping CI from scanning the wider
graph. Rewritten: the config now owns feature selection, and both paths scan the
same graph.

Review: MERGE-SAFE, no findings.
