### PR TITLE
test(server): pin every in-process Cli parse against ambient env

### DIFF
--- a/crates/bugwarden/src/config.rs
+++ b/crates/bugwarden/src/config.rs
@@ -382,21 +382,29 @@ mod tests {
     use std::io::Write as _;
 
     use super::*;
+    use crate::pinned_cli::pinned;
 
-    /// A `Cli` for `transport` with both key sources explicitly cleared, so
-    /// the ambient environment (`BUGZILLA_API_KEY`, `BUGZILLA_API_KEY_FILE`)
-    /// cannot leak into what a test resolves.
+    /// The pin's own self-check, run in each binary that relies on it so a
+    /// single-binary `cargo test ...` still proves what its harness claims.
+    /// Both halves assert with their own message, so folding them into one
+    /// test costs no diagnosis.
+    #[test]
+    fn the_environment_pin_holds() {
+        crate::pinned_cli::assert_the_pin_drops_every_fallback::<Cli>();
+        crate::pinned_cli::assert_the_pin_neutralises_a_flag_added_later::<Cli>();
+    }
+
+    /// A `Cli` for `transport` carrying no key source, so what a test
+    /// resolves is decided by the test and not by the ambient
+    /// `BUGZILLA_API_KEY` / `BUGZILLA_API_KEY_FILE`.
     fn base_cli(transport: &str) -> Cli {
-        let mut cli = Cli::parse_from([
+        pinned(&[
             "bugwarden",
             "--bugzilla-server",
             "https://bugzilla.example.com",
             "--transport",
             transport,
-        ]);
-        cli.api_key = None;
-        cli.api_key_file = None;
-        cli
+        ])
     }
 
     fn key_file(content: &str) -> tempfile::NamedTempFile {
@@ -521,7 +529,7 @@ mod tests {
         // "unset" idiom) must behave exactly like an unset variable: the
         // parser accepts the empty value and resolution ignores it —
         // mirroring the empty --api-key convention.
-        let mut cli = Cli::parse_from([
+        let cli: Cli = pinned(&[
             "bugwarden",
             "--bugzilla-server",
             "https://bugzilla.example.com",
@@ -530,7 +538,6 @@ mod tests {
             "--api-key-file",
             "",
         ]);
-        cli.api_key = None;
         let custody = cli.resolve_key_custody().expect("http resolves");
         assert!(
             matches!(custody, KeyCustody::PerRequest),
@@ -606,7 +613,7 @@ mod tests {
         // and both sources feed the one field — so the normalization the
         // environment needs is proven here, on the flag. Whitespace around
         // commas is trimmed; whitespace is not itself a separator.
-        let cli = Cli::parse_from([
+        let cli: Cli = pinned(&[
             "bugwarden",
             "--bugzilla-server",
             "https://bugzilla.example.com",
@@ -624,7 +631,7 @@ mod tests {
 
         // An entry naming no host leaves validation off — `MCP_ALLOWED_HOSTS=`
         // is unset, not "allow nothing" (see `resolved_allowed_hosts`).
-        let cli = Cli::parse_from([
+        let cli: Cli = pinned(&[
             "bugwarden",
             "--bugzilla-server",
             "https://bugzilla.example.com",
@@ -648,7 +655,7 @@ mod tests {
         // `a b.example` is a missing-dot typo, not two hosts. Splitting on
         // whitespace would manufacture a single-label `a` (meaningful in a
         // k8s namespace) and hide the typo.
-        let cli = Cli::parse_from([
+        let cli: Cli = pinned(&[
             "bugwarden",
             "--bugzilla-server",
             "https://bugzilla.example.com",

--- a/crates/bugwarden/src/lib.rs
+++ b/crates/bugwarden/src/lib.rs
@@ -17,3 +17,11 @@ pub mod server;
 
 #[cfg(test)]
 mod testlog;
+
+// The environment pin the integration tests share, so the crate's own unit
+// tests parse a `Cli` the same way (#214). `#[path]` rather than a module
+// of `tests/common/mod.rs`: that one compiles into every binary saying `mod
+// common;`, where a helper only some of them use is `dead_code` (#167).
+#[cfg(test)]
+#[path = "../tests/common/pinned_cli.rs"]
+mod pinned_cli;

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -4721,11 +4721,11 @@ mod tests {
     }
 
     use super::*;
+    use crate::pinned_cli::pinned;
     use bugwarden_core::policy::Policy;
 
     fn parts(policy: &str) -> (Arc<Cli>, Arc<Guard>, Arc<BugzillaClient>) {
-        use clap::Parser as _;
-        let mut cli = Cli::parse_from([
+        let cfg: Arc<Cli> = Arc::new(pinned(&[
             "bugwarden",
             "--bugzilla-server",
             "https://bugzilla.example.com",
@@ -4733,11 +4733,7 @@ mod tests {
             "stdio",
             "--api-key",
             "test-key",
-        ]);
-        // The ambient environment (BUGZILLA_API_KEY_FILE) must not leak into
-        // what these tests resolve.
-        cli.api_key_file = None;
-        let cfg = Arc::new(cli);
+        ]));
         let guard = Arc::new(Guard {
             policy: Policy::from_toml_str(policy).expect("test policy must parse"),
         });
@@ -4767,17 +4763,15 @@ mod tests {
         // Key custody is resolved by BugWarden::new on every construction
         // path: stdio without any key source must fail at startup, never at
         // the first request. main.rs no longer duplicates this bail.
-        use clap::Parser as _;
-        let mut cli = Cli::parse_from([
+        // No key source in the argv, and the pin keeps the environment
+        // from supplying one.
+        let cli: Cli = pinned(&[
             "bugwarden",
             "--bugzilla-server",
             "https://bugzilla.example.com",
             "--transport",
             "stdio",
         ]);
-        // The ambient environment must not decide this test.
-        cli.api_key = None;
-        cli.api_key_file = None;
         let guard = Arc::new(Guard {
             policy: Policy::from_toml_str("").expect("empty policy parses"),
         });
@@ -4799,7 +4793,6 @@ mod tests {
         // account that owns the key, so a created_by_me policy written for
         // per-request custody silently changes meaning — construction must
         // say so. A policy that never consults identity stays quiet.
-        use clap::Parser as _;
         use std::io::Write as _;
         let mut file = tempfile::NamedTempFile::new().expect("temp key file");
         file.write_all(b"srv-key\n").expect("write key file");
@@ -4808,14 +4801,13 @@ mod tests {
             "[rule.match]\ncreated_by_me = true\n",
         );
         for (policy, expect_warn) in [(identity_policy, true), ("", false)] {
-            let mut cli = Cli::parse_from([
+            let mut cli: Cli = pinned(&[
                 "bugwarden",
                 "--bugzilla-server",
                 "https://bugzilla.example.com",
                 "--transport",
                 "http",
             ]);
-            cli.api_key = None;
             cli.api_key_file = Some(file.path().to_path_buf());
             let guard = Arc::new(Guard {
                 policy: Policy::from_toml_str(policy).expect("test policy must parse"),
@@ -4846,16 +4838,15 @@ mod tests {
         // Per-request http custody holds no server-side key at all, so
         // there is nothing for the declared login to describe — this must
         // be a hard startup error, unlike whoami's warn-and-continue.
-        use clap::Parser as _;
-        let mut cli = Cli::parse_from([
+        // No key source in the argv, and none from the environment: custody
+        // stays per-request.
+        let cli: Cli = pinned(&[
             "bugwarden",
             "--bugzilla-server",
             "https://bugzilla.example.com",
             "--transport",
             "http",
         ]);
-        cli.api_key = None;
-        cli.api_key_file = None; // stays per-request: no server-held key
         let guard = Arc::new(Guard {
             policy: Policy::from_toml_str(concat!(
                 "[global]\n",
@@ -4883,8 +4874,7 @@ mod tests {
     fn new_allows_declared_identity_under_server_held_custody() {
         // The companion positive case: a server-held key is exactly what a
         // declared login describes, so construction must succeed.
-        use clap::Parser as _;
-        let cli = Cli::parse_from([
+        let cli: Cli = pinned(&[
             "bugwarden",
             "--bugzilla-server",
             "https://bugzilla.example.com",
@@ -6179,8 +6169,7 @@ mod tests {
         mock_uri: &str,
         audit: Option<Arc<AuditState>>,
     ) -> RunningService<RoleClient, ()> {
-        use clap::Parser as _;
-        let mut cli = Cli::parse_from([
+        let cfg: Arc<Cli> = Arc::new(pinned(&[
             "bugwarden",
             "--bugzilla-server",
             mock_uri,
@@ -6188,10 +6177,7 @@ mod tests {
             "stdio",
             "--api-key",
             "test-key",
-        ]);
-        // The ambient environment (BUGZILLA_API_KEY_FILE) must not leak in.
-        cli.api_key_file = None;
-        let cfg = Arc::new(cli);
+        ]));
         let guard = Arc::new(Guard {
             policy: Policy::from_toml_str(policy).expect("test policy must parse"),
         });
@@ -7244,13 +7230,12 @@ mod tests {
         // meta is empty — killing a mutant that reads only `context.meta`
         // (behavior-preserving over every serialized transport, so no
         // other test can).
-        use clap::Parser as _;
         let mock = MockServer::start().await;
         mount_bug7(&mock).await;
         let dir = tempfile::tempdir().unwrap();
         let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
 
-        let mut cli = Cli::parse_from([
+        let cli: Cli = pinned(&[
             "bugwarden",
             "--bugzilla-server",
             &mock.uri(),
@@ -7259,7 +7244,6 @@ mod tests {
             "--api-key",
             "test-key",
         ]);
-        cli.api_key_file = None;
         let guard = Arc::new(Guard {
             policy: Policy::from_toml_str("").expect("test policy must parse"),
         });
@@ -7451,11 +7435,10 @@ mod tests {
         // typo — `ProtocolVersion` deserializes an unknown string through
         // and every rmcp comparison is lexical, so a fabricated future
         // date outranks every real revision.
-        use clap::Parser as _;
         let mock = MockServer::start().await;
         let dir = tempfile::tempdir().unwrap();
         let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
-        let mut cli = Cli::parse_from([
+        let cli: Cli = pinned(&[
             "bugwarden",
             "--bugzilla-server",
             &mock.uri(),
@@ -7464,7 +7447,6 @@ mod tests {
             "--api-key",
             "test-key",
         ]);
-        cli.api_key_file = None;
         let guard = Arc::new(Guard {
             policy: Policy::from_toml_str("").expect("test policy must parse"),
         });
@@ -7764,18 +7746,15 @@ mod tests {
             .mount(&mock)
             .await;
 
-        let cli = {
-            use clap::Parser as _;
-            Cli::parse_from([
-                "bugwarden",
-                "--bugzilla-server",
-                &mock.uri(),
-                "--transport",
-                "stdio",
-                "--api-key",
-                "test-key",
-            ])
-        };
+        let cli: Cli = pinned(&[
+            "bugwarden",
+            "--bugzilla-server",
+            &mock.uri(),
+            "--transport",
+            "stdio",
+            "--api-key",
+            "test-key",
+        ]);
         let bz = bugzilla_client(&cli).expect("client must build");
         bz.version("test-key").await.expect("version must parse");
 
@@ -7907,8 +7886,7 @@ mod tests {
     }
 
     fn http_server_with(hosts: Vec<String>, api_key: Option<String>) -> BugWarden {
-        use clap::Parser as _;
-        let mut cli = Cli::parse_from([
+        let mut cli: Cli = pinned(&[
             "bugwarden",
             "--bugzilla-server",
             "https://bugzilla.example.com",
@@ -7916,7 +7894,6 @@ mod tests {
             "http",
         ]);
         cli.api_key = api_key;
-        cli.api_key_file = None;
         cli.allowed_hosts = hosts;
         let guard = Arc::new(Guard {
             policy: Policy::default(),

--- a/crates/bugwarden/tests/audit_wiremock.rs
+++ b/crates/bugwarden/tests/audit_wiremock.rs
@@ -21,13 +21,27 @@ use bugwarden::server::{BugWarden, USER_AGENT};
 use bugwarden_core::client::BugzillaClient;
 use bugwarden_core::guard::Guard;
 use bugwarden_core::policy::Policy;
-use clap::Parser as _;
 use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::service::{RoleClient, RunningService};
 use rmcp::ServiceExt as _;
 use serde_json::{json, Value};
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[path = "common/pinned_cli.rs"]
+mod pinned_cli;
+
+use pinned_cli::pinned;
+
+/// The pin's own self-check, run in each binary that relies on it so a
+/// single-binary `cargo test --test ...` still proves what its harness
+/// claims. Both halves assert with their own message, so folding them into
+/// one test costs no diagnosis.
+#[test]
+fn the_environment_pin_holds() {
+    pinned_cli::assert_the_pin_drops_every_fallback::<Cli>();
+    pinned_cli::assert_the_pin_neutralises_a_flag_added_later::<Cli>();
+}
 
 /// A served, audited server plus the handles the assertions need.
 struct Audited {
@@ -69,7 +83,7 @@ async fn audited_client_with(
         Some("sha256:policy-under-test".to_string()),
     ));
 
-    let mut cli = Cli::parse_from([
+    let cfg: Arc<Cli> = Arc::new(pinned(&[
         "bugwarden",
         "--bugzilla-server",
         &mock.uri(),
@@ -77,10 +91,7 @@ async fn audited_client_with(
         "stdio",
         "--api-key",
         api_key,
-    ]);
-    // The ambient environment (BUGZILLA_API_KEY_FILE) must not leak in.
-    cli.api_key_file = None;
-    let cfg = Arc::new(cli);
+    ]));
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(policy).expect("test policy must parse"),
     });
@@ -106,7 +117,7 @@ async fn audited_client_with(
 
 /// An un-audited server over the same transport, for comparisons.
 async fn plain_client_for(policy: &str, mock: &MockServer) -> RunningService<RoleClient, ()> {
-    let mut cli = Cli::parse_from([
+    let cfg: Arc<Cli> = Arc::new(pinned(&[
         "bugwarden",
         "--bugzilla-server",
         &mock.uri(),
@@ -114,10 +125,7 @@ async fn plain_client_for(policy: &str, mock: &MockServer) -> RunningService<Rol
         "stdio",
         "--api-key",
         "test-key",
-    ]);
-    // The ambient environment (BUGZILLA_API_KEY_FILE) must not leak in.
-    cli.api_key_file = None;
-    let cfg = Arc::new(cli);
+    ]));
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(policy).expect("test policy must parse"),
     });

--- a/crates/bugwarden/tests/common/pinned_cli.rs
+++ b/crates/bugwarden/tests/common/pinned_cli.rs
@@ -1,0 +1,109 @@
+//! Parse a `Cli` with every clap `env` fallback dropped, so a harness's
+//! configuration comes from its argv and clap's defaults alone (#190, #214).
+//!
+//! Included by `#[path]` from each user rather than declared in
+//! `common/mod.rs`: that module is compiled into every test binary that
+//! says `mod common;`, so a helper only some of them use would be
+//! `dead_code` in the rest, which `-D warnings` rejects (#167). `#[path]`
+//! is also what lets the crate's own unit tests share this file, and that
+//! is why nothing here names the crate — `bugwarden::config::Cli` does not
+//! resolve inside `bugwarden`, so the type arrives as a parameter. The
+//! generic buys nothing else; [`MINIMAL_ARGV`] below is `Cli`'s.
+//!
+//! Not `std::env::remove_var`: libtest runs a binary's tests on parallel
+//! threads, so mutating the process environment races every other test in
+//! the binary (`tests/env_config.rs`).
+
+/// A command line carrying only what `Cli` requires, for the probe below.
+const MINIMAL_ARGV: &[&str] = &["bugwarden", "--bugzilla-server", "https://bugzilla.example"];
+
+/// Drop every `env` fallback from `cmd`, so parsing it consults only argv.
+///
+/// `Arg::env` snapshots the variable when the command is built, so the
+/// reset covers fields added to `Cli` after this line was written — which
+/// is the point. The sibling `AMBIENT_VARS` list in `http_auth_wiremock.rs`
+/// solves the other half of the same problem and is deliberately not
+/// shared: it scrubs the environment of a *spawned* binary, and doing that
+/// in-process would race every other test in the binary.
+fn pin_environment(cmd: clap::Command) -> clap::Command {
+    cmd.mut_args(|arg| arg.env(None::<&'static str>))
+}
+
+/// Parse `argv` through `C`'s own clap command with the environment pinned
+/// out, giving the clap defaults for everything argv omits.
+///
+/// Two drifts nothing here catches: a test calling `C::parse_from` instead
+/// of this, and an env-backed arg on a future subcommand — `mut_args` and
+/// `get_arguments` both walk top-level args only.
+pub fn pinned<C: clap::CommandFactory + clap::FromArgMatches>(argv: &[&str]) -> C {
+    let matches = pin_environment(C::command())
+        .try_get_matches_from(argv)
+        .expect("the harness command line must parse");
+    C::from_arg_matches(&matches).expect("the harness command line must build a Cli")
+}
+
+/// The pin is worth its doc comment only if the command really keeps no
+/// fallback, and only if the unpinned command still has some — a check over
+/// an already-empty set can never fail.
+pub fn assert_the_pin_drops_every_fallback<C: clap::CommandFactory>() {
+    let mut pinned = pin_environment(C::command());
+    pinned.build();
+    let leaking: Vec<String> = pinned
+        .get_arguments()
+        .filter_map(clap::Arg::get_env)
+        .map(|env| env.to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        leaking.is_empty(),
+        "these environment fallbacks still reach the harness: {leaking:?}"
+    );
+
+    let mut real = C::command();
+    real.build();
+    assert!(
+        real.get_arguments().any(|arg| arg.get_env().is_some()),
+        "the binary declares no environment fallback at all, so the assertion \
+         above proves nothing"
+    );
+}
+
+/// The drift the pin exists to survive: a `Cli` field added later, with an
+/// `env` fallback whose variable is set in the runner's environment. Any
+/// variable this process already carries reproduces it, so the check never
+/// mutates the environment libtest shares across threads.
+pub fn assert_the_pin_neutralises_a_flag_added_later<C: clap::CommandFactory>() {
+    let (name, value) = std::env::vars_os()
+        .next()
+        .expect("the test process must carry at least one environment variable");
+    // clap only accepts a `'static` variable name without its `string`
+    // feature; one leaked name per run is cheaper than turning that on.
+    let name: &'static std::ffi::OsStr = Box::leak(name.into_boxed_os_str());
+    let added_later = || {
+        clap::Arg::new("added-later")
+            .long("added-later")
+            .env(name)
+            .value_parser(clap::builder::OsStringValueParser::new())
+    };
+
+    // Added *after* the pin, so only the probe keeps a fallback: a
+    // malformed ambient value for a real one (`MCP_PORT=notanumber`) would
+    // otherwise fail this check.
+    let ambient = pin_environment(C::command())
+        .arg(added_later())
+        .try_get_matches_from(MINIMAL_ARGV)
+        .expect("the probe command line must parse");
+    assert_eq!(
+        ambient.get_one::<std::ffi::OsString>("added-later"),
+        Some(&value),
+        "the probe variable must reach an unpinned field, or this proves nothing"
+    );
+
+    let pinned = pin_environment(C::command().arg(added_later()))
+        .try_get_matches_from(MINIMAL_ARGV)
+        .expect("the probe command line must parse");
+    assert_eq!(
+        pinned.get_one::<std::ffi::OsString>("added-later"),
+        None,
+        "{name:?} reached a pinned field"
+    );
+}

--- a/crates/bugwarden/tests/http_auth_wiremock.rs
+++ b/crates/bugwarden/tests/http_auth_wiremock.rs
@@ -36,7 +36,6 @@ use bugwarden::server::{BugWarden, USER_AGENT, WRITE_TOOLS};
 use bugwarden_core::client::BugzillaClient;
 use bugwarden_core::guard::Guard;
 use bugwarden_core::policy::Policy;
-use clap::Parser as _;
 use rmcp::model::CallToolRequestParams;
 use rmcp::service::{RoleClient, RunningService};
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
@@ -52,6 +51,21 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 #[path = "common/raw_post.rs"]
 mod raw_post;
 
+#[path = "common/pinned_cli.rs"]
+mod pinned_cli;
+
+use pinned_cli::pinned;
+
+/// The pin's own self-check, run in each binary that relies on it so a
+/// single-binary `cargo test --test ...` still proves what its harness
+/// claims. Both halves assert with their own message, so folding them into
+/// one test costs no diagnosis.
+#[test]
+fn the_environment_pin_holds() {
+    pinned_cli::assert_the_pin_drops_every_fallback::<Cli>();
+    pinned_cli::assert_the_pin_neutralises_a_flag_added_later::<Cli>();
+}
+
 /// 32 printable non-space characters each, and distinct.
 const WRITE_TOKEN: &str = "0123456789abcdef0123456789abcdef";
 const READ_TOKEN: &str = "fedcba9876543210fedcba9876543210";
@@ -61,7 +75,8 @@ const READ_TOKEN: &str = "fedcba9876543210fedcba9876543210";
 const EXIT_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Every environment variable the binary reads, cleared before each spawn:
-/// an ambient value would change exactly what is under test.
+/// an ambient value would change exactly what is under test. The spawned
+/// leg only; `pinned` above covers the in-process one.
 const AMBIENT_VARS: &[&str] = &[
     "BUGZILLA_SERVER",
     "BUGZILLA_API_KEY",
@@ -132,17 +147,15 @@ fn the_scrub_list_covers_every_environment_fallback() {
 /// no test can exercise a differently-guarded server than the deployment
 /// serves.
 async fn serve_guarded(mock: &MockServer, env: &HttpEnv, insecure: bool) -> SocketAddr {
-    let mut cli = Cli::parse_from([
+    // No `--api-key`/`--api-key-file`, so custody stays per-request and the
+    // tests send the key with each request.
+    let cli: Cli = pinned(&[
         "bugwarden",
         "--bugzilla-server",
         &mock.uri(),
         "--transport",
         "http",
     ]);
-    // Both key fields explicitly cleared, so the ambient environment cannot
-    // leak into what these tests resolve; the tests send the key per request.
-    cli.api_key = None;
-    cli.api_key_file = None;
     let guard = Arc::new(Guard {
         policy: Policy::default(),
     });

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -67,7 +67,6 @@ use bugwarden::server::{BugWarden, USER_AGENT};
 use bugwarden_core::client::BugzillaClient;
 use bugwarden_core::guard::Guard;
 use bugwarden_core::policy::Policy;
-use clap::FromArgMatches as _;
 use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::service::{RoleClient, RunningService};
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
@@ -81,35 +80,15 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 #[path = "common/raw_post.rs"]
 mod raw_post;
 
-/// Drop every `env` fallback from `cmd`, so parsing it consults only argv.
-///
-/// `Arg::env` snapshots the variable when the command is built, so the
-/// reset covers fields added to `Cli` after this line was written — which
-/// is the point. The sibling `AMBIENT_VARS` list in `http_auth_wiremock.rs`
-/// solves the other half of the same problem and is deliberately not
-/// shared: it scrubs the environment of a *spawned* binary, and doing that
-/// in-process would race every other test in this binary (`env_config.rs`).
-fn pin_environment(cmd: clap::Command) -> clap::Command {
-    cmd.mut_args(|arg| arg.env(None::<&'static str>))
-}
+#[path = "common/pinned_cli.rs"]
+mod pinned_cli;
 
-/// Parse `argv` through the binary's own clap command with the environment
-/// pinned out, giving the clap defaults for everything argv omits.
-///
-/// Two drifts nothing below catches: a test here calling `Cli::parse_from`
-/// instead of this, and an env-backed arg on a future subcommand —
-/// `mut_args` and `get_arguments` both walk top-level args only.
-fn pinned_cli(argv: &[&str]) -> Cli {
-    let matches = pin_environment(bugwarden::config::command())
-        .try_get_matches_from(argv)
-        .expect("the harness command line must parse");
-    Cli::from_arg_matches(&matches).expect("the harness command line must build a Cli")
-}
+use pinned_cli::pinned;
 
 /// Build the http-transport `Cli` against `mock`, with `key_file` when the
 /// test runs in server-held mode.
 ///
-/// No clap `env` fallback reaches this `Cli`: [`pinned_cli`] drops them
+/// No clap `env` fallback reaches this `Cli`: [`pinned`] drops them
 /// wholesale rather than overwriting a list of named fields — the list is
 /// what drifted in #190, having lost `read_only` while still claiming to be
 /// complete. That is the whole of the claim; the rest of the environment
@@ -118,7 +97,7 @@ fn pinned_cli(argv: &[&str]) -> Cli {
 /// the only field a caller varies.
 fn http_cli(mock: &MockServer, key_file: Option<&std::path::Path>) -> Arc<Cli> {
     let uri = mock.uri();
-    let mut cli = pinned_cli(&[
+    let mut cli: Cli = pinned(&[
         "bugwarden",
         "--bugzilla-server",
         &uri,
@@ -131,72 +110,14 @@ fn http_cli(mock: &MockServer, key_file: Option<&std::path::Path>) -> Arc<Cli> {
     Arc::new(cli)
 }
 
-/// The pin is worth its doc comment only if the command really keeps no
-/// fallback, and only if the unpinned command still has some — a check over
-/// an already-empty set can never fail.
+/// The pin's own self-check, run in each binary that relies on it so a
+/// single-binary `cargo test --test ...` still proves what its harness
+/// claims. Both halves assert with their own message, so folding them into
+/// one test costs no diagnosis.
 #[test]
-fn the_pinned_command_keeps_no_environment_fallback() {
-    let mut pinned = pin_environment(bugwarden::config::command());
-    pinned.build();
-    let leaking: Vec<String> = pinned
-        .get_arguments()
-        .filter_map(clap::Arg::get_env)
-        .map(|env| env.to_string_lossy().into_owned())
-        .collect();
-    assert!(
-        leaking.is_empty(),
-        "these environment fallbacks still reach the harness: {leaking:?}"
-    );
-
-    let mut real = bugwarden::config::command();
-    real.build();
-    assert!(
-        real.get_arguments().any(|arg| arg.get_env().is_some()),
-        "the binary declares no environment fallback at all, so the assertion \
-         above proves nothing"
-    );
-}
-
-/// The drift the pin exists to survive: a `Cli` field added later, with an
-/// `env` fallback whose variable is set in the runner's environment. Any
-/// variable this process already carries reproduces it, so the test never
-/// mutates the environment libtest shares across threads.
-#[test]
-fn the_pin_neutralises_an_environment_backed_flag_added_later() {
-    let (name, value) = std::env::vars_os()
-        .next()
-        .expect("the test process must carry at least one environment variable");
-    // clap only accepts a `'static` variable name without its `string`
-    // feature; one leaked name per run is cheaper than turning that on.
-    let name: &'static std::ffi::OsStr = Box::leak(name.into_boxed_os_str());
-    let added_later = || {
-        clap::Arg::new("added-later")
-            .long("added-later")
-            .env(name)
-            .value_parser(clap::builder::OsStringValueParser::new())
-    };
-    let argv = ["bugwarden", "--bugzilla-server", "https://bugzilla.example"];
-
-    // Only the probe keeps a fallback: a malformed ambient value for a real
-    // one (`MCP_PORT=notanumber`) would otherwise fail this test.
-    let ambient = pin_environment(bugwarden::config::command())
-        .arg(added_later())
-        .try_get_matches_from(argv)
-        .expect("the probe command line must parse");
-    assert_eq!(
-        ambient.get_one::<std::ffi::OsString>("added-later"),
-        Some(&value),
-        "the probe variable must reach an unpinned field, or this proves nothing"
-    );
-
-    let pinned = pin_environment(bugwarden::config::command().arg(added_later()))
-        .try_get_matches_from(argv)
-        .expect("the probe command line must parse");
-    assert_eq!(
-        pinned.get_one::<std::ffi::OsString>("added-later"),
-        None,
-        "{name:?} reached a pinned field"
-    );
+fn the_environment_pin_holds() {
+    pinned_cli::assert_the_pin_drops_every_fallback::<Cli>();
+    pinned_cli::assert_the_pin_neutralises_a_flag_added_later::<Cli>();
 }
 
 /// Serve a [`BugWarden`] built from `cli` and `policy` over a real TCP

--- a/crates/bugwarden/tests/otel_wiremock.rs
+++ b/crates/bugwarden/tests/otel_wiremock.rs
@@ -22,13 +22,27 @@ use bugwarden::server::{BugWarden, USER_AGENT};
 use bugwarden_core::client::BugzillaClient;
 use bugwarden_core::guard::Guard;
 use bugwarden_core::policy::Policy;
-use clap::Parser as _;
 use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::service::{RoleClient, RunningService};
 use rmcp::ServiceExt as _;
 use serde_json::{json, Value};
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[path = "common/pinned_cli.rs"]
+mod pinned_cli;
+
+use pinned_cli::pinned;
+
+/// The pin's own self-check, run in each binary that relies on it so a
+/// single-binary `cargo test --test ...` still proves what its harness
+/// claims. Both halves assert with their own message, so folding them into
+/// one test costs no diagnosis.
+#[test]
+fn the_environment_pin_holds() {
+    pinned_cli::assert_the_pin_drops_every_fallback::<Cli>();
+    pinned_cli::assert_the_pin_neutralises_a_flag_added_later::<Cli>();
+}
 
 const TRACEPARENT: &str = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
 const TRACE_ID: [u8; 16] = [
@@ -235,7 +249,7 @@ async fn server_with_sinks(
     };
     let audit = Arc::new(AuditState::new(sink, fail_mode, None));
 
-    let mut cli = Cli::parse_from([
+    let cfg: Arc<Cli> = Arc::new(pinned(&[
         "bugwarden",
         "--bugzilla-server",
         &mock.uri(),
@@ -243,9 +257,7 @@ async fn server_with_sinks(
         "stdio",
         "--api-key",
         "test-key",
-    ]);
-    cli.api_key_file = None;
-    let cfg = Arc::new(cli);
+    ]));
     let guard = Arc::new(Guard {
         policy: Policy::default(),
     });

--- a/crates/bugwarden/tests/preflight_wiremock.rs
+++ b/crates/bugwarden/tests/preflight_wiremock.rs
@@ -26,9 +26,23 @@ use bugwarden::server::{BugWarden, USER_AGENT};
 use bugwarden_core::client::BugzillaClient;
 use bugwarden_core::guard::Guard;
 use bugwarden_core::policy::Policy;
-use clap::Parser as _;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[path = "common/pinned_cli.rs"]
+mod pinned_cli;
+
+use pinned_cli::pinned;
+
+/// The pin's own self-check, run in each binary that relies on it so a
+/// single-binary `cargo test --test ...` still proves what its harness
+/// claims. Both halves assert with their own message, so folding them into
+/// one test costs no diagnosis.
+#[test]
+fn the_environment_pin_holds() {
+    pinned_cli::assert_the_pin_drops_every_fallback::<Cli>();
+    pinned_cli::assert_the_pin_neutralises_a_flag_added_later::<Cli>();
+}
 
 /// The issue's policy shape: an access-scoped `created_by_me` carve-out
 /// above a blanket group-restricted deny. This is what makes
@@ -91,7 +105,7 @@ async fn mount_valid_login(mock: &MockServer, login: &str, result: bool, hits: u
 
 /// Build a stdio (server-held key) `BugWarden` against `mock` with `policy`.
 fn server_custody_server(policy: &str, mock: &MockServer) -> BugWarden {
-    let mut cli = Cli::parse_from([
+    let cfg: Arc<Cli> = Arc::new(pinned(&[
         "bugwarden",
         "--bugzilla-server",
         &mock.uri(),
@@ -99,9 +113,7 @@ fn server_custody_server(policy: &str, mock: &MockServer) -> BugWarden {
         "stdio",
         "--api-key",
         "test-key",
-    ]);
-    cli.api_key_file = None; // the ambient environment must not leak in
-    let cfg = Arc::new(cli);
+    ]));
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(policy).expect("test policy must parse"),
     });
@@ -114,16 +126,13 @@ fn server_custody_server(policy: &str, mock: &MockServer) -> BugWarden {
 /// `policy` (no `--api-key`/`--api-key-file`, so custody stays
 /// `PerRequest`).
 fn per_request_custody_server(policy: &str, mock: &MockServer) -> BugWarden {
-    let mut cli = Cli::parse_from([
+    let cfg: Arc<Cli> = Arc::new(pinned(&[
         "bugwarden",
         "--bugzilla-server",
         &mock.uri(),
         "--transport",
         "http",
-    ]);
-    cli.api_key = None;
-    cli.api_key_file = None; // the ambient environment must not leak in
-    let cfg = Arc::new(cli);
+    ]));
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(policy).expect("test policy must parse"),
     });
@@ -270,7 +279,7 @@ async fn preflight_transport_error_does_not_leak_the_api_key_i12() {
     // it. Nothing in the preflight error text may contain the key.
     let base = common::refused_base_url();
 
-    let mut cli = Cli::parse_from([
+    let cfg: Arc<Cli> = Arc::new(pinned(&[
         "bugwarden",
         "--bugzilla-server",
         &base,
@@ -278,9 +287,7 @@ async fn preflight_transport_error_does_not_leak_the_api_key_i12() {
         "stdio",
         "--api-key",
         "SUPERSECRETKEY123",
-    ]);
-    cli.api_key_file = None; // the ambient environment must not leak in
-    let cfg = Arc::new(cli);
+    ]));
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(IDENTITY_POLICY).expect("test policy must parse"),
     });

--- a/crates/bugwarden/tests/tools_wiremock.rs
+++ b/crates/bugwarden/tests/tools_wiremock.rs
@@ -28,13 +28,27 @@ use bugwarden::server::{BugWarden, USER_AGENT, WRITE_TOOLS};
 use bugwarden_core::client::BugzillaClient;
 use bugwarden_core::guard::Guard;
 use bugwarden_core::policy::Policy;
-use clap::Parser as _;
 use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::service::{RoleClient, RunningService};
 use rmcp::ServiceExt as _;
 use serde_json::{json, Value};
 use wiremock::matchers::{body_partial_json, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[path = "common/pinned_cli.rs"]
+mod pinned_cli;
+
+use pinned_cli::pinned;
+
+/// The pin's own self-check, run in each binary that relies on it so a
+/// single-binary `cargo test --test ...` still proves what its harness
+/// claims. Both halves assert with their own message, so folding them into
+/// one test costs no diagnosis.
+#[test]
+fn the_environment_pin_holds() {
+    pinned_cli::assert_the_pin_drops_every_fallback::<Cli>();
+    pinned_cli::assert_the_pin_neutralises_a_flag_added_later::<Cli>();
+}
 
 /// The uniform create refusal (`Guard::create_denial`), pinned by value so a
 /// wording change in either path breaks a test instead of passing silently.
@@ -43,7 +57,7 @@ const CREATE_DENIAL: &str = "Filing this bug is not permitted through this serve
 /// Serve a [`BugWarden`] built from `policy` against `mock`, and connect an
 /// MCP client to it over an in-memory duplex transport.
 async fn client_for(policy: &str, mock: &MockServer) -> RunningService<RoleClient, ()> {
-    let mut cli = Cli::parse_from([
+    let cfg: Arc<Cli> = Arc::new(pinned(&[
         "bugwarden",
         "--bugzilla-server",
         &mock.uri(),
@@ -51,11 +65,7 @@ async fn client_for(policy: &str, mock: &MockServer) -> RunningService<RoleClien
         "stdio",
         "--api-key",
         "test-key",
-    ]);
-    // The ambient environment (BUGZILLA_API_KEY_FILE) must not leak into
-    // what these tests resolve.
-    cli.api_key_file = None;
-    let cfg = Arc::new(cli);
+    ]));
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(policy).expect("test policy must parse"),
     });
@@ -2513,7 +2523,7 @@ async fn whoami_transport_error_does_not_leak_the_api_key_i12() {
     // api_key=... in it. Nothing the client sees may contain the key.
     let base = common::refused_base_url();
 
-    let mut cli = Cli::parse_from([
+    let cfg: Arc<Cli> = Arc::new(pinned(&[
         "bugwarden",
         "--bugzilla-server",
         &base,
@@ -2521,9 +2531,7 @@ async fn whoami_transport_error_does_not_leak_the_api_key_i12() {
         "stdio",
         "--api-key",
         "SUPERSECRETKEY123",
-    ]);
-    cli.api_key_file = None; // the ambient environment must not leak in
-    let cfg = Arc::new(cli);
+    ]));
     let guard = Arc::new(Guard {
         policy: Policy::from_toml_str(IDENTITY_POLICY).expect("test policy must parse"),
     });


### PR DESCRIPTION
Closes #214. Spreads #190's environment pin to every in-process
`Cli::parse_from` site.

## The issue's "blast radius appears nil at HEAD" is false

Reproduced at HEAD, and independently by review:

- `MCP_ALLOWED_HOSTS=…` → **6 of 12 `http_auth_wiremock` tests fail**, `403
  Forbidden: Host header is not allowed`. `serve_guarded` →
  `http_server_config()` → host validation on. Not future drift — this breaks
  half that binary **today** on any machine with the variable exported.
- `MCP_API_KEY_HEADER=…` → the config startup-log test fails (and, review found,
  three more in `http_auth_wiremock` — my commit body undercounts).
- `BUGZILLA_API_KEY_FILE=…` → a `server.rs` test fails; the one parse that
  carried no manual clobber.

Eight distinct failures. At the branch, all twelve fallbacks set hostile change
nothing.

## Sharing mechanism

`tests/common/pinned_cli.rs`, `#[path]`-included — the #167 precedent, because
`common/mod.rs` compiles into every binary declaring `mod common;` and would
make existing helpers dead under `-D warnings`.

A constraint the issue did not anticipate: `src/server.rs` and `src/config.rs`
are **inside the lib crate**, where `bugwarden::config::Cli` cannot resolve. So
the helper is generic over `C: CommandFactory + FromArgMatches` and `lib.rs`
`#[path]`-includes the same file under `#[cfg(test)]`. Rejected: `extern crate
self as bugwarden` (production line for test plumbing) and a second copy (the
drift this issue is about).

## Beyond the issue's list

**`src/config.rs` ×5** — same exposure, and one of the three live HEAD failures
is there.

Skipped, each checked rather than assumed: `env_config.rs` (it *is* the test of
the fallbacks), `binary_shutdown.rs` / `binary_user_agent.rs` (spawn the binary
— `AMBIENT_VARS` scrubbing is the right mechanism, and each already carries a
coverage self-check), `otel_diagnostics.rs` (builds no `Cli`).

Every redundant `api_key = None` / `api_key_file = None` clobber is deleted as
superseded; load-bearing assignments stay. Review verified no deletion changed
what any test resolves.

## Self-check

#190's two checks became shared generics called from one
`the_environment_pin_holds()` per pinning binary (7). Neutered pin, clean env:
**exactly one failure per binary, all seven**, each listing the twelve
fallbacks that would reach the harness.

Review: MERGE-SAFE. No assertion changed.
