### PR TITLE
test(otel): decode the wire encoder's output with an independent decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "clap_mangen",
  "futures-core",
  "http",
+ "prost",
  "reqwest",
  "rmcp",
  "schemars",
@@ -531,6 +532,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "equivalent"
@@ -1007,6 +1014,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1258,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -88,6 +88,12 @@ rmcp = { version = "3.1", features = [
     "reqwest",
 ] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
+# An independent protobuf decoder for the hand-rolled OTLP encoder in
+# `otel.rs`: the tests transcribe the opentelemetry-proto messages as
+# `prost::Message` derives, so no `.proto`, no build script and no protoc.
+# Adds four crates (prost, prost-derive, itertools, either) to the dev graph
+# and nothing to the shipped binary.
+prost = "0.14"
 tempfile = "3"
 # `process` and `time`: binary_user_agent spawns the shipped executable
 # and reads its answers under a timeout, so a hung handler fails the test

--- a/crates/bugwarden/src/otel.rs
+++ b/crates/bugwarden/src/otel.rs
@@ -1940,6 +1940,378 @@ mod tests {
         encode_request("bugwarden", std::slice::from_ref(entry))
     }
 
+    // -- protobuf, read back by an independent decoder -----------------------
+
+    /// The OTLP messages `wire` emits, transcribed as prost derives from
+    /// `opentelemetry/proto/{collector/logs,logs,common,resource}/v1/*.proto`
+    /// — the same files `wire`'s own doc comment cites. No `.proto` ships
+    /// here, so no build script and no `protoc`: the field numbers and types
+    /// below are the whole schema.
+    ///
+    /// The point is that none of this shares a line with `wire`. prost reads
+    /// the varints and length prefixes, so a misreading of the encoding spec
+    /// that the encoder and the `fields`/`read_varint` helpers above happen
+    /// to share still fails here. Those helpers are also blind three ways
+    /// this is not: they select a field by number and ignore its WIRE TYPE
+    /// (a varint payload comes back as the same eight little-endian bytes a
+    /// fixed64 would); they only look for the fields they expect, so a
+    /// duplicated or undeclared one passes unseen; and `read_varint` accepts
+    /// non-canonical encodings `put_varint` never emits, so a padded zero
+    /// round-trips clean.
+    mod otlp {
+        // collector/logs/v1/logs_service.proto
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub(super) struct ExportLogsServiceRequest {
+            #[prost(message, repeated, tag = "1")]
+            pub(super) resource_logs: Vec<ResourceLogs>,
+        }
+
+        // logs/v1/logs.proto
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub(super) struct ResourceLogs {
+            #[prost(message, optional, tag = "1")]
+            pub(super) resource: Option<Resource>,
+            #[prost(message, repeated, tag = "2")]
+            pub(super) scope_logs: Vec<ScopeLogs>,
+            #[prost(string, tag = "3")]
+            pub(super) schema_url: String,
+        }
+
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub(super) struct ScopeLogs {
+            #[prost(message, optional, tag = "1")]
+            pub(super) scope: Option<InstrumentationScope>,
+            #[prost(message, repeated, tag = "2")]
+            pub(super) log_records: Vec<LogRecord>,
+            #[prost(string, tag = "3")]
+            pub(super) schema_url: String,
+        }
+
+        /// Field 4 is reserved in the proto and is deliberately absent: prost
+        /// skips fields it does not know, so the guarantee that nothing is
+        /// written there comes from the byte-identity test, not from this.
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub(super) struct LogRecord {
+            #[prost(fixed64, tag = "1")]
+            pub(super) time_unix_nano: u64,
+            #[prost(int32, tag = "2")]
+            pub(super) severity_number: i32,
+            #[prost(string, tag = "3")]
+            pub(super) severity_text: String,
+            #[prost(message, optional, tag = "5")]
+            pub(super) body: Option<AnyValue>,
+            #[prost(message, repeated, tag = "6")]
+            pub(super) attributes: Vec<KeyValue>,
+            #[prost(uint32, tag = "7")]
+            pub(super) dropped_attributes_count: u32,
+            #[prost(fixed32, tag = "8")]
+            pub(super) flags: u32,
+            #[prost(bytes = "vec", tag = "9")]
+            pub(super) trace_id: Vec<u8>,
+            #[prost(bytes = "vec", tag = "10")]
+            pub(super) span_id: Vec<u8>,
+            #[prost(fixed64, tag = "11")]
+            pub(super) observed_time_unix_nano: u64,
+        }
+
+        // resource/v1/resource.proto
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub(super) struct Resource {
+            #[prost(message, repeated, tag = "1")]
+            pub(super) attributes: Vec<KeyValue>,
+            #[prost(uint32, tag = "2")]
+            pub(super) dropped_attributes_count: u32,
+        }
+
+        // common/v1/common.proto
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub(super) struct InstrumentationScope {
+            #[prost(string, tag = "1")]
+            pub(super) name: String,
+            #[prost(string, tag = "2")]
+            pub(super) version: String,
+            #[prost(message, repeated, tag = "3")]
+            pub(super) attributes: Vec<KeyValue>,
+            #[prost(uint32, tag = "4")]
+            pub(super) dropped_attributes_count: u32,
+        }
+
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub(super) struct KeyValue {
+            #[prost(string, tag = "1")]
+            pub(super) key: String,
+            #[prost(message, optional, tag = "2")]
+            pub(super) value: Option<AnyValue>,
+        }
+
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub(super) struct AnyValue {
+            #[prost(oneof = "AnyValueKind", tags = "1, 2, 3, 4, 5, 6, 7")]
+            pub(super) value: Option<AnyValueKind>,
+        }
+
+        /// The `AnyValue` oneof. Variant names are the proto's own field
+        /// names, hence the shared suffix.
+        #[allow(clippy::enum_variant_names)]
+        #[derive(Clone, PartialEq, ::prost::Oneof)]
+        pub(super) enum AnyValueKind {
+            #[prost(string, tag = "1")]
+            StringValue(String),
+            #[prost(bool, tag = "2")]
+            BoolValue(bool),
+            #[prost(int64, tag = "3")]
+            IntValue(i64),
+            #[prost(double, tag = "4")]
+            DoubleValue(f64),
+            #[prost(message, tag = "5")]
+            ArrayValue(ArrayValue),
+            #[prost(message, tag = "6")]
+            KvlistValue(KeyValueList),
+            #[prost(bytes = "vec", tag = "7")]
+            BytesValue(Vec<u8>),
+        }
+
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub(super) struct ArrayValue {
+            #[prost(message, repeated, tag = "1")]
+            pub(super) values: Vec<AnyValue>,
+        }
+
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub(super) struct KeyValueList {
+            #[prost(message, repeated, tag = "1")]
+            pub(super) values: Vec<KeyValue>,
+        }
+    }
+
+    /// Parse the encoder's output with prost, or fail the test.
+    fn decode_request(bytes: &[u8]) -> otlp::ExportLogsServiceRequest {
+        <otlp::ExportLogsServiceRequest as prost::Message>::decode(bytes)
+            .expect("the emitted bytes must parse as an OTLP ExportLogsServiceRequest")
+    }
+
+    /// The one `LogRecord` of a single-entry request.
+    fn decode_record(bytes: &[u8]) -> otlp::LogRecord {
+        let request = decode_request(bytes);
+        let [resource_logs] = &request.resource_logs[..] else {
+            panic!("exactly one ResourceLogs");
+        };
+        let [scope_logs] = &resource_logs.scope_logs[..] else {
+            panic!("exactly one ScopeLogs");
+        };
+        let [record] = &scope_logs.log_records[..] else {
+            panic!("exactly one LogRecord");
+        };
+        record.clone()
+    }
+
+    fn any(value: &Option<otlp::AnyValue>) -> Option<otlp::AnyValueKind> {
+        value.as_ref().and_then(|v| v.value.clone())
+    }
+
+    /// A body of `len` bytes and one attribute, with a nonzero stamp: a zero
+    /// `time_unix_nano` is the one value `wire` writes and prost omits, which
+    /// would fail the byte-identity check for a reason that is not a defect.
+    fn padded_entry(len: usize) -> LogEntry {
+        LogEntry {
+            time_unix_nano: 1_755_000_000_000_000_000,
+            severity: Severity::Info,
+            body: "x".repeat(len),
+            attrs: vec![("bugwarden.pad", AttrValue::Str("y".repeat(len)))],
+            trace: None,
+        }
+    }
+
+    #[test]
+    fn varints_are_byte_for_byte_what_prost_writes_and_reads() {
+        // Both sides of every 7-bit group boundary: each is a place where a
+        // continuation byte appears or a length prefix grows a byte.
+        let mut values = vec![0u64, 300, u64::MAX];
+        for shift in 0..64 {
+            values.push(1u64 << shift);
+            values.push((1u64 << shift) - 1);
+        }
+        for value in values {
+            let mut ours = Vec::new();
+            wire::put_varint(&mut ours, value);
+            let mut theirs = Vec::new();
+            prost::encoding::encode_varint(value, &mut theirs);
+            assert_eq!(ours, theirs, "varint encoding of {value}");
+            let mut cursor = ours.as_slice();
+            assert_eq!(
+                prost::encoding::decode_varint(&mut cursor).ok(),
+                Some(value),
+                "prost must read back {value}"
+            );
+            assert!(cursor.is_empty(), "{value} must use no spare bytes");
+        }
+    }
+
+    #[test]
+    fn an_independent_decoder_reads_back_the_whole_request() {
+        let entry = audit_entry(
+            &event(tool_call(Some(TraceContext {
+                trace_id: "4bf92f3577b34da6a3ce929d0e0e4736".to_owned(),
+                span_id: "00f067aa0ba902b7".to_owned(),
+            }))),
+            br#"{"seq":42}"#,
+        );
+        let bytes = encode_request("bugwarden-edge", std::slice::from_ref(&entry));
+        let request = decode_request(&bytes);
+
+        let [resource_logs] = &request.resource_logs[..] else {
+            panic!("exactly one ResourceLogs");
+        };
+        let resource = resource_logs.resource.as_ref().expect("a Resource");
+        let [service] = &resource.attributes[..] else {
+            panic!("exactly one resource attribute");
+        };
+        assert_eq!(service.key, "service.name");
+        assert_eq!(
+            any(&service.value),
+            Some(otlp::AnyValueKind::StringValue("bugwarden-edge".to_owned()))
+        );
+
+        let [scope_logs] = &resource_logs.scope_logs[..] else {
+            panic!("exactly one ScopeLogs");
+        };
+        let scope = scope_logs.scope.as_ref().expect("an InstrumentationScope");
+        assert_eq!(scope.name, SCOPE_NAME);
+        assert_eq!(scope.version, env!("CARGO_PKG_VERSION"));
+
+        let [record] = &scope_logs.log_records[..] else {
+            panic!("exactly one LogRecord");
+        };
+        assert_eq!(record.severity_number, i32::from(Severity::Info as u8));
+        assert_eq!(record.severity_text, "INFO");
+        assert_eq!(
+            any(&record.body),
+            Some(otlp::AnyValueKind::StringValue(r#"{"seq":42}"#.to_owned()))
+        );
+        // Both stamps must be fixed64, not varints of the same number. prost
+        // refuses the wrong wire type outright; `only(record, 1)` cannot tell
+        // the two apart, because it hands a decoded varint back as the same
+        // eight little-endian bytes.
+        assert_eq!(record.time_unix_nano, entry.time_unix_nano);
+        assert_eq!(record.observed_time_unix_nano, entry.time_unix_nano);
+        assert_eq!(record.trace_id.len(), 16);
+        assert_eq!(record.span_id.len(), 8);
+        assert_eq!(record.trace_id[0], 0x4b);
+        assert_eq!(record.span_id[1], 0xf0);
+
+        // Every attribute, in order, with its AnyValue variant — the type is
+        // half the contract: an int written as a string still decodes.
+        let decoded: Vec<(&str, otlp::AnyValueKind)> = record
+            .attributes
+            .iter()
+            .map(|kv| {
+                (
+                    kv.key.as_str(),
+                    any(&kv.value).expect("an attribute must carry a value"),
+                )
+            })
+            .collect();
+        let expected: Vec<(&str, otlp::AnyValueKind)> = entry
+            .attrs
+            .iter()
+            .map(|(key, value)| {
+                let value = match value {
+                    AttrValue::Str(s) => otlp::AnyValueKind::StringValue(s.clone()),
+                    AttrValue::Int(i) => otlp::AnyValueKind::IntValue(*i),
+                };
+                (*key, value)
+            })
+            .collect();
+        assert!(!expected.is_empty(), "the fixture must carry attributes");
+        assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    fn re_encoding_the_decoded_request_reproduces_every_byte() {
+        // prost writes fields in tag order and omits defaults, which is what
+        // `wire` does, so equality means more than a round trip: every byte
+        // emitted belonged to a field the schema declares, at a canonical
+        // length, with nothing duplicated and nothing trailing. `only`/`all`
+        // see none of that — they look up the fields they expect and let the
+        // rest of the buffer be. An encoder that legitimately reordered its
+        // fields would have to relax this to a decode-and-compare.
+        let entries = vec![
+            audit_entry(&event(tool_call(None)), b"{}"),
+            audit_entry(
+                &event(tool_call(Some(TraceContext {
+                    trace_id: "4bf92f3577b34da6a3ce929d0e0e4736".to_owned(),
+                    span_id: "00f067aa0ba902b7".to_owned(),
+                }))),
+                br#"{"seq":42}"#,
+            ),
+            audit_entry(
+                &event(AuditEventKind::AuditGap(crate::audit::AuditGapEvent {
+                    dropped: 2,
+                    reason: crate::audit::GapReason::WriteError,
+                })),
+                b"{}",
+            ),
+        ];
+        let bytes = encode_request("bugwarden", &entries);
+        assert_eq!(
+            prost::Message::encode_to_vec(&decode_request(&bytes)),
+            bytes,
+            "the request must contain nothing but the fields OTLP declares"
+        );
+    }
+
+    #[test]
+    fn length_prefixes_hold_on_both_sides_of_every_boundary() {
+        // A wrong length prefix is not an error at the collector — the record
+        // is silently dropped — and the prefix is a varint, so the widths it
+        // steps through are where it would go wrong. Cheap enough to check
+        // exhaustively at each step rather than sample.
+        for len in [
+            0usize, 1, 126, 127, 128, 129, 16_382, 16_383, 16_384, 16_385,
+        ] {
+            let entry = padded_entry(len);
+            let bytes = encode_request("bugwarden", std::slice::from_ref(&entry));
+            assert_eq!(
+                any(&decode_record(&bytes).body),
+                Some(otlp::AnyValueKind::StringValue(entry.body.clone())),
+                "a body of {len} bytes"
+            );
+            assert_eq!(
+                prost::Message::encode_to_vec(&decode_request(&bytes)),
+                bytes,
+                "a body of {len} bytes"
+            );
+        }
+    }
+
+    #[test]
+    fn attribute_integers_survive_the_signed_varint_extremes() {
+        // `int_value` is a proto3 `int64`; `wire` reaches it by casting to
+        // u64, which is what makes a negative a ten-byte varint rather than
+        // a wrong one. Nothing in the audit stream is negative today —
+        // `bugwarden.seq` counts up and `bugwarden.response_bytes` is
+        // clamped — so this pins the cast before something needs it.
+        for value in [0i64, 1, -1, 127, 128, -128, i64::MAX, i64::MIN] {
+            let mut entry = padded_entry(0);
+            entry.attrs = vec![("bugwarden.response_bytes", AttrValue::Int(value))];
+            let bytes = encode_request("bugwarden", std::slice::from_ref(&entry));
+            let record = decode_record(&bytes);
+            let [attribute] = &record.attributes[..] else {
+                panic!("exactly one attribute");
+            };
+            assert_eq!(
+                any(&attribute.value),
+                Some(otlp::AnyValueKind::IntValue(value)),
+                "{value} must survive the wire"
+            );
+            assert_eq!(
+                prost::Message::encode_to_vec(&decode_request(&bytes)),
+                bytes,
+                "{value}"
+            );
+        }
+    }
+
     // -- drop accounting ----------------------------------------------------
 
     #[test]

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1815,13 +1815,23 @@ names an endpoint.
   processor logs the transport error itself, with the endpoint URL at debug
   level. Against that, the whole OTLP logs schema this module needs is one
   request message, four nested messages and a varint writer, and going
-  without adds ZERO crates to the lock file for a security-guard product —
-  the SDK route added 17 (`prost` and `prost-derive`,
+  without adds ZERO crates to the SHIPPED BINARY for a security-guard
+  product — the SDK route added 17 (`prost` and `prost-derive`,
   `opentelemetry-proto`, and their own transitive tail), proc macros among
-  them. `cargo deny` therefore has nothing new to judge, and `Cargo.lock`
-  is unchanged by this feature. The cost is owned protobuf encoding, which the
-  unit tests pin field by field and the integration tests decode off the
-  wire.
+  them. The runtime dependency graph is unchanged by this feature.
+  `Cargo.lock` and `cargo deny`'s scope are NOT: the tests take `prost` as a
+  DEV-dependency (issue #201), four lock entries — `prost`, `prost-derive`,
+  `itertools`, `either` — under already-allowed licenses, adding no new
+  duplicate and no normal edge. The cost is owned protobuf encoding, which
+  the unit tests pin field by field and the integration tests decode off the
+  wire. That dev-dependency is what makes those unit tests an oracle rather
+  than a mirror: their hand-written extractor shares its author's reading of
+  the encoding spec with the encoder, and selects fields by number alone, so
+  it cannot see a wrong wire type, a duplicated or undeclared field, or a
+  non-canonical varint — and a wrong length prefix is not an error at the
+  collector, it is a record dropped in silence. No `.proto`, build script or
+  protoc: the messages are transcribed as `prost::Message` derives in the
+  test module.
 - **Invariants.** I15 is untouched: the pipeline is reachable through no
   MCP tool, resource or prompt, and no client can turn it on, off, or
   inspect it. I9 is untouched: nothing here reaches the guard or loosens


### PR DESCRIPTION
Closes #201.

`otel.rs`'s `wire` module hand-rolls protobuf. A wrong length prefix does not
throw — **the collector silently drops the record** and the audit-adjacent
export goes dark. Everything else in the audit path fails loudly or not at all.

## The gap is not where the issue says

The existing hand-written extractor already decodes the emitted bytes, and it
**catches all three failure modes the issue names**. What it misses:

- **Wire types.** `fields()` normalizes a decoded varint to `to_le_bytes()` —
  byte-identical to a `fixed64` payload. A `fixed64` emitted as a varint passes.
  A real collector rejects it.
- **Anything unexpected.** `only()` takes the first match by field number and
  nothing asserts the buffer holds no more, so duplicated fields, undeclared
  fields and non-canonical varints are all invisible.

Seven-mutation matrix, reproduced independently by review:

| mutation | old | new |
|---|---|---|
| length prefix `len+1` | caught | caught |
| dropped continuation byte | caught | caught |
| field number 3 → 4 | caught | caught |
| **fixed64 → varint** | **missed** | caught |
| **field emitted twice** | **missed** | caught |
| **undeclared field appended** | **missed** | caught |
| **non-canonical varint for zero** | **missed** | caught |

## Shape

`prost` as a **dev-dependency** only — no `protoc`, no `.proto`, no `build.rs`.
The messages are hand-transcribed derives, which is what makes them an
independent oracle rather than generated code sharing the encoder's assumptions.
Review diffed every one against `opentelemetry-proto-0.32.0`: no mirrored
transcription error.

**proptest rejected**: the input space is narrow and varint widths enumerable, so
a targeted table is exhaustive where it matters *and* deterministic.

That choice earned itself — the byte-identity test **passed** under the
padded-zero mutation, because its fixtures contain no zero-valued varint. Only
the boundary tables caught it. They are not redundant with it.

## Cost

Four crates in the dev graph (`prost`, `prost-derive`, `itertools`, `either`),
all already-allowed licences, no new duplicates, **none reaching the shipped
binary** (`cargo tree -e normal`: zero hits). MSRV clear.

**No encoder defect found** — `wire` is correct and untouched.

DESIGN.md's rationale for hand-rolling said `cargo deny` "has nothing new to
judge, and `Cargo.lock` is unchanged by this feature". Both were falsified by
this change, so the clauses are rewritten rather than corrected by juxtaposition:
the *runtime* graph is unchanged; the lock and deny's scope are not.

Review: MERGE-SAFE.
