### PR TITLE
fix(server): arm the shutdown signals before announcing readiness

### DIFF
--- a/crates/bugwarden/src/main.rs
+++ b/crates/bugwarden/src/main.rs
@@ -220,8 +220,9 @@ async fn main() -> anyhow::Result<()> {
             Transport::Stdio => {
                 // Two stages: an unused stdio container sits in `serve`
                 // (handshake). After initialize it sits in `waiting`.
-                // Handlers register on the first poll of `shutdown`, which
-                // is this `select!` immediately after the startup line.
+                // Load-bearing order: `shutdown_signal` arms the handlers
+                // in the call, so the startup line below cannot be read by
+                // anything that then races an unhandled signal (#173).
                 let shutdown = shutdown_signal();
                 tokio::pin!(shutdown);
                 tracing::info!("Starting Bugzilla MCP server on stdio");
@@ -284,10 +285,19 @@ async fn main() -> anyhow::Result<()> {
                     auth,
                 );
                 let addr = format!("{}:{}", cfg.host, cfg.port);
-                tracing::info!("Starting Bugzilla MCP server on {addr}");
+                // Armed before the bind, so nothing that can reach the port
+                // can outrun the handlers; see `shutdown_signal` (#173).
+                let shutdown = shutdown_signal();
                 let tcp_listener = tokio::net::TcpListener::bind(&addr)
                     .await
                     .with_context(|| format!("failed to bind {addr}"))?;
+                // The bound address, not the requested one: `--port 0` asks
+                // the kernel for a free port, and the operator (or a test)
+                // has no other way to learn which.
+                let bound = tcp_listener
+                    .local_addr()
+                    .with_context(|| format!("failed to read the local address of {addr}"))?;
+                tracing::info!("Starting Bugzilla MCP server on {bound}");
                 // Connect-info makes the remote peer address available in the
                 // request extensions, where the audit session info reads it.
                 axum::serve(
@@ -295,7 +305,7 @@ async fn main() -> anyhow::Result<()> {
                     router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
                 )
                 .with_graceful_shutdown(async move {
-                    shutdown_signal().await;
+                    shutdown.await;
                     tracing::info!("received shutdown signal");
                     // Tear the live streamable-HTTP transport down with the
                     // listener: axum's graceful shutdown alone waits for
@@ -329,38 +339,66 @@ async fn flush_otel_and_exit(otel: Option<&Pipeline>) -> ! {
     std::process::exit(0);
 }
 
-/// Wait until the process should stop serving.
+/// Arm the shutdown signals; the returned future resolves when one arrives.
 ///
-/// `SIGINT` (`ctrl_c`) and, on Unix, `SIGTERM`. As container PID 1 the
-/// kernel does not apply SIGTERM's default terminate action, so without
-/// this waiter `docker stop` / `podman stop` wait out the runtime grace
-/// period and SIGKILL (issue #114). Both signals take the same path: the
-/// caller then cancels whatever is serving (the HTTP transport token, or
-/// the stdio `select!`). A failed SIGTERM install is logged and the
-/// waiter falls back to SIGINT only — refusing to start would be worse
-/// than a container that still needs `--init`.
-async fn shutdown_signal() {
-    let ctrl_c = tokio::signal::ctrl_c();
-    #[cfg(unix)]
-    {
-        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
-            Ok(mut term) => {
-                tokio::select! {
-                    _ = ctrl_c => {}
-                    _ = term.recv() => {}
-                }
-            }
-            Err(err) => {
+/// `SIGINT` and, on Unix, `SIGTERM`. As container PID 1 the kernel does not
+/// apply SIGTERM's default terminate action, so without this waiter `docker
+/// stop` / `podman stop` wait out the runtime grace period and SIGKILL
+/// (issue #114). Both signals take the same path: the caller then cancels
+/// whatever is serving (the HTTP transport token, or the stdio `select!`).
+///
+/// Arming happens in the call, not on the first poll of the returned future
+/// — an `async fn` body runs nothing until polled, so a signal delivered in
+/// the gap between "serving" and that first poll still got the kernel's
+/// default action, which is a kill rather than the graceful exit this exists
+/// for (#173). Both callers therefore call this *before* they announce
+/// readiness, which is what lets anything waiting on the startup line signal
+/// immediately. Arm no earlier than that needs: everything ahead of the call
+/// (policy load, preflight, OTLP probe) keeps the default disposition, so a
+/// signal during a slow startup still stops the process at once.
+///
+/// A signal whose handler will not install is logged and dropped from the
+/// set — refusing to start would be worse than a container that still needs
+/// `--init`. If neither installs, the future stays pending: resolving would
+/// shut down a healthy server instead of failing to stop a doomed one.
+#[cfg(unix)]
+fn shutdown_signal() -> impl std::future::Future<Output = ()> {
+    use tokio::signal::unix::{signal, Signal, SignalKind};
+
+    fn arm(kind: SignalKind, name: &str) -> Option<Signal> {
+        signal(kind)
+            .inspect_err(|err| {
                 tracing::error!(
                     error = %err,
-                    "failed to install SIGTERM handler; only SIGINT will stop the process"
+                    "failed to install the {name} handler; {name} will not stop the process"
                 );
-                let _ = ctrl_c.await;
+            })
+            .ok()
+    }
+
+    let interrupt = arm(SignalKind::interrupt(), "SIGINT");
+    let terminate = arm(SignalKind::terminate(), "SIGTERM");
+    async move {
+        match (interrupt, terminate) {
+            (Some(mut interrupt), Some(mut terminate)) => {
+                tokio::select! {
+                    _ = interrupt.recv() => {}
+                    _ = terminate.recv() => {}
+                }
             }
+            (Some(mut only), None) | (None, Some(mut only)) => {
+                only.recv().await;
+            }
+            (None, None) => std::future::pending::<()>().await,
         }
     }
-    #[cfg(not(unix))]
-    {
-        let _ = ctrl_c.await;
+}
+
+/// Non-Unix fallback: ctrl-c only, and installed on the first poll — the
+/// arming contract above is Unix-only.
+#[cfg(not(unix))]
+fn shutdown_signal() -> impl std::future::Future<Output = ()> {
+    async {
+        let _ = tokio::signal::ctrl_c().await;
     }
 }

--- a/crates/bugwarden/tests/binary_shutdown.rs
+++ b/crates/bugwarden/tests/binary_shutdown.rs
@@ -16,6 +16,15 @@
 //! - stdio wrapping only `serve` and not `waiting()`;
 //! - HTTP SIGTERM returning without `ct.cancel()`, leaving an open MCP
 //!   session to outlive the shutdown.
+//!
+//! Both races this file used to lose (#173) were readiness barriers that
+//! did not prove what they had to, and both are answered in `main`:
+//! the port is the kernel's choice, read back from the child's own startup
+//! line, so no stranger holding a guessed port can answer for the child;
+//! and `shutdown_signal` arms the handlers *before* that line is logged, so
+//! a signal sent the instant it appears cannot land on the kernel's default
+//! disposition and kill the process. Waiting on the line is the whole
+//! barrier — a sleep would only trade a fast flake for a slow one.
 
 #![cfg(unix)]
 
@@ -31,7 +40,10 @@ use rmcp::ServiceExt as _;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
+use tokio::io::Lines;
 use tokio::process::Child;
+use tokio::process::ChildStderr;
+use tokio::process::ChildStdin;
 use tokio::process::Command;
 
 /// Bounded so a binary that ignores the signal fails this test rather than
@@ -97,40 +109,167 @@ fn the_scrub_list_covers_every_environment_fallback() {
     );
 }
 
-/// A port to hand the child, chosen by binding and releasing an ephemeral
-/// one. Racy in principle; the child's readiness poll below turns a lost
-/// race into a test failure rather than a hang.
-fn free_port() -> u16 {
-    std::net::TcpListener::bind("127.0.0.1:0")
-        .expect("bind")
-        .local_addr()
-        .expect("addr")
-        .port()
+/// The line the http transport logs once it is bound *and* its signal
+/// handlers are armed; the address that follows is the one the kernel
+/// assigned, which with `--port 0` is the only way to learn it.
+const HTTP_READY: &str = "Starting Bugzilla MCP server on ";
+
+/// The same, for stdio, which has no address.
+const STDIO_READY: &str = "Starting Bugzilla MCP server on stdio";
+
+/// A spawned binary, its pipes, and every stderr line it has written.
+struct Server {
+    child: Child,
+    /// Held until the process exits, never dropped early: `Child::wait`
+    /// closes the child's stdin, and EOF there unblocks a stdio child's
+    /// read — which would let a handshake arm that merely returned pass
+    /// the pre-handshake test.
+    stdin: Option<ChildStdin>,
+    /// One reader for the process's whole life. A `BufReader` built per
+    /// wait throws away whatever it buffered past the line it matched,
+    /// which can swallow the line a later assertion needs.
+    stderr: Lines<BufReader<ChildStderr>>,
+    /// Every stderr line read so far, for the assertions and diagnostics.
+    log: String,
 }
 
-fn send_signal(pid: u32, signal: &str) {
-    let status = std::process::Command::new("kill")
-        .args(["-s", signal, &pid.to_string()])
-        .status()
-        .expect("kill must be executable");
-    assert!(status.success(), "kill -s {signal} {pid} failed: {status}");
-}
-
-/// Spawn the shipped binary. Stdin is piped so a stdio child does not see
-/// EOF the moment we start; stderr is piped so tests can wait on the
-/// startup line. `kill_on_drop` reaps a child if the assertion panics.
-fn spawn_binary(args: &[&str]) -> Child {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_bugwarden"));
-    cmd.args(args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    for var in AMBIENT_VARS {
-        cmd.env_remove(var);
+impl Server {
+    /// Spawn the shipped binary with every environment fallback scrubbed.
+    /// `kill_on_drop` reaps the child if an assertion panics.
+    fn spawn(args: &[&str]) -> Self {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_bugwarden"));
+        cmd.args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        for var in AMBIENT_VARS {
+            cmd.env_remove(var);
+        }
+        cmd.env("RUST_LOG", "info");
+        cmd.kill_on_drop(true);
+        let mut child = cmd.spawn().expect("the built binary must start");
+        let stdin = child.stdin.take();
+        let stderr = BufReader::new(child.stderr.take().expect("stderr is piped")).lines();
+        Self {
+            child,
+            stdin,
+            stderr,
+            log: String::new(),
+        }
     }
-    cmd.env("RUST_LOG", "info");
-    cmd.kill_on_drop(true);
-    cmd.spawn().expect("the built binary must start")
+
+    /// Read stderr until a line contains `needle`, and return that line.
+    /// The startup lines are the readiness barriers: see the module docs.
+    async fn wait_for_stderr(&mut self, needle: &str) -> String {
+        let found = tokio::time::timeout(EXIT_TIMEOUT, async {
+            while let Some(line) = self.next_stderr_line().await {
+                if line.contains(needle) {
+                    return Some(line);
+                }
+            }
+            None
+        })
+        .await;
+        match found {
+            Ok(Some(line)) => line,
+            Ok(None) => panic!(
+                "the child's stderr ended before {needle:?}: {log}",
+                log = self.log
+            ),
+            Err(_) => panic!(
+                "timed out waiting for {needle:?} on the child's stderr: {log}",
+                log = self.log
+            ),
+        }
+    }
+
+    /// Next stderr line, recorded in `log`; `None` at EOF.
+    async fn next_stderr_line(&mut self) -> Option<String> {
+        let line = self
+            .stderr
+            .next_line()
+            .await
+            .expect("the child's stderr must be readable")?;
+        self.log.push_str(&line);
+        self.log.push('\n');
+        Some(line)
+    }
+
+    fn pid(&self) -> u32 {
+        self.child.id().expect("the child has a pid")
+    }
+
+    fn signal(&self, signal: &str) {
+        let pid = self.pid();
+        let status = std::process::Command::new("kill")
+            .args(["-s", signal, &pid.to_string()])
+            .status()
+            .expect("kill must be executable");
+        assert!(status.success(), "kill -s {signal} {pid} failed: {status}");
+    }
+
+    /// The process exits 0 — not a signal-kill, not an error — and its
+    /// stderr shows the shutdown path ran.
+    async fn assert_graceful_exit(mut self, what: &str) {
+        let status = tokio::time::timeout(EXIT_TIMEOUT, self.child.wait())
+            .await
+            .unwrap_or_else(|_| panic!("{what}: the process must exit within {EXIT_TIMEOUT:?}"))
+            .expect("the child must be waitable");
+        // The tail of stderr: the exit raced the writes, so read to EOF
+        // rather than assert on whatever had arrived by then.
+        let _ = tokio::time::timeout(EXIT_TIMEOUT, async {
+            while self.next_stderr_line().await.is_some() {}
+        })
+        .await;
+        assert_eq!(
+            status.code(),
+            Some(0),
+            "{what}: SIGTERM/SIGINT must be a clean exit 0, not a signal-kill \
+             (code=None) or an error: status={status:?} stderr={log}",
+            log = self.log
+        );
+        assert!(
+            self.log.contains("received shutdown signal"),
+            "{what}: the shutdown path must log that it ran: {log}",
+            log = self.log
+        );
+    }
+}
+
+/// Spawn the http transport and return the address it actually bound.
+///
+/// `--port 0` leaves the choice to the kernel, which assigns the port to
+/// the process that then keeps it: unlike bind-then-drop there is no window
+/// for anything else on the host to take it (#173), the pattern
+/// `tests/common/mod.rs` documents as known-bad. The address comes back
+/// from the child's own startup line, which is also a stronger readiness
+/// barrier than a connect probe — a stranger holding a guessed port would
+/// have answered that probe on the child's behalf.
+async fn spawn_http() -> (Server, SocketAddr) {
+    let mut server = Server::spawn(&[
+        "--bugzilla-server",
+        "https://bugzilla.example.invalid",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--insecure-no-auth",
+    ]);
+    let line = server.wait_for_stderr(HTTP_READY).await;
+    let (_, addr) = line
+        .split_once(HTTP_READY)
+        .expect("wait_for_stderr matched the needle");
+    let addr: SocketAddr = addr
+        .trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("the startup line must name the bound address: {line}: {e}"));
+    assert!(
+        addr.ip().is_loopback() && addr.port() != 0,
+        "the startup line must carry the loopback address the kernel \
+         assigned, not the requested port 0: {line}"
+    );
+    wait_for_tcp(addr).await;
+    (server, addr)
 }
 
 async fn wait_for_tcp(addr: SocketAddr) {
@@ -146,49 +285,6 @@ async fn wait_for_tcp(addr: SocketAddr) {
     assert!(ready.is_ok(), "the binary must start serving on {addr}");
 }
 
-/// Block until `needle` appears on the child's stderr, so a signal is not
-/// delivered before `shutdown_signal` is armed.
-async fn wait_for_stderr(child: &mut Child, needle: &str) {
-    let stderr = child.stderr.as_mut().expect("stderr is piped");
-    let mut lines = BufReader::new(stderr).lines();
-    let found = tokio::time::timeout(EXIT_TIMEOUT, async {
-        loop {
-            let line = lines
-                .next_line()
-                .await
-                .expect("stderr must be readable")
-                .expect("the server must log the startup line before EOF");
-            if line.contains(needle) {
-                return;
-            }
-        }
-    })
-    .await;
-    assert!(
-        found.is_ok(),
-        "timed out waiting for {needle:?} on the child's stderr"
-    );
-}
-
-async fn assert_graceful_exit(child: Child, what: &str) {
-    let output = tokio::time::timeout(EXIT_TIMEOUT, child.wait_with_output())
-        .await
-        .unwrap_or_else(|_| panic!("{what}: the process must exit within {EXIT_TIMEOUT:?}"))
-        .expect("the child must be waitable");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert_eq!(
-        output.status.code(),
-        Some(0),
-        "{what}: SIGTERM/SIGINT must be a clean exit 0, not a signal-kill \
-         (code=None) or an error: status={status:?} stderr={stderr}",
-        status = output.status
-    );
-    assert!(
-        stderr.contains("received shutdown signal"),
-        "{what}: the shutdown path must log that it ran: {stderr}"
-    );
-}
-
 async fn connect_insecure(addr: SocketAddr) -> RunningService<RoleClient, ()> {
     let transport = StreamableHttpClientTransport::with_client(
         reqwest::Client::new(),
@@ -201,40 +297,16 @@ async fn connect_insecure(addr: SocketAddr) -> RunningService<RoleClient, ()> {
 
 #[tokio::test]
 async fn http_sigterm_exits_zero_on_an_idle_listener() {
-    let port = free_port();
-    let child = spawn_binary(&[
-        "--bugzilla-server",
-        "https://bugzilla.example.invalid",
-        "--host",
-        "127.0.0.1",
-        "--port",
-        &port.to_string(),
-        "--insecure-no-auth",
-    ]);
-    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
-    wait_for_tcp(addr).await;
-    let pid = child.id().expect("the child has a pid");
-    send_signal(pid, "TERM");
-    assert_graceful_exit(child, "http idle SIGTERM").await;
+    let (server, _addr) = spawn_http().await;
+    server.signal("TERM");
+    server.assert_graceful_exit("http idle SIGTERM").await;
 }
 
 #[tokio::test]
 async fn http_sigint_still_exits_zero() {
-    let port = free_port();
-    let child = spawn_binary(&[
-        "--bugzilla-server",
-        "https://bugzilla.example.invalid",
-        "--host",
-        "127.0.0.1",
-        "--port",
-        &port.to_string(),
-        "--insecure-no-auth",
-    ]);
-    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
-    wait_for_tcp(addr).await;
-    let pid = child.id().expect("the child has a pid");
-    send_signal(pid, "INT");
-    assert_graceful_exit(child, "http idle SIGINT").await;
+    let (server, _addr) = spawn_http().await;
+    server.signal("INT");
+    server.assert_graceful_exit("http idle SIGINT").await;
 }
 
 #[tokio::test]
@@ -242,29 +314,19 @@ async fn http_sigterm_cancels_a_live_session() {
     // axum's graceful shutdown waits for in-flight connections. A live
     // streamable-HTTP session is one: without `ct.cancel()` the process
     // stays up until this test's timeout, which is the mutation.
-    let port = free_port();
-    let child = spawn_binary(&[
-        "--bugzilla-server",
-        "https://bugzilla.example.invalid",
-        "--host",
-        "127.0.0.1",
-        "--port",
-        &port.to_string(),
-        "--insecure-no-auth",
-    ]);
-    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
-    wait_for_tcp(addr).await;
+    let (server, addr) = spawn_http().await;
     let _session = connect_insecure(addr).await;
-    let pid = child.id().expect("the child has a pid");
-    send_signal(pid, "TERM");
-    assert_graceful_exit(child, "http live-session SIGTERM").await;
+    server.signal("TERM");
+    server
+        .assert_graceful_exit("http live-session SIGTERM")
+        .await;
 }
 
 #[tokio::test]
 async fn stdio_sigterm_during_the_handshake_wait_exits_zero() {
     // `serve(stdio())` blocks on initialize. A stdio container that no
     // client has spoken to yet is in this wait, not in `waiting()`.
-    let mut child = spawn_binary(&[
+    let mut server = Server::spawn(&[
         "--transport",
         "stdio",
         "--bugzilla-server",
@@ -272,28 +334,19 @@ async fn stdio_sigterm_during_the_handshake_wait_exits_zero() {
         "--api-key",
         "test-key",
     ]);
-    wait_for_stderr(&mut child, "Starting Bugzilla MCP server on stdio").await;
-    // Keep stdin open: wait_with_output drops it and EOF-unblocks the
-    // child's blocking read, so a handshake arm that only `return Ok(())`
-    // would go green. Matching the post-initialize test, take stdin and
-    // wait() instead.
-    let _stdin = child.stdin.take();
-    let pid = child.id().expect("the child has a pid");
-    send_signal(pid, "TERM");
-    let status = tokio::time::timeout(EXIT_TIMEOUT, child.wait())
-        .await
-        .expect("stdio pre-handshake SIGTERM: the process must exit")
-        .expect("the child must be waitable");
-    assert_eq!(
-        status.code(),
-        Some(0),
-        "stdio pre-handshake SIGTERM: clean exit 0, not a signal-kill: {status:?}"
-    );
+    // `Server` holds stdin open for the whole test: EOF there unblocks the
+    // child's read, so a handshake arm that only `return Ok(())` would go
+    // green.
+    server.wait_for_stderr(STDIO_READY).await;
+    server.signal("TERM");
+    server
+        .assert_graceful_exit("stdio pre-handshake SIGTERM")
+        .await;
 }
 
 #[tokio::test]
 async fn stdio_sigterm_after_initialize_exits_zero() {
-    let mut child = spawn_binary(&[
+    let mut server = Server::spawn(&[
         "--transport",
         "stdio",
         "--bugzilla-server",
@@ -301,10 +354,10 @@ async fn stdio_sigterm_after_initialize_exits_zero() {
         "--api-key",
         "test-key",
     ]);
-    wait_for_stderr(&mut child, "Starting Bugzilla MCP server on stdio").await;
+    server.wait_for_stderr(STDIO_READY).await;
 
-    let mut stdin = child.stdin.take().expect("stdin is piped");
-    let stdout = child.stdout.take().expect("stdout is piped");
+    let stdin = server.stdin.as_mut().expect("stdin is piped");
+    let stdout = server.child.stdout.take().expect("stdout is piped");
     let mut stdout = BufReader::new(stdout).lines();
     stdin
         .write_all(
@@ -328,16 +381,8 @@ async fn stdio_sigterm_after_initialize_exits_zero() {
     let _drain =
         tokio::spawn(async move { while stdout.next_line().await.ok().flatten().is_some() {} });
 
-    let pid = child.id().expect("the child has a pid");
-    send_signal(pid, "TERM");
-    // stdin/stdout already taken; wait() not wait_with_output.
-    let status = tokio::time::timeout(EXIT_TIMEOUT, child.wait())
-        .await
-        .expect("stdio post-handshake SIGTERM: the process must exit")
-        .expect("the child must be waitable");
-    assert_eq!(
-        status.code(),
-        Some(0),
-        "stdio post-handshake SIGTERM: clean exit 0, not a signal-kill: {status:?}"
-    );
+    server.signal("TERM");
+    server
+        .assert_graceful_exit("stdio post-handshake SIGTERM")
+        .await;
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2953,10 +2953,13 @@ wired, `server.rs` and `main.rs` are the reference.
   live streamable-HTTP session still exits `0` in the same bound, which is
   what `ct.cancel()` is for (axum's graceful shutdown alone waits for that
   connection); stdio SIGTERM during the initialize wait (where an unused
-  stdio container sits) and after a completed handshake both exit `0` with
-  the child's stdin still held, so wrapping only `serve` or only `waiting`
-  fails, and a handshake arm that only `return Ok(())` cannot go green
-  via `wait_with_output` dropping the pipe.
+  stdio container sits) and after a completed handshake both exit `0` and
+  log `received shutdown signal` too, with the child's stdin still held,
+  so wrapping only `serve` or only `waiting` fails, and a handshake arm
+  that only `return Ok(())` cannot go green on an EOF the harness handed
+  it: the test's `Server` takes stdin out of the `Child` at spawn and
+  holds it past `Child::wait`, which closes whatever stdin the `Child`
+  still owns.
 - Unit tests (#[cfg(test)] in crates/bugwarden/src/otel.rs): configuration
   resolution — an unset, emptied or blank endpoint resolves to NO
   configuration and a bad protocol beside it is therefore not an error,


### PR DESCRIPTION
Closes #173. **Started as a test-flake fix; found a production defect.**

## Two races, same root: a readiness barrier that did not prove what it had to

**(1) Signal arming — a shipped bug.** `shutdown_signal()` was an `async fn`, so
the `tokio::signal::unix::signal()` calls that install the handlers ran only on
the future's **first poll** — which happens *after* the "Starting Bugzilla MCP
server on …" line in both transports. A signal in that window got the kernel's
default action: `unix_wait_status(15)`.

Not load-dependent in kind — a fixed program-order defect. The HTTP arm had it
too, arming inside `axum::serve`'s first poll, after a bind that had already made
the port connectable.

Verified from tokio 1.53.1 source: arming is synchronous in `signal_with_handle`
→ `signal_enable`, and a signal delivered before first poll is **retained** via
tokio's watch channel. So arming in the call closes the window completely —
confirmed by delaying the first poll 2s and still passing.

**(2) A handler that failed to install was counted as delivered.** `let _ =
ctrl_c.await` on an install error resolves *immediately* — **shutting down a
healthy server**. Now a failed handler is dropped from the set; with neither
installed the waiter parks on `pending()`, so the kernel's default disposition
survives rather than the process killing itself.

**(3) Port TOCTOU.** Worse than filed: when a stranger holds the port,
`wait_for_tcp` is answered *by the stranger*, so the barrier passes while the
child is still starting — and race (1)'s exact signature follows. Reproduced:
one test failed in **0.01 s with empty stderr**, another **hung past 100 s**.

## Fixes

`shutdown_signal()` is now `fn … -> impl Future`, arming both handlers in the
call — placed late enough that policy load, preflight and the OTLP probe keep the
default disposition, so a signal during slow startup still kills at once.
HTTP logs `local_addr()`, which is what makes `--port 0` usable.

`free_port()` deleted. `spawn_http()` passes `--port 0` and reads the address
from the child's own startup line — #115's shape, an address a stranger can
never occupy, rather than a retry. (Retrying on `EADDRINUSE` would not have
worked: the child is killed before it ever reports a bind failure.)

One stderr reader for the process's life, replacing a per-wait `BufReader` that
discarded whatever it buffered past the matched line.

## Evidence

Pre-fix with a 200 ms injected delay: both stdio tests fail with the
CI-identical text. Post-fix with the window widened to **2 s**: 6/6 pass.
Mutations still bite — dropping SIGTERM fails exactly the 4 SIGTERM tests,
dropping `ct.cancel()` fails exactly the live-session test.

**111/111 passes** under an adversary churning 256 ephemeral binds per cycle;
review independently ran 60/60 with per-iteration binary integrity checks.

No assertion weakened; two added — the stdio tests now also assert `received
shutdown signal`, which only the HTTP ones did.

## Corrections to the issue

The stale `bw159` processes are **not** a test leaking a child: `kill_on_drop`
covers every panic path (probed, 0 survivors). SIGKILLing the harness orphans the
child, and `PR_SET_PDEATHSIG` is ruled out by `unsafe_code = "forbid"`.

And `free_port()`'s own doc comment lied — "turns a lost race into a test failure
rather than a hang". It hangs.

Filed, not fixed: **#222**, the identical `free_port()` copy in
`http_auth_wiremock.rs`.

Review: MERGE-SAFE.
