### PR TITLE
ci: guard DESIGN.md's rmcp version stamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,74 @@ jobs:
           done <<< "$tags"
           echo "in sync: Dockerfile rust:$channel == rust-toolchain.toml channel $channel"
 
+  design-stamp-drift:
+    # docs/DESIGN.md hard-stamps the pinned rmcp version in registry-path,
+    # macro-crate, git-tag and prose shapes -- including one line that names
+    # the version with no `rmcp` token on it at all -- and #135 exists because
+    # a bump landed and they went stale. A sibling job rather than a leg of
+    # toolchain-drift: that one has a deliberate twin in release.yml gating the
+    # image push, where a docs stamp has no business. Same reason it skips the
+    # `changes` filter: it is four one-line extractions, and paths-filter
+    # would skip it on a tag push.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Compare DESIGN.md version stamps with Cargo.lock's rmcp
+        shell: bash
+        run: |
+          set -euo pipefail
+          # In a lock entry version always follows name, so `n` fails closed if
+          # that shape ever changes. Two rmcp entries would be ambiguous, so
+          # anything but exactly one line is an error, not a pick.
+          lock="$(sed -nE '/^name = "rmcp"$/{n;s/^version = "([^"]*)"$/\1/p;}' Cargo.lock)"
+          if [ -z "$lock" ] || [ "$(printf '%s\n' "$lock" | wc -l)" -ne 1 ]; then
+            echo "::error::cannot read one rmcp version from Cargo.lock (got '$lock')"
+            exit 1
+          fi
+          # Every three-or-more-part version token in the file, not just the
+          # ones on a line mentioning rmcp: one stamp says only "in 3.1.4". The
+          # loopback addresses are the sole other such token today and this
+          # check keeps it that way -- a new non-rmcp X.Y.Z fails here and has
+          # to be decided, rather than being silently skipped by a narrower
+          # pattern (#171). Comparison is textual: a prerelease pin
+          # (3.1.4-rc.1) fails closed until this pattern learns the suffix.
+          drift=0
+          stamps="$(grep -oE '[0-9]+(\.[0-9]+){2,}' docs/DESIGN.md \
+            | grep -vE '^127\.0\.0\.[0-9]+$' | sort -u)" || true
+          if [ -z "$stamps" ]; then
+            echo "::error::no version stamps found in docs/DESIGN.md -- the doc or this pattern changed"
+            exit 1
+          fi
+          while IFS= read -r stamp; do
+            if [ "$stamp" != "$lock" ]; then
+              echo "::error::stamp drift: docs/DESIGN.md says $stamp but Cargo.lock pins rmcp $lock"
+              grep -nF -- "$stamp" docs/DESIGN.md || true
+              drift=1
+            fi
+          done <<< "$stamps"
+          # The one two-part stamp is DESIGN.md quoting the manifest's own
+          # requirement, so it is compared with that manifest and not with the
+          # lock: a lock-only patch bump does not move the requirement, and
+          # comparing it there would teach the doc to misquote Cargo.toml.
+          # DESIGN.md's other two-part mentions ("rmcp 3.1 usage notes", "rmcp
+          # 3.1 default") stay unchecked -- the file also names rmcp 2.2 and
+          # axum 0.8 in that shape, so no line rule tells a stamp from a
+          # deliberate reference. They can only go stale alongside a three-part
+          # stamp, which already fails above.
+          req="$(sed -nE 's/^rmcp = \{ version = "([^"]*)".*/\1/p' crates/bugwarden/Cargo.toml | sort -u)"
+          quote="$(sed -nE 's/.*rmcp = \{ version = "([^"]*)".*/\1/p' docs/DESIGN.md | sort -u)"
+          if [ -z "$req" ] || [ -z "$quote" ] || [ "$req" != "$quote" ]; then
+            echo "::error::quote drift: docs/DESIGN.md quotes rmcp version '$quote' but crates/bugwarden/Cargo.toml requires '$req'"
+            drift=1
+          fi
+          if [ "$drift" -ne 0 ]; then
+            exit 1
+          fi
+          echo "in sync: docs/DESIGN.md stamps rmcp $lock, quotes requirement $quote"
+
   changes:
     # Gate for the docker job: a full image build on every PR would be the
     # slowest leg in CI for changes that cannot affect it.


### PR DESCRIPTION
Closes #198. One new `design-stamp-drift` job.

`docs/DESIGN.md` stamps the pinned rmcp version in **13 places, five shapes** —
registry paths, `rmcp-macros-`, a git tag, prose, and one line at :2110 with no
`rmcp` token on it at all. #135 exists because a bump landed and they went
stale, and DESIGN.md is the sole design authority.

This is the one mechanically checkable instance of the "true once" class that
has cost this repo repeated review rounds (#172, #174, #179, #184, #193).

## Two corrections to the issue

**Its recommended extractor would have failed on a clean tree, every run.** A
literal `X.Y.Z` pattern truncates the four-part loopbacks (`127.0.0.1` →
`127.0.0`), which then miss the drop-list. Committed form uses `{2,}`.

**Its advice on the two-part `version = "3.1"` quote was wrong.** Checking it
against `Cargo.lock` false-fires on a caret bump — and would teach maintainers
to edit DESIGN.md until it misquotes `Cargo.toml`. The quote is compared against
the **manifest requirement** instead: verified to catch a doc edit, a manifest
edit, and dep/dev-dep disagreement.

## Approach

Extract every 3+-part version token from DESIGN.md, drop the loopback family,
require the rest to equal `Cargo.lock`'s rmcp version. Catches a stamp in any
prose shape, and **fails closed** when a future non-rmcp X.Y.Z appears — forcing
a deliberate decision rather than a silent miss.

## Verified — 29 probes

Each of the five shapes mutated individually fails, including the rmcp-less
line. A lock-only bump with DESIGN.md untouched fails, listing all 13 lines. A
new non-rmcp X.Y.Z fails; an extra loopback passes.

Fail-closed on: missing DESIGN.md, missing rmcp lock entry, two rmcp entries, a
reordered lock entry, the quote line deleted, a prerelease pin.

**And a correctly executed bump PASSES** — so the job cannot be satisfied only
by deleting it.

Copies #171's corrected guard shape (`d14c4e7`), including its honesty about
what a line-based tool cannot see: textual comparison, prerelease suffixes, and
two-part mentions all named in the job's own comment rather than left implicit.

New sibling job rather than a leg of `toolchain-drift`: that one has a
byte-identical twin in `release.yml` gating the image push, where a docs stamp
has no business.

Review: MERGE-SAFE.

**Needs a scoped branch-protection PATCH to become blocking** — `design-stamp-drift`
is a new context.
