### PR TITLE
ci: make the toolchain-drift guard see every rust stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,15 +303,20 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          tags="$(sed -n 's/^FROM rust:\([0-9][0-9.]*\)-alpine.*/\1/p' Dockerfile)"
+          # Any rust stage a per-line pattern can catch: indented, lowercase,
+          # --flag=value, registry-qualified, any tag, a bare digest, or none
+          # (`T` drops non-matches; an untagged stage is the rust:latest it
+          # really is). ARG indirection and continuations stay out of reach.
+          tags="$(sed -nE 's/^[[:space:]]*FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*([^[:space:]]*\/)?rust([:@]([^[:space:]]+))?([[:space:]].*)?$/\4/I; T; s/^$/latest/; p' Dockerfile)"
           channel="$(sed -n 's/^channel = "\([^"]*\)".*/\1/p' rust-toolchain.toml)"
           if [ -z "$tags" ] || [ -z "$channel" ]; then
             echo "::error::cannot read the Rust version: Dockerfile FROM tags '$tags', rust-toolchain.toml channel '$channel'"
             exit 1
           fi
-          # Check every rust stage, so a second one cannot drift past the guard.
+          # Check every stage found above, so a second one cannot drift past.
           while IFS= read -r tag; do
-            if [ "$tag" != "$channel" ]; then
+            tag="${tag%%@*}"  # the digest pins the image, not the toolchain
+            if [ "${tag%%-*}" != "$channel" ]; then
               echo "::error::toolchain drift: Dockerfile builds on rust:$tag but rust-toolchain.toml pins channel $channel -- bump both together"
               exit 1
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,15 +261,20 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          tags="$(sed -n 's/^FROM rust:\([0-9][0-9.]*\)-alpine.*/\1/p' Dockerfile)"
+          # Any rust stage a per-line pattern can catch: indented, lowercase,
+          # --flag=value, registry-qualified, any tag, a bare digest, or none
+          # (`T` drops non-matches; an untagged stage is the rust:latest it
+          # really is). ARG indirection and continuations stay out of reach.
+          tags="$(sed -nE 's/^[[:space:]]*FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*([^[:space:]]*\/)?rust([:@]([^[:space:]]+))?([[:space:]].*)?$/\4/I; T; s/^$/latest/; p' Dockerfile)"
           channel="$(sed -n 's/^channel = "\([^"]*\)".*/\1/p' rust-toolchain.toml)"
           if [ -z "$tags" ] || [ -z "$channel" ]; then
             echo "::error::cannot read the Rust version: Dockerfile FROM tags '$tags', rust-toolchain.toml channel '$channel'"
             exit 1
           fi
-          # Check every rust stage, so a second one cannot drift past the guard.
+          # Check every stage found above, so a second one cannot drift past.
           while IFS= read -r tag; do
-            if [ "$tag" != "$channel" ]; then
+            tag="${tag%%@*}"  # the digest pins the image, not the toolchain
+            if [ "${tag%%-*}" != "$channel" ]; then
               echo "::error::toolchain drift: Dockerfile builds on rust:$tag but rust-toolchain.toml pins channel $channel -- bump both together"
               exit 1
             fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Pinned to the channel in rust-toolchain.toml, which this stage never COPYs —
 # so a floating `rust:1` would silently build releases with an unpinned
-# compiler. Bump this tag and rust-toolchain.toml together; ci.yml's
+# compiler. Bump this tag and rust-toolchain.toml together; the
 # toolchain-drift job fails when they disagree.
 FROM rust:1.98.0-alpine@sha256:a10e64dd139b7387337c7fbe8aca31b959b57b2fd4c8ae20a02cf1d6ea424dce AS build
 # gcc and musl-dev are already in the base; aws-lc-sys (the rustls crypto

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Pinned toolchain for reproducible local checks. Keep in sync with the CI
 # toolchain inputs that name this channel (rust-msrv and rust-beta
-# deliberately differ) and with the Dockerfile's rust tag, which ci.yml's
+# deliberately differ) and with the Dockerfile's rust tag, which the
 # toolchain-drift job compares against this channel; the workspace MSRV
 # (rust-version in Cargo.toml) is a separate, lower bound.
 [toolchain]


### PR DESCRIPTION
Closes #171.

The guard's sed matched only `^FROM rust:N.N-alpine` — unindented, uppercase,
flagless — while its comment claimed "Check every rust stage, so a second one
cannot drift past the guard". An added stage in any other shape printed
**"in sync"**.

## What was invisible

The issue listed five shapes. Three more were equally invisible:
registry-qualified (`docker.io/library/rust:…`), non-numeric (`rust:stable`, an
unexpanded ARG), and digest-only. All eight now fail closed.

## The fix the review suggested would have re-armed the bug

Making the tag group optional emits an **empty line** for a tagless stage. When
that stage is the last rust `FROM` — the normal case for an appended second
stage — the empty line is trailing, and `$(...)` strips trailing newlines, so
the entry vanishes before the loop runs. Silent pass, with a regex that looks
correct.

Committed form uses `T` to drop non-matching lines without printing, and maps a
tagless stage to the `rust:latest` it actually resolves to:

```sh
sed -nE 's/^[[:space:]]*FROM[[:space:]]+(--[^[:space:]]+[[:space:]]+)*([^[:space:]]*\/)?rust([:@]([^[:space:]]+))?([[:space:]].*)?$/\4/I; T; s/^$/latest/; p'
```

Bare `FROM rust` was the blocking finding: it is `rust:latest`, a floating
compiler — the exact failure the Dockerfile's own comment names — and `rust:1`
was caught while bare `rust` was not.

## Verified

28-case shape table, script extracted from the committed YAML. Every listed
shape plus the three additions plus four tagless forms: old exit 0 "in sync" →
new exit 1 with the tag echoed. No false positives on `rustacean-image:1.0`,
`notrust:1.0`, `alpine:3.20`, or a commented-out `FROM`. `-z` fail-closed
intact; missing Dockerfile still exit 2.

**Byte-identity of the two copies** re-verified by hashing the YAML-parsed `run:`
bodies: both `73fc65ea…`. actionlint and shellcheck clean.

## Honest about the limit

The comment now claims only what a per-line tool can: line continuations, `ARG`
indirection and `COPY --from=` stay out of reach, and they are named in the
commit body rather than papered over. That is the overclaim this issue existed
to fix, so re-committing it would have been the same defect.

Folded in: `Dockerfile` and `rust-toolchain.toml` said "ci.yml's toolchain-drift
job" — still true, incomplete since #170 added the second copy.
