### PR TITLE
ci: run the advisory check on a schedule

### DIFF
--- a/.github/workflows/advisories.yml
+++ b/.github/workflows/advisories.yml
@@ -1,0 +1,49 @@
+---
+name: advisories
+on:
+  schedule:
+    # Weekly like codeql, in a different slot; off the hour, since the top of
+    # one is GitHub's most contended and most-dropped minute.
+    - cron: '47 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  # No PR event to supersede here: let a hand-fired run finish rather than
+  # have the next cron cancel it.
+  cancel-in-progress: false
+
+jobs:
+  advisories:
+    # `cargo deny check advisories` against a freshly fetched advisory-db.
+    # Config: deny.toml, same file ci.yml's rust-deny uses.
+    #
+    # Its own workflow, not a `schedule:` on ci.yml: that trigger is
+    # workflow-level and would run every ci.yml job weekly. And deliberately
+    # NOT the gating rust-deny job — keep this off the required contexts, so
+    # a RustSec advisory published today fails here rather than reddening
+    # main or whichever stranger's PR arrives next.
+    #
+    # Surfacing is GitHub's failed-run email to the repo owner. Nothing
+    # pages, nothing files an issue. GitHub also disables crons after 60 days
+    # of repo inactivity, so silence is not by itself proof of a clean tree.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: cargo-deny (advisories)
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25  # v2
+        with:
+          manifest-path: Cargo.toml
+          command: check
+          # `arguments` land before the subcommand, `command-arguments`
+          # after it — the check name is the latter. Empty arguments: the
+          # action defaults to --all-features; deny.toml's [graph] owns
+          # feature selection instead.
+          arguments: ""
+          command-arguments: advisories


### PR DESCRIPTION
Closes #197. One new workflow file.

`rust-deny` fires only on push/PR, so a fresh RustSec advisory waits and then
fails **whichever stranger's PR arrives next**, in a job unrelated to their
change. Weekly advisories-only run, separate from the gating job so a new
advisory never retroactively reddens a contributor's PR.

`schedule` + `workflow_dispatch` only — cannot become a PR check, and is not in
branch protection.

## Two limits on its value, both documented in-file

- **Email surfacing is settings-dependent**, not automatic: GitHub notifies only
  if Actions notifications are enabled, and for a cron the recipient is whoever
  last edited the cron line.
- **GitHub disables scheduled workflows after 60 days of repository inactivity**
  (this repo is public, so it applies). **Silence from this job is not evidence
  of a clean tree.** No keepalive added — that needs `contents: write` and dummy
  commits, against this repo's permissions posture.

## Verified

`cargo deny check advisories` clean today. Forced failure via a fabricated
RUSTSEC entry in a local db copy: `advisories FAILED`, exit 1 — reproduced
independently by review. The action invocation was checked at the pinned SHA:
the entrypoint composes `<arguments> <command> <command-arguments>`, so the
check name belongs in `command-arguments`.

`concurrency` deliberately diverges from the house pattern (`group:
${{ github.workflow }}`, `cancel-in-progress: false`): the ref key is a no-op for
a cron, and cancelling would let the weekly run kill a hand-fired one. `codeql.yml`
has no concurrency block at all — the brief was wrong about that.

`cargo-audit` stays rejected as redundant with cargo-deny (#169).

Review: MERGE-SAFE.
