### PR TITLE
ci(release): attest the shipped artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,12 +224,34 @@ jobs:
     permissions:
       # required for `gh release create`
       contents: write
+      # Attestation: `id-token` mints the OIDC token the short-lived Sigstore
+      # signing certificate is issued against, `attestations` stores the signed
+      # bundle on the repository. Not `artifact-metadata: write` -- that covers
+      # the registry storage record, which only runs under push-to-registry.
+      id-token: write
+      attestations: write
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: dist
           merge-multiple: true
+      - name: Attest the release artifacts
+        # Between download and `gh release create` deliberately: a failure here
+        # costs the tag and leaves nothing published, where attesting afterwards
+        # would leave a downloadable release whose provenance never arrived and
+        # whose re-run then trips over the release already existing. Signing is
+        # the only thing that makes the sibling .sha256 files worth anything --
+        # they ship in the release they describe.
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
+        with:
+          # Exactly what `gh release create dist/*` uploads, less the checksums:
+          # a glob list would silently under-cover a future artifact, since the
+          # action only errors when *no* pattern matches. Multiple subjects
+          # produce one attestation naming all of them.
+          subject-path: |
+            dist/*
+            !dist/*.sha256
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,14 @@ A release is one push of an annotated tag; nothing is released by hand.
   finally the crates.io publish — `bugwarden-core` before `bugwarden`,
   because the binary crate resolves its dependency from the index and cannot
   be packaged before core is there.
+- Every released artifact is attested with
+  `actions/attest-build-provenance` in the `release` job, between the
+  artifact download and `gh release create`: a provenance failure must cost
+  the tag rather than leave a published release nobody can verify. Subjects
+  are `dist/*` less the `.sha256` files, so a new artifact is covered
+  without editing the step. Verify with `gh attestation verify <file>
+  --repo plusky/bugwarden`. crates.io gets its own provenance from Trusted
+  Publishing; the container image has none yet.
 - The same tag also ships the multi-arch container image
   `ghcr.io/plusky/bugwarden` (jobs `container`, `container-manifest`).
   `container` is a sibling of `publish`, not upstream of it — a broken image


### PR DESCRIPTION
Refs #196 — the **artifact half**. Container provenance is deliberately excluded
(below).

Nothing bugwarden ships is signed, and the `.sha256` files live in the same
release as the artifacts they describe: anyone who can alter one can alter the
other. Integrity, zero authenticity, for a guard product people mount in front
of Bugzilla.

`actions/attest-build-provenance` over the tarballs, `.deb` and `.rpm`, in the
`release` job.

## Placement is the design

**After artifact download, before `gh release create`.** Attest fails → `release`
fails → no GitHub release, no ghcr push (`container: needs: [release, …]`), no
crates.io publish (`publish: needs: release`). Tag spent, nothing published,
and the job re-runs cleanly because the build artifacts set no `retention-days`.

Attesting *after* create would leave a live, downloadable release with no
provenance — and the re-run then dies on "release already exists", genuinely
bricking the tag.

## What the issue got wrong

**`id-token: write` alone is insufficient** — `attestations: write` is also
required for the bundle upload. Verified in the action's source, not its README.
`artifact-metadata: write` is genuinely *not* needed: that branch is gated
behind `push-to-registry` (default false) and is `try`/`catch` → warning anyway.

Review confirmed the new permission block is a pure superset of the old.

`subject-path` re-hashes the bytes rather than `subject-checksums` trusting the
sibling `.sha256` files — those files are exactly what this issue exists to stop
trusting.

## Deliberately out of scope

`provenance: mode=max` on the container. That turns each per-arch push into an
OCI index while `container-manifest` merges digests with `imagetools create` —
unrehearsable, and it could half-publish at tag time. Its own PR, after an rc
rehearsal.

## What cannot be verified until a real tag

`release.yml` runs only on a tag push. Statically verified: the SHA matches tag
v4.2.2 and is tag-pointed so Dependabot tracks releases; `!dist/*.sha256`
exclusion is real and order-sensitive in `@actions/glob`; four subjects, one
attestation, cap 1024; actionlint clean.

Unverifiable until a tag: Sigstore issuing a cert for this repo's OIDC identity,
the attestations API accepting the upload, and `repository.visibility` being
populated on the push payload — if absent the action silently picks the GitHub
Sigstore instance instead of public-good. Degraded transparency, not a broken
release.

## Note for later

Upstream's README at this version says `attest-build-provenance` is now a
wrapper and "new implementations should use `actions/attest`". Kept the issue's
named action; review confirmed the swap would be behaviour-identical and change
none of the analysis above.

AGENTS.md's Releases section enumerates what `release.yml` does, so it gains the
step and a `gh attestation verify` recipe.
