### PR TITLE
ci: make the canary toolchain jobs mirror the rust job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,19 @@ jobs:
           esac
       - name: Clippy (beta)
         run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Doc (beta)
+        # The rustdoc gate is -D warnings so it picks up future
+        # warn-by-default rustdoc lints by itself; without a leg here the
+        # first one to land fires in the required `rust` job instead.
+        # Per-step env, like that job: job-level would leak into a doctest
+        # collection.
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --workspace --no-deps --document-private-items --locked
+      - name: Doc (beta, gen tool)
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc -p bugwarden --features gen --no-deps --document-private-items --locked
       - name: Test (beta)
         run: cargo test --workspace --all-targets --locked
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
           arguments: ""
 
   rust-msrv:
-    # Build with the minimum supported Rust version (rust-version in
+    # Compile with the minimum supported Rust version (rust-version in
     # Cargo.toml) so MSRV cannot silently drift.
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -223,8 +223,16 @@ jobs:
               exit 1
               ;;
           esac
-      - name: Build (MSRV)
-        run: cargo build --workspace --locked
+      - name: Check (MSRV)
+        # --all-targets, not a build: an MSRV break in test code or a
+        # dev-dependency otherwise passes here and only bites a contributor
+        # on the MSRV when they run AGENTS.md's verification block.
+        run: cargo check --workspace --all-targets --locked
+      - name: Check (MSRV, gen tool)
+        # --all-targets skips bins whose required-features are off, and that
+        # block compiles the generator too; same split as the rust job's
+        # clippy/doc legs.
+        run: cargo check -p bugwarden --features gen --all-targets --locked
 
   rust-assets-drift:
     # Regenerate the committed man page + shell completions from the clap CLI


### PR DESCRIPTION
Closes #200, #177. Two commits, same defect class: an early-warning job covering
less than the required `rust` job.

## #200 — `rust-msrv` built but did not check tests

`cargo build --workspace --locked` → `cargo check --workspace --all-targets
--locked`. An MSRV break in test code or a dev-dependency previously passed CI
and bit a contributor on 1.88 the moment they ran AGENTS.md's verification
block.

**Plus a `--features gen` leg the issue did not ask for.** `bugwarden-gen` has
`required-features`, so neither the old build nor the new check reaches it —
verified with `--message-format=json`: leg 1 emits artifacts for both libs, the
bin and all 17 test targets, and **zero** for `bugwarden-gen`. The generator and
`clap_mangen`/`clap_complete` were outside every MSRV assertion in the repo,
while AGENTS.md compiles them twice.

**Proven on a real 1.88.0**: a post-MSRV API in a test file passes `build`
(exit 0) and fails the new check (E0658, exit 101).

**The issue's "expect it to fail the first time" was wrong** — both legs are
green today. But no package in the graph declares `rust-version` above 1.88 and
three sit exactly on it (`rmcp` 3.1.4, `rmcp-macros`, the `darling` family), so
the next rmcp bump raising it will fail this job. That is the job working.

Deliberate trade, disclosed: `check` drops codegen on the MSRV. Review
constructed a class it misses (post-monomorphization const-eval) but could not
make it MSRV-specific; the front end — where MSRV breaks overwhelmingly live —
is fully covered, and the workspace is still built and linked on the pin by
`rust`, `rust-macos`, docker and release.yml.

## #177 — `rust-beta` had no doc legs

The rustdoc gate is `-D warnings` precisely so it **auto-adopts** future
warn-by-default rustdoc lints. Without beta legs, the first one to land fires in
the **required** `rust` job on someone's toolchain-bump PR — the surprise
`rust-beta` exists to absorb.

Asymmetry verified: a broken intra-doc link exits 0 under plain `cargo doc`,
101 with `RUSTDOCFLAGS`. `RUSTDOCFLAGS` is per-step, as in the `rust` job;
`rust-beta`'s job env holds only `RUSTUP_TOOLCHAIN: beta` and the keys merge, so
it is not displaced — which matters, since displacing it would silently re-test
1.98. (The issue mis-names it `RUSTOOLCHAIN`.)

Review: MERGE-SAFE. Both commits touch only `ci.yml` and are independently green.
