### PR TITLE
fix(server): cap strings inside object-valued audited params

### DIFF
--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -318,13 +318,22 @@ const PARAM_ALLOWLIST: &[&str] = &[
 /// Cap on recorded string values; see [`PARAM_ALLOWLIST`].
 const PARAM_VALUE_MAX_CHARS: usize = 1024;
 
-/// An allowlisted value with every string (top level or inside a list)
-/// [`capped`]. No marker is appended; the cap is documented at the
+/// An allowlisted value with every string [`capped`], at ANY depth: the
+/// client picks the JSON shape, so the bound must not depend on it (#211).
+/// Object VALUES only — a long key still records whole, accepted because
+/// capping keys would silently collide two that share a 1024-char prefix
+/// into one entry. No marker is appended; the cap is documented at the
 /// allowlist.
 fn truncated(value: &Value) -> Value {
     match value {
         Value::String(s) => Value::String(capped(s)),
         Value::Array(items) => Value::Array(items.iter().map(truncated).collect()),
+        Value::Object(fields) => Value::Object(
+            fields
+                .iter()
+                .map(|(key, value)| (key.clone(), truncated(value)))
+                .collect(),
+        ),
         other => other.clone(),
     }
 }
@@ -6071,6 +6080,22 @@ mod tests {
             serde_json::from_value(json!({ "keywords": ["k".repeat(2000)] })).unwrap();
         let params = allowlisted(Some(&obj));
         assert_eq!(params["keywords"][0].as_str().unwrap().len(), 1024);
+        // #211: and inside an object, at the top level or under a list —
+        // the client picks the shape, so the shape must not pick the bound.
+        let obj: JsonObject = serde_json::from_value(json!({
+            "groups": { "g": "o".repeat(3000) },
+            "keywords": [{ "k": [{ "deep": "d".repeat(3000) }] }],
+        }))
+        .unwrap();
+        let params = allowlisted(Some(&obj));
+        assert_eq!(params["groups"]["g"].as_str().unwrap().len(), 1024);
+        assert_eq!(
+            params["keywords"][0]["k"][0]["deep"]
+                .as_str()
+                .unwrap()
+                .len(),
+            1024
+        );
         // A short value is passed through untouched.
         let obj: JsonObject = serde_json::from_value(json!({ "query": "kernel" })).unwrap();
         assert_eq!(allowlisted(Some(&obj))["query"], json!("kernel"));
@@ -7026,6 +7051,64 @@ mod tests {
                 "the version is capped too — it is client text on the same terms"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn an_object_valued_param_reaches_a_record_and_is_capped_there() {
+        // #211's reachability half, pinned: the `Object` arm is not dead
+        // code. Two independent reasons it is reachable, and this call
+        // exercises both — no tool params struct carries
+        // `deny_unknown_fields`, so serde IGNORES the off-schema `groups`
+        // and the call SUCCEEDS; and `allowlisted` runs on the raw
+        // arguments BEFORE dispatch, so a struct that did reject them
+        // would still be recorded. Asserting the success is the point:
+        // a refused call would prove nothing about the served path.
+        let long = "z".repeat(PARAM_VALUE_MAX_CHARS * 4);
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz)
+            .expect("server must build")
+            .with_audit(Arc::clone(&audit));
+        let peer = peer_of(&server).await;
+        let context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer);
+        let Value::Object(args) = json!({
+            "bug_id": 7,
+            "groups": { "g": long },
+        }) else {
+            panic!("tool arguments must be a JSON object");
+        };
+        ServerHandler::call_tool(
+            &server,
+            CallToolRequestParams::new("bug_url".to_string()).with_arguments(args),
+            context,
+        )
+        .await
+        .expect("an off-schema object key is ignored, not rejected");
+
+        let events = read_audit_events(&audit_path);
+        let calls: Vec<&audit::ToolCallEvent> = events
+            .iter()
+            .filter_map(|e| match &e.kind {
+                AuditEventKind::ToolCall(ev) => Some(&**ev),
+                _ => None,
+            })
+            .collect();
+        let [call] = calls.as_slice() else {
+            panic!("exactly one tool-call record, got {}", calls.len());
+        };
+        assert_eq!(
+            call.outcome.class,
+            audit::OutcomeClass::Ok,
+            "the served path, not a refusal"
+        );
+        assert_eq!(
+            call.request.params["groups"]["g"]
+                .as_str()
+                .map(|s| s.chars().count()),
+            Some(PARAM_VALUE_MAX_CHARS),
+            "a string under an object-valued allowlisted param is capped like any other"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #211.

`truncated()` capped recorded strings at 1024 at the top level and inside
arrays, but never walked `Value::Object` — so a string inside an object-valued
allowlisted param recorded **uncapped**.

## The issue's premise was wrong twice

It hypothesised deserialization might reject such a param first, making the gap
unreachable. Neither half holds:

1. **No `*Params` struct carries `deny_unknown_fields`** — only `policy.rs` and
   `audit.rs` do. rmcp extracts params with bare `serde_json::from_value`; the
   schemars schema is advertisement, never enforced. So `bug_url` with
   `{"bug_id": 7, "groups": {"g": "<4000 chars>"}}` deserializes fine and the
   call **succeeds**.
2. **`allowlisted()` runs on the raw arguments *before* dispatch**, and the
   record carries them for `Ok` and `Err` alike — so a struct that *did* reject
   the object would still have recorded it.

Plus a third path: the `OutOfContract` arm records raw arguments with no
dispatch at all.

Empirically pinned, not just argued: under the mutant, a real audit record on
the **served** path carried the uncapped string.

## The change

An `Object` arm recursing through `truncated`, so it routes through `capped`
(#191's single boundary) rather than re-inlining. Two tests: the unit test gains
object cases at array→object→array→object depth, and a new end-to-end test pins
**reachability** — without it, someone later adding `deny_unknown_fields` or
moving `allowlisted` after dispatch would make the arm dead while the unit test
kept passing.

Mutation: delete the arm, both die.

DESIGN.md needed no change — its "strings capped at 1024 chars" was already
unqualified, so the implementation was what disagreed with the design.

## Deliberately not fixed

Object **keys** stay uncapped. Capping them collides two sharing a 1024-char
prefix into one `Map` entry, last-wins — a record that *misreports which key was
sent*, worse for an audit trail than a large but faithful one. Review also found
the same channel has always existed for **top-level** keys, so fixing only
nested ones would close nothing.

Tracked as **#220**, amended with both findings and with the bound that matters:
the POST body cap already bounds any single record, so this is a large-record
problem, not an unbounded-write one.

Review: MERGE-SAFE.
