### PR TITLE
ci: assert the image ships a usable CA bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,3 +613,90 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Ship a CA bundle the binary loads
+        shell: bash
+        run: |
+          set -euo pipefail
+          # TLS trust is reqwest -> rustls-platform-verifier ->
+          # rustls-native-certs, which reads the distroless base's own
+          # SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt unfiltered (unset,
+          # it probes the same path first), so the runtime base's bundle is
+          # what every Bugzilla call trusts. Nothing above dials TLS —
+          # bugzilla.invalid is never reached under the identity-free policy —
+          # and what covers the bundle today is an accident: reqwest builds the
+          # verifier in Client::build and errors on an empty root store, so a
+          # scratch base happens to die at the serve step naming nothing about
+          # certificates, while a one-cert stub passes all five (#225).
+          bundle=etc/ssl/certs/ca-certificates.crt
+          cid="$(docker create "$IMAGE")"
+          docker export "$cid" > "$RUNNER_TEMP/rootfs.tar"
+          docker rm "$cid" > /dev/null
+          if ! tar -xf "$RUNNER_TEMP/rootfs.tar" -C "$RUNNER_TEMP" "$bundle" 2> /dev/null; then
+            echo "::error::the image ships no /$bundle"
+            exit 1
+          fi
+          # Decoded, not grepped for BEGIN lines: a truncated or re-encoded
+          # bundle keeps those, and rustls-native-certs drops what it cannot
+          # parse without erroring. distroless ships 150; the floor only has
+          # to sit above a stub.
+          subjects="$(openssl crl2pkcs7 -nocrl -certfile "$RUNNER_TEMP/$bundle" \
+            | openssl pkcs7 -print_certs -noout)"
+          roots="$(grep -c '^subject=' <<< "$subjects" || true)"
+          if [ "$roots" -lt 100 ]; then
+            echo "::error::/$bundle decodes to $roots certificates, expected at least 100"
+            exit 1
+          fi
+          # Present is not loaded: the check above extracts the file as the
+          # runner and reads it with openssl, not as uid 65532 with rustls.
+          # An unreadable bundle has already killed the serve step by the time
+          # this runs, so what this adds is the control-first pattern of "Ship
+          # no shell" — the same command as the masked run below, minus the
+          # mask, so that refusal is attributable to the mask and nothing else.
+          docker run -d --name "$CTR-ca" \
+            -v "$RUNNER_TEMP/policy.toml:/etc/bugwarden/policy.toml:ro" \
+            -e BUGZILLA_SERVER=https://bugzilla.invalid \
+            -e BUGWARDEN_HTTP_TOKEN="$TOKEN" \
+            "$IMAGE" > /dev/null
+          for _ in $(seq 1 100); do
+            if docker logs "$CTR-ca" 2>&1 | grep -qF 'Starting Bugzilla MCP server'; then
+              break
+            fi
+            sleep 0.2
+          done
+          logs="$(docker logs "$CTR-ca" 2>&1)"
+          docker rm -f "$CTR-ca" > /dev/null
+          if ! grep -qF 'Starting Bugzilla MCP server' <<< "$logs"; then
+            echo "::error::the image did not start with its own CA bundle in place"
+            echo "$logs"
+            exit 1
+          fi
+          # The control for that run. Without it, an image whose trust stopped
+          # coming from this directory — SSL_CERT_FILE moved, webpki-roots, a
+          # lazily built verifier — would still start, and everything above
+          # would be measuring a decoration.
+          mkdir -p "$RUNNER_TEMP/no-certs"
+          set +e
+          out="$(timeout 30 docker run --rm \
+            -v "$RUNNER_TEMP/policy.toml:/etc/bugwarden/policy.toml:ro" \
+            -v "$RUNNER_TEMP/no-certs:/etc/ssl/certs:ro" \
+            -e BUGZILLA_SERVER=https://bugzilla.invalid \
+            -e BUGWARDEN_HTTP_TOKEN="$TOKEN" \
+            "$IMAGE" 2>&1)"
+          status=$?
+          set -e
+          echo "$out"
+          # Before the exit status, as in the missing-policy step: a container
+          # that served is killed by `timeout` and exits nonzero too.
+          if grep -qF 'Starting Bugzilla MCP server' <<< "$out"; then
+            echo "::error::the image served with an empty /etc/ssl/certs, so nothing here proves the bundle is used"
+            exit 1
+          fi
+          if [ "$status" -eq 0 ]; then
+            echo "::error::the image started with an empty /etc/ssl/certs"
+            exit 1
+          fi
+          if ! grep -qF 'No CA certificates were loaded from the system' <<< "$out"; then
+            echo "::error::it refused, but not over the empty CA store (check whether rustls-platform-verifier reworded it)"
+            exit 1
+          fi


### PR DESCRIPTION
Closes #225.

## The issue's premise was wrong — mine

It claimed a `scratch` runtime base keeps all five of #202's assertions green.
**False**, verified by building exactly that image: it exits 1 at startup with
`No CA certificates were loaded from the system`, because
`reqwest::ClientBuilder::build` constructs the verifier **eagerly**. #202's serve
step already fails, and diagnosably — that step dumps `docker logs`, which
carries the whole chain.

## So why the step

That coverage is **incidental** — an accident of eager construction, unlabelled,
and it vanishes if reqwest ever goes lazy or if bugwarden gains a `--ca-cert`
option (that path takes `new_with_extra_roots`, which does not error on an empty
system store).

And the sharper reason: **a bundle truncated to one root passes all five today.**

Three claims: the bundle **decodes** to ≥100 certificates (decoded, not
`grep -c BEGIN` — rustls silently drops what it cannot parse, so a truncated
bundle keeps its BEGIN lines); an unmasked run as the control; and the control's
pair, `/etc/ssl/certs` masked, requiring the refusal by name.

## The mechanism the issue got wrong too

It said trust ends at `rustls-native-certs` reading `/etc/ssl/certs`. Actually
`load_native_certs` takes `CertPaths::from_env()` first and returns **early and
unfiltered, with no `exists()` check**, and the distroless base sets
`SSL_CERT_FILE`. openssl-probe never runs.

That matters twice: a base swap removes **both**, and an image that sets
`SSL_CERT_FILE` *wrong* breaks trust with the bundle sitting untouched on disk —
which an existence check alone would never catch.

## The loopback probe the issue suggested does not work

A loopback server cannot present a chain rooted in the shipped bundle — we hold
no CA key — so it proves only that *some* verifier ran, which an empty store
proves identically by failing. The only distinguishing dial is a real public
host, putting third-party availability on every PR.

## Proven

Four mutations, each run: `scratch` base → no bundle; `0600 root:root` →
unreadable; one-root stub → decodes to 1; `SSL_CERT_FILE` moved outside
`/etc/ssl/certs` → served with an empty store. ~8s in CI.

Review re-ran three of them and verified the eagerness and `from_env()` claims in
source. It also caught two prose overclaims — a comment naming the wrong step as
where an unreadable bundle surfaces, and the commit undersell of how diagnosable
the incidental coverage is. Both fixed.

No Dockerfile defect found.

Review: MERGE-SAFE.
