### PR TITLE
docs(server): module docs live in //!, never on the mod declaration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,11 @@ are never a justification for undoing them.
   cloning to resolve a lifetime issue by default.
 - Public items need rustdoc that explains purpose, relevant errors, and
   behavioral constraints. Keep crate documentation accurate.
+- Module docs live in the module's own `//!`, never as a `///` on the `mod`
+  declaration: one outer line there makes rustdoc resolve the *whole* merged
+  block's intra-doc links in the parent scope, and the `unresolved link` error
+  prints no file or line — only the offending doc text, which is the module's,
+  never `lib.rs`.
 - Return errors with actionable context (`anyhow` with context in the
   core crate). Do not use `unwrap`, `expect`, or panics in recoverable
   production paths.

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -1,3 +1,5 @@
+//! Operator-facing audit event stream: record schema and JSONL file sink.
+//!
 //! bugwarden places an operator-written guard policy between an MCP client
 //! and Bugzilla. On the client side that guard is invisible by design: a
 //! hidden bug is indistinguishable from a nonexistent one, filtered search

--- a/crates/bugwarden/src/lib.rs
+++ b/crates/bugwarden/src/lib.rs
@@ -8,14 +8,10 @@
 //! as a unit. The supported product remains the `bugwarden` binary; this
 //! API carries no stability promise of its own.
 
-/// Operator-facing audit event stream: record schema and JSONL file sink.
 pub mod audit;
 pub mod config;
-/// Bearer authentication for the streamable-HTTP transport.
 pub mod http_auth;
 pub mod http_session;
-/// OTLP export of the audit stream (load-bearing) and of the server's
-/// own diagnostics (best-effort).
 pub mod otel;
 pub mod server;
 


### PR DESCRIPTION
Closes #183.

Drops the `///` lines from `pub mod audit`, `http_auth` and `otel` in `lib.rs`
(moving audit's one non-redundant sentence into its own `//!`), and records the
rule in AGENTS.md.

## The issue's central claim was wrong, and the truth is worse

It said those three pass "only because their `///` lines happen to contain no
intra-doc links". They don't. A **link-free `///` still breaks** the module's
inner links — one outer line flips the whole merged block to parent-scope
resolution. Confirmed by an independent three-leg repro on the pinned toolchain
and reproduced in-repo both ways.

They actually pass because **every link in those modules is `crate::`-qualified**
— reference blocks at `audit.rs:97-106` and `otel.rs:52-56`, inline in
`http_auth.rs`.

So the severity was understated. The routine hazard is not someone adding a link
to a `///` line (rare); it is someone writing an ordinary unqualified link in a
module's own `//!` (normal), right next to a qualified one that works.

The `///` arms the trap; the unqualified link springs it.

## The diagnostic gives you nothing to go on

Verified on rustc 1.98.0: the error prints **no file or line span at all** — just
`the link appears in this line` and the quoted doc text, which is the module's,
never `lib.rs`. An earlier draft of the rule said the error "blames the module's
file", claiming a span rustc does not emit; corrected.

## Not done

The `crate::`-qualified reference blocks are partly a workaround this bug forced
and are now unnecessary. Removing them is cosmetic churn outside this issue's
scope — a possible follow-up.

Review: MERGE-SAFE. Central claim independently confirmed.
