### PR TITLE
ci: smoke-test both release images before the manifest publishes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@ target
 docs
 assets
 examples
+scripts
 # Local run artifacts from the README/compose examples. No COPY reaches them,
 # but a token file has no business in a build context.
 bugwarden.env

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,10 +16,12 @@ concurrency:
 jobs:
   actionlint:
     # Workflow syntax, expression and `run:` shell checks over
-    # .github/workflows/. Its own workflow, not a ci.yml job: a malformed
-    # ci.yml is one of the things this has to report, and GitHub runs no job
-    # from a workflow it cannot parse. No .github/actionlint.yaml: the
-    # defaults pass on every workflow here as it stands.
+    # .github/workflows/, plus shellcheck over scripts/ — actionlint reads
+    # `run:` blocks and nothing else, so a script a workflow calls falls
+    # outside it. Its own workflow, not a ci.yml job: a malformed ci.yml is
+    # one of the things this has to report, and GitHub runs no job from a
+    # workflow it cannot parse. No .github/actionlint.yaml: the defaults pass
+    # on every workflow here as it stands.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -53,3 +55,12 @@ jobs:
           "$RUNNER_TEMP/actionlint" -version
           shellcheck --version
           "$RUNNER_TEMP/actionlint" -color
+      - name: Lint scripts
+        # Whole-file, which is stronger than the per-`run:` snippets actionlint
+        # feeds shellcheck: a snippet has no shebang, no function bodies to
+        # follow and no cross-line dataflow. Unquoted glob so a scripts/
+        # emptied by accident fails here rather than silently passing.
+        shell: bash
+        run: |
+          set -euo pipefail
+          shellcheck scripts/*.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,17 +418,20 @@ jobs:
               - 'Cargo.lock'
               - 'crates/**'
               # The workflows themselves: without ci.yml a change to the
-              # docker job below cannot retrigger it.
+              # docker job below cannot retrigger it. Same for the smoke
+              # script the job runs.
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
+              - 'scripts/**'
 
   docker:
     # Builds the image and then RUNS it. `push: false` alone only proved the
     # image still assembles: nothing started it, so the distroless base, the
     # nonroot uid, the ENV defaults and the BUGWARDEN_POLICY refuse-to-start
     # path all shipped unverified (#202). #114 was a defect of exactly that
-    # shape. release.yml owns the push. amd64 only — the arm64 leg needs a
-    # native runner and exists there.
+    # shape. release.yml owns the push, and runs the same script on both
+    # architectures against the digests it pushed; amd64 here, on a locally
+    # loaded image, is the rehearsal every docker-touching PR gets.
     needs: changes
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
@@ -455,248 +458,19 @@ jobs:
           load: true
           tags: ${{ env.IMAGE }}
 
+      # The assertions live in scripts/container-smoke.sh so release.yml can
+      # run the identical set against each architecture's pushed digest
+      # (#223); actionlint's per-`run:` shellcheck stops at a workflow file, so
+      # actionlint.yml shellchecks the script whole.
       - name: Serve behind the bearer gate with a mounted policy
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Deliberately identity-free: a policy consulting created_by_me
-          # makes startup preflight GET /rest/whoami, and this container
-          # reaches no Bugzilla. 0644 so uid 65532 can read the bind mount.
-          cat > "$RUNNER_TEMP/policy.toml" <<'EOF'
-          default_action = "deny"
-          EOF
-          # Generated rather than written down: the gate refuses anything
-          # under 32 characters, and a literal would be a secret scanner's
-          # problem for no gain. Worthless by construction — it guards a
-          # server holding no Bugzilla credential.
-          token="$(openssl rand -hex 32)"
-          echo "TOKEN=$token" >> "$GITHUB_ENV"
-          docker run -d --name "$CTR" \
-            -p 127.0.0.1:8000:8000 \
-            -v "$RUNNER_TEMP/policy.toml:/etc/bugwarden/policy.toml:ro" \
-            -e BUGZILLA_SERVER=https://bugzilla.invalid \
-            -e BUGWARDEN_HTTP_TOKEN="$token" \
-            "$IMAGE"
-          # Nothing here passes --transport, --host or --port, so an answer on
-          # the published port is the assertion on the image's ENV block: the
-          # CLI's own defaults bind 127.0.0.1, which no port mapping reaches,
-          # and a stdio or off-by-one-port default reaches it no better. The
-          # `:ro` mount is compose.yaml's, since the guard reads the policy
-          # once and nothing may reach it afterwards.
-          code=000
-          for _ in $(seq 1 100); do
-            if [ "$(docker inspect -f '{{.State.Running}}' "$CTR")" != "true" ]; then
-              echo "::error::the container exited during startup"
-              docker logs "$CTR"
-              exit 1
-            fi
-            code="$(curl -s -o /dev/null -m 2 -w '%{http_code}' -X POST http://127.0.0.1:8000/mcp || true)"
-            [ "$code" = "000" ] || break
-            sleep 0.2
-          done
-          # The gate wraps the whole router, so an unauthenticated POST is
-          # refused before rmcp sees it: the 401 is both the readiness signal
-          # and the proof the door is locked.
-          if [ "$code" != "401" ]; then
-            echo "::error::an unauthenticated POST /mcp answered $code, expected 401"
-            docker logs "$CTR"
-            exit 1
-          fi
-          body="$(curl -sS -m 10 -X POST http://127.0.0.1:8000/mcp \
-            -H "Authorization: Bearer $token" \
-            -H 'Accept: application/json, text/event-stream' \
-            -H 'Content-Type: application/json' \
-            -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"ci-smoke","version":"1"}}}' || true)"
-          # serverInfo names this crate and not the SDK (#53), so the
-          # handshake identifies which process answered, not merely that one
-          # did.
-          if ! grep -qF '"serverInfo"' <<< "$body" || ! grep -qF '"name":"bugwarden"' <<< "$body"; then
-            echo "::error::the handshake was not answered by bugwarden: $body"
-            docker logs "$CTR"
-            exit 1
-          fi
-
+        run: scripts/container-smoke.sh serve
       - name: Run as the nonroot uid the deployment docs pin
-        shell: bash
-        run: |
-          set -euo pipefail
-          # The number, not `docker inspect .Config.User`'s "nonroot:nonroot"
-          # name: compose.yaml and the README tell operators to chown the key
-          # file and the audit directory to 65532, so a base whose nonroot
-          # resolves to a different uid breaks every documented deployment
-          # while the name still reads correctly.
-          uids="$(docker top "$CTR" -o uid,pid | awk 'NR > 1 { print $1 }' | sort -u)"
-          if [ "$uids" != "65532" ]; then
-            echo "::error::the container runs as uid '$uids', expected 65532"
-            exit 1
-          fi
-
+        run: scripts/container-smoke.sh uid
       - name: Stop gracefully on SIGTERM as PID 1
-        shell: bash
-        run: |
-          set -euo pipefail
-          # #114: PID 1 gets no default SIGTERM action from the kernel, so a
-          # binary listening only for ctrl_c survives `docker stop` until the
-          # grace period expires and SIGKILL lands — exit 137, never 0.
-          # binary_shutdown.rs pins the handlers in the binary; this is the
-          # only thing that runs them at PID 1 in the distroless image.
-          start="$(date +%s)"
-          docker stop -t 10 "$CTR" > /dev/null
-          elapsed="$(( $(date +%s) - start ))"
-          status="$(docker inspect -f '{{.State.ExitCode}}' "$CTR")"
-          if [ "$status" != "0" ]; then
-            echo "::error::the container exited $status on SIGTERM (137 = ignored it and was killed)"
-            docker logs "$CTR"
-            exit 1
-          fi
-          # Not binary_shutdown.rs's 5s: `date +%s` quantizes, and a loaded
-          # runner has stopped a healthy container in 6s where steady state
-          # is under a second. Still inside the 10s grace, past which SIGKILL
-          # lands and the exit-code arm above catches it instead.
-          if [ "$elapsed" -ge 8 ]; then
-            echo "::error::SIGTERM took ${elapsed}s to stop the container"
-            exit 1
-          fi
-
+        run: scripts/container-smoke.sh sigterm
       - name: Refuse to start with no policy mounted
-        shell: bash
-        run: |
-          set -euo pipefail
-          # The image presets BUGWARDEN_POLICY precisely so an unmounted
-          # /etc/bugwarden/policy.toml is a startup error instead of the
-          # binary's allow-all fallback. Both variables below are supplied on
-          # purpose: clap rejects a missing --server and the bearer gate
-          # resolves before the policy loads, so omitting either would make
-          # this exit nonzero for a reason that is not the one under test.
-          set +e
-          out="$(timeout 30 docker run --rm \
-            -e BUGZILLA_SERVER=https://bugzilla.invalid \
-            -e BUGWARDEN_HTTP_TOKEN="$TOKEN" \
-            "$IMAGE" 2>&1)"
-          status=$?
-          set -e
-          echo "$out"
-          # Before the exit status, because a container that served instead of
-          # refusing is killed by `timeout` and exits nonzero too.
-          if grep -qF 'Starting Bugzilla MCP server' <<< "$out"; then
-            echo "::error::the image served with no policy mounted"
-            exit 1
-          fi
-          if [ "$status" -eq 0 ]; then
-            echo "::error::the image started with no policy mounted"
-            exit 1
-          fi
-          if ! grep -qF 'failed to load guard policy from /etc/bugwarden/policy.toml' <<< "$out"; then
-            echo "::error::it refused, but not over the missing policy"
-            exit 1
-          fi
-
+        run: scripts/container-smoke.sh policy
       - name: Ship no shell
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Control first: without it a broken --entrypoint or a wrong tag
-          # would make the refusals below pass for the wrong reason.
-          version="$(docker run --rm --entrypoint /usr/local/bin/bugwarden "$IMAGE" --version)"
-          case "$version" in
-            'bugwarden '*) ;;
-            *)
-              echo "::error::--version printed '$version'"
-              exit 1
-              ;;
-          esac
-          # A base swapped for a debugging-friendly one (alpine, debian) is
-          # the regression this catches; distroless static carries no /bin.
-          for sh in /bin/sh /bin/bash; do
-            if docker run --rm --entrypoint "$sh" "$IMAGE" -c 'exit 0' 2> /dev/null; then
-              echo "::error::$sh runs in the image, so the base is no longer distroless"
-              exit 1
-            fi
-          done
-
+        run: scripts/container-smoke.sh shell
       - name: Ship a CA bundle the binary loads
-        shell: bash
-        run: |
-          set -euo pipefail
-          # TLS trust is reqwest -> rustls-platform-verifier ->
-          # rustls-native-certs, which reads the distroless base's own
-          # SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt unfiltered (unset,
-          # it probes the same path first), so the runtime base's bundle is
-          # what every Bugzilla call trusts. Nothing above dials TLS —
-          # bugzilla.invalid is never reached under the identity-free policy —
-          # and what covers the bundle today is an accident: reqwest builds the
-          # verifier in Client::build and errors on an empty root store, so a
-          # scratch base happens to die at the serve step naming nothing about
-          # certificates, while a one-cert stub passes all five (#225).
-          bundle=etc/ssl/certs/ca-certificates.crt
-          cid="$(docker create "$IMAGE")"
-          docker export "$cid" > "$RUNNER_TEMP/rootfs.tar"
-          docker rm "$cid" > /dev/null
-          if ! tar -xf "$RUNNER_TEMP/rootfs.tar" -C "$RUNNER_TEMP" "$bundle" 2> /dev/null; then
-            echo "::error::the image ships no /$bundle"
-            exit 1
-          fi
-          # Decoded, not grepped for BEGIN lines: a truncated or re-encoded
-          # bundle keeps those, and rustls-native-certs drops what it cannot
-          # parse without erroring. distroless ships 150; the floor only has
-          # to sit above a stub.
-          subjects="$(openssl crl2pkcs7 -nocrl -certfile "$RUNNER_TEMP/$bundle" \
-            | openssl pkcs7 -print_certs -noout)"
-          roots="$(grep -c '^subject=' <<< "$subjects" || true)"
-          if [ "$roots" -lt 100 ]; then
-            echo "::error::/$bundle decodes to $roots certificates, expected at least 100"
-            exit 1
-          fi
-          # Present is not loaded: the check above extracts the file as the
-          # runner and reads it with openssl, not as uid 65532 with rustls.
-          # An unreadable bundle has already killed the serve step by the time
-          # this runs, so what this adds is the control-first pattern of "Ship
-          # no shell" — the same command as the masked run below, minus the
-          # mask, so that refusal is attributable to the mask and nothing else.
-          docker run -d --name "$CTR-ca" \
-            -v "$RUNNER_TEMP/policy.toml:/etc/bugwarden/policy.toml:ro" \
-            -e BUGZILLA_SERVER=https://bugzilla.invalid \
-            -e BUGWARDEN_HTTP_TOKEN="$TOKEN" \
-            "$IMAGE" > /dev/null
-          for _ in $(seq 1 100); do
-            if docker logs "$CTR-ca" 2>&1 | grep -qF 'Starting Bugzilla MCP server'; then
-              break
-            fi
-            sleep 0.2
-          done
-          logs="$(docker logs "$CTR-ca" 2>&1)"
-          docker rm -f "$CTR-ca" > /dev/null
-          if ! grep -qF 'Starting Bugzilla MCP server' <<< "$logs"; then
-            echo "::error::the image did not start with its own CA bundle in place"
-            echo "$logs"
-            exit 1
-          fi
-          # The control for that run. Without it, an image whose trust stopped
-          # coming from this directory — SSL_CERT_FILE moved, webpki-roots, a
-          # lazily built verifier — would still start, and everything above
-          # would be measuring a decoration.
-          mkdir -p "$RUNNER_TEMP/no-certs"
-          set +e
-          out="$(timeout 30 docker run --rm \
-            -v "$RUNNER_TEMP/policy.toml:/etc/bugwarden/policy.toml:ro" \
-            -v "$RUNNER_TEMP/no-certs:/etc/ssl/certs:ro" \
-            -e BUGZILLA_SERVER=https://bugzilla.invalid \
-            -e BUGWARDEN_HTTP_TOKEN="$TOKEN" \
-            "$IMAGE" 2>&1)"
-          status=$?
-          set -e
-          echo "$out"
-          # Before the exit status, as in the missing-policy step: a container
-          # that served is killed by `timeout` and exits nonzero too.
-          if grep -qF 'Starting Bugzilla MCP server' <<< "$out"; then
-            echo "::error::the image served with an empty /etc/ssl/certs, so nothing here proves the bundle is used"
-            exit 1
-          fi
-          if [ "$status" -eq 0 ]; then
-            echo "::error::the image started with an empty /etc/ssl/certs"
-            exit 1
-          fi
-          if ! grep -qF 'No CA certificates were loaded from the system' <<< "$out"; then
-            echo "::error::it refused, but not over the empty CA store (check whether rustls-platform-verifier reworded it)"
-            exit 1
-          fi
+        run: scripts/container-smoke.sh ca

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,8 +306,10 @@ jobs:
   container:
     # Native runners per architecture: an emulated aws-lc-sys compile under
     # QEMU takes tens of minutes, and ubuntu-24.04-arm makes it unnecessary.
-    # Sibling of `publish`, not upstream of it: a broken image build must not
-    # hold back the crates.io release of a tag whose binaries already shipped.
+    # It also runs each image, on its own architecture, before the manifest
+    # publishes. Sibling of `publish`, not upstream of it: a broken or broken-
+    # behaving image must not hold back the crates.io release of a tag whose
+    # binaries already shipped.
     needs: [release, toolchain-drift]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -315,6 +317,8 @@ jobs:
       contents: read
       # Push the per-architecture images to ghcr.io.
       packages: write
+    env:
+      CTR: bugwarden-smoke
     strategy:
       fail-fast: false
       matrix:
@@ -353,6 +357,36 @@ jobs:
           # No cache-from/cache-to: releases build hermetically, same rule as
           # the cargo-cache-free `build` job above.
           outputs: type=image,name=ghcr.io/plusky/bugwarden,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Pull the pushed image by digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Smoke the registry's bytes, not the builder's local sibling.
+          image="ghcr.io/plusky/bugwarden@${{ steps.build.outputs.digest }}"
+          docker pull "$image"
+          echo "IMAGE=$image" >>"$GITHUB_ENV"
+      # ci.yml's assertions, same script, now on both architectures and against
+      # what ghcr.io will actually serve (#223) — the arm64 image was never
+      # executed anywhere before this. The digest is in ghcr.io before any of
+      # them can run, which push-by-digest makes unavoidable; a failure fails
+      # the leg, so container-manifest never runs and no :$VERSION or :latest
+      # names it. The bytes stay behind as an unreferenced, tag-invisible
+      # digest — the same residue a failed container-manifest leaves today,
+      # and accepted as such.
+      - name: Serve behind the bearer gate with a mounted policy
+        run: scripts/container-smoke.sh serve
+      - name: Run as the nonroot uid the deployment docs pin
+        run: scripts/container-smoke.sh uid
+      - name: Stop gracefully on SIGTERM as PID 1
+        run: scripts/container-smoke.sh sigterm
+      - name: Refuse to start with no policy mounted
+        run: scripts/container-smoke.sh policy
+      - name: Ship no shell
+        run: scripts/container-smoke.sh shell
+      - name: Ship a CA bundle the binary loads
+        run: scripts/container-smoke.sh ca
+
       - name: Export digest
         shell: bash
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,9 +187,13 @@ A release is one push of an annotated tag; nothing is released by hand.
   Publishing; the container image has none yet.
 - The same tag also ships the multi-arch container image
   `ghcr.io/plusky/bugwarden` (jobs `container`, `container-manifest`).
-  `container` is a sibling of `publish`, not upstream of it — a broken image
-  build must not hold back the crates.io release of a tag whose binaries
-  already shipped.
+  `container` runs `scripts/container-smoke.sh` — ci.yml's own assertions —
+  against the digest each architecture just pushed, so a misbehaving image
+  fails its leg and `container-manifest` publishes no tag naming it; the
+  rejected bytes stay in ghcr.io as an unreferenced digest, which
+  push-by-digest makes unavoidable. `container` is a sibling of `publish`,
+  not upstream of it — a broken image build must not hold back the crates.io
+  release of a tag whose binaries already shipped.
 - The `.deb`/`.rpm` come from `cargo-deb` and `cargo-generate-rpm`, both
   pinned to an exact version and installed `--locked`, reading
   `[package.metadata.deb]` / `[package.metadata.generate-rpm]` in

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# Runtime assertions on the bugwarden container image: the things only running
+# it can prove (#202, #225). Two callers, so the set cannot drift between them
+# — ci.yml smokes a locally built amd64 image on PRs, release.yml smokes each
+# architecture's pushed digest before container-manifest publishes the tag.
+#
+#   usage: scripts/container-smoke.sh serve|uid|sigterm|policy|shell|ca
+#
+# One assertion per invocation, so a failure names itself in the job UI.
+# `serve` starts the container the `uid` and `sigterm` assertions inspect and
+# must run before them; the rest stand alone.
+#
+#   IMAGE        image to run — a local tag, or a ghcr.io/...@sha256: ref
+#   CTR          name for the served container (`ca` also uses "$CTR-ca")
+#   RUNNER_TEMP  scratch: the policy bind mount, the bearer token, a rootfs tar
+set -euo pipefail
+
+: "${IMAGE:?IMAGE must name the image to smoke}"
+: "${CTR:?CTR must name the container to run}"
+: "${RUNNER_TEMP:?RUNNER_TEMP must name a writable scratch directory}"
+
+# The policy file and the bearer token are made here rather than handed
+# between steps through $GITHUB_ENV, so each assertion below can also run on
+# its own.
+write_policy() {
+  # Deliberately identity-free: a policy consulting created_by_me makes
+  # startup preflight GET /rest/whoami, and this container reaches no
+  # Bugzilla. 0644 so uid 65532 can read the bind mount.
+  cat > "$RUNNER_TEMP/policy.toml" <<'EOF'
+default_action = "deny"
+EOF
+}
+
+# Generated rather than written down: the gate refuses anything under 32
+# characters, and a literal would be a secret scanner's problem for no gain.
+# Worthless by construction — it guards a server holding no Bugzilla
+# credential. Cached in a file so the assertions that run after `serve` present
+# the token its container was started with.
+bearer_token() {
+  [ -s "$RUNNER_TEMP/smoke-token" ] ||
+    (umask 077 && openssl rand -hex 32 > "$RUNNER_TEMP/smoke-token")
+  cat "$RUNNER_TEMP/smoke-token"
+}
+
+smoke_serve() {
+  write_policy
+  token="$(bearer_token)"
+  docker run -d --name "$CTR" \
+    -p 127.0.0.1:8000:8000 \
+    -v "$RUNNER_TEMP/policy.toml:/etc/bugwarden/policy.toml:ro" \
+    -e BUGZILLA_SERVER=https://bugzilla.invalid \
+    -e BUGWARDEN_HTTP_TOKEN="$token" \
+    "$IMAGE"
+  # Nothing here passes --transport, --host or --port, so an answer on
+  # the published port is the assertion on the image's ENV block: the
+  # CLI's own defaults bind 127.0.0.1, which no port mapping reaches,
+  # and a stdio or off-by-one-port default reaches it no better. The
+  # `:ro` mount is compose.yaml's, since the guard reads the policy
+  # once and nothing may reach it afterwards.
+  code=000
+  for _ in $(seq 1 100); do
+    if [ "$(docker inspect -f '{{.State.Running}}' "$CTR")" != "true" ]; then
+      echo "::error::the container exited during startup"
+      docker logs "$CTR"
+      exit 1
+    fi
+    code="$(curl -s -o /dev/null -m 2 -w '%{http_code}' -X POST http://127.0.0.1:8000/mcp || true)"
+    [ "$code" = "000" ] || break
+    sleep 0.2
+  done
+  # The gate wraps the whole router, so an unauthenticated POST is
+  # refused before rmcp sees it: the 401 is both the readiness signal
+  # and the proof the door is locked.
+  if [ "$code" != "401" ]; then
+    echo "::error::an unauthenticated POST /mcp answered $code, expected 401"
+    docker logs "$CTR"
+    exit 1
+  fi
+  body="$(curl -sS -m 10 -X POST http://127.0.0.1:8000/mcp \
+    -H "Authorization: Bearer $token" \
+    -H 'Accept: application/json, text/event-stream' \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"ci-smoke","version":"1"}}}' || true)"
+  # serverInfo names this crate and not the SDK (#53), so the
+  # handshake identifies which process answered, not merely that one
+  # did.
+  if ! grep -qF '"serverInfo"' <<< "$body" || ! grep -qF '"name":"bugwarden"' <<< "$body"; then
+    echo "::error::the handshake was not answered by bugwarden: $body"
+    docker logs "$CTR"
+    exit 1
+  fi
+}
+
+smoke_uid() {
+  # The number, not `docker inspect .Config.User`'s "nonroot:nonroot"
+  # name: compose.yaml and the README tell operators to chown the key
+  # file and the audit directory to 65532, so a base whose nonroot
+  # resolves to a different uid breaks every documented deployment
+  # while the name still reads correctly.
+  uids="$(docker top "$CTR" -o uid,pid | awk 'NR > 1 { print $1 }' | sort -u)"
+  if [ "$uids" != "65532" ]; then
+    echo "::error::the container runs as uid '$uids', expected 65532"
+    exit 1
+  fi
+}
+
+smoke_sigterm() {
+  # #114: PID 1 gets no default SIGTERM action from the kernel, so a
+  # binary listening only for ctrl_c survives `docker stop` until the
+  # grace period expires and SIGKILL lands — exit 137, never 0.
+  # binary_shutdown.rs pins the handlers in the binary; this is the
+  # only thing that runs them at PID 1 in the distroless image.
+  start="$(date +%s)"
+  docker stop -t 10 "$CTR" > /dev/null
+  elapsed="$(( $(date +%s) - start ))"
+  status="$(docker inspect -f '{{.State.ExitCode}}' "$CTR")"
+  if [ "$status" != "0" ]; then
+    echo "::error::the container exited $status on SIGTERM (137 = ignored it and was killed)"
+    docker logs "$CTR"
+    exit 1
+  fi
+  # Not binary_shutdown.rs's 5s: `date +%s` quantizes, and a loaded
+  # runner has stopped a healthy container in 6s where steady state
+  # is under a second. Still inside the 10s grace, past which SIGKILL
+  # lands and the exit-code arm above catches it instead.
+  if [ "$elapsed" -ge 8 ]; then
+    echo "::error::SIGTERM took ${elapsed}s to stop the container"
+    exit 1
+  fi
+}
+
+smoke_policy() {
+  # The image presets BUGWARDEN_POLICY precisely so an unmounted
+  # /etc/bugwarden/policy.toml is a startup error instead of the
+  # binary's allow-all fallback. Both variables below are supplied on
+  # purpose: clap rejects a missing --server and the bearer gate
+  # resolves before the policy loads, so omitting either would make
+  # this exit nonzero for a reason that is not the one under test.
+  set +e
+  out="$(timeout 30 docker run --rm \
+    -e BUGZILLA_SERVER=https://bugzilla.invalid \
+    -e BUGWARDEN_HTTP_TOKEN="$(bearer_token)" \
+    "$IMAGE" 2>&1)"
+  status=$?
+  set -e
+  echo "$out"
+  # Before the exit status, because a container that served instead of
+  # refusing is killed by `timeout` and exits nonzero too.
+  if grep -qF 'Starting Bugzilla MCP server' <<< "$out"; then
+    echo "::error::the image served with no policy mounted"
+    exit 1
+  fi
+  if [ "$status" -eq 0 ]; then
+    echo "::error::the image started with no policy mounted"
+    exit 1
+  fi
+  if ! grep -qF 'failed to load guard policy from /etc/bugwarden/policy.toml' <<< "$out"; then
+    echo "::error::it refused, but not over the missing policy"
+    exit 1
+  fi
+}
+
+smoke_shell() {
+  # Control first: without it a broken --entrypoint or a wrong tag
+  # would make the refusals below pass for the wrong reason.
+  version="$(docker run --rm --entrypoint /usr/local/bin/bugwarden "$IMAGE" --version)"
+  case "$version" in
+    'bugwarden '*) ;;
+    *)
+      echo "::error::--version printed '$version'"
+      exit 1
+      ;;
+  esac
+  # A base swapped for a debugging-friendly one (alpine, debian) is
+  # the regression this catches; distroless static carries no /bin.
+  for sh in /bin/sh /bin/bash; do
+    if docker run --rm --entrypoint "$sh" "$IMAGE" -c 'exit 0' 2> /dev/null; then
+      echo "::error::$sh runs in the image, so the base is no longer distroless"
+      exit 1
+    fi
+  done
+}
+
+smoke_ca() {
+  # TLS trust is reqwest -> rustls-platform-verifier ->
+  # rustls-native-certs, which reads the distroless base's own
+  # SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt unfiltered (unset,
+  # it probes the same path first), so the runtime base's bundle is
+  # what every Bugzilla call trusts. Nothing above dials TLS —
+  # bugzilla.invalid is never reached under the identity-free policy —
+  # and what covers the bundle today is an accident: reqwest builds the
+  # verifier in Client::build and errors on an empty root store, so a
+  # scratch base happens to die at the serve step naming nothing about
+  # certificates, while a one-cert stub passes all five (#225).
+  bundle=etc/ssl/certs/ca-certificates.crt
+  cid="$(docker create "$IMAGE")"
+  docker export "$cid" > "$RUNNER_TEMP/rootfs.tar"
+  docker rm "$cid" > /dev/null
+  if ! tar -xf "$RUNNER_TEMP/rootfs.tar" -C "$RUNNER_TEMP" "$bundle" 2> /dev/null; then
+    echo "::error::the image ships no /$bundle"
+    exit 1
+  fi
+  # Decoded, not grepped for BEGIN lines: a truncated or re-encoded
+  # bundle keeps those, and rustls-native-certs drops what it cannot
+  # parse without erroring. distroless ships 150; the floor only has
+  # to sit above a stub.
+  subjects="$(openssl crl2pkcs7 -nocrl -certfile "$RUNNER_TEMP/$bundle" \
+    | openssl pkcs7 -print_certs -noout)"
+  roots="$(grep -c '^subject=' <<< "$subjects" || true)"
+  if [ "$roots" -lt 100 ]; then
+    echo "::error::/$bundle decodes to $roots certificates, expected at least 100"
+    exit 1
+  fi
+  # Present is not loaded: the check above extracts the file as the
+  # runner and reads it with openssl, not as uid 65532 with rustls.
+  # An unreadable bundle has already killed the serve step by the time
+  # this runs, so what this adds is the control-first pattern of "Ship
+  # no shell" — the same command as the masked run below, minus the
+  # mask, so that refusal is attributable to the mask and nothing else.
+  write_policy  # `serve` already did, unless this assertion is run alone
+  docker run -d --name "$CTR-ca" \
+    -v "$RUNNER_TEMP/policy.toml:/etc/bugwarden/policy.toml:ro" \
+    -e BUGZILLA_SERVER=https://bugzilla.invalid \
+    -e BUGWARDEN_HTTP_TOKEN="$(bearer_token)" \
+    "$IMAGE" > /dev/null
+  for _ in $(seq 1 100); do
+    if docker logs "$CTR-ca" 2>&1 | grep -qF 'Starting Bugzilla MCP server'; then
+      break
+    fi
+    sleep 0.2
+  done
+  logs="$(docker logs "$CTR-ca" 2>&1)"
+  docker rm -f "$CTR-ca" > /dev/null
+  if ! grep -qF 'Starting Bugzilla MCP server' <<< "$logs"; then
+    echo "::error::the image did not start with its own CA bundle in place"
+    echo "$logs"
+    exit 1
+  fi
+  # The control for that run. Without it, an image whose trust stopped
+  # coming from this directory — SSL_CERT_FILE moved, webpki-roots, a
+  # lazily built verifier — would still start, and everything above
+  # would be measuring a decoration.
+  mkdir -p "$RUNNER_TEMP/no-certs"
+  set +e
+  out="$(timeout 30 docker run --rm \
+    -v "$RUNNER_TEMP/policy.toml:/etc/bugwarden/policy.toml:ro" \
+    -v "$RUNNER_TEMP/no-certs:/etc/ssl/certs:ro" \
+    -e BUGZILLA_SERVER=https://bugzilla.invalid \
+    -e BUGWARDEN_HTTP_TOKEN="$(bearer_token)" \
+    "$IMAGE" 2>&1)"
+  status=$?
+  set -e
+  echo "$out"
+  # Before the exit status, as in the missing-policy step: a container
+  # that served is killed by `timeout` and exits nonzero too.
+  if grep -qF 'Starting Bugzilla MCP server' <<< "$out"; then
+    echo "::error::the image served with an empty /etc/ssl/certs, so nothing here proves the bundle is used"
+    exit 1
+  fi
+  if [ "$status" -eq 0 ]; then
+    echo "::error::the image started with an empty /etc/ssl/certs"
+    exit 1
+  fi
+  if ! grep -qF 'No CA certificates were loaded from the system' <<< "$out"; then
+    echo "::error::it refused, but not over the empty CA store (check whether rustls-platform-verifier reworded it)"
+    exit 1
+  fi
+}
+
+case "${1-}" in
+  serve) smoke_serve ;;
+  uid) smoke_uid ;;
+  sigterm) smoke_sigterm ;;
+  policy) smoke_policy ;;
+  shell) smoke_shell ;;
+  ca) smoke_ca ;;
+  *)
+    echo "usage: ${0##*/} serve|uid|sigterm|policy|shell|ca" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Closes #223.

`release.yml`'s container job built both arches, pushed them by digest, and
`container-manifest` published the manifest — **running nothing**. The arm64
image that ships to ghcr was never executed anywhere in this repo.

`ci.yml` had eight proven assertions (#202, #225) — amd64 only, PRs only.

## Extracted to `scripts/container-smoke.sh`, called by both

Alternatives rejected for concrete reasons: duplicating is ~281 lines of shell
that #225 already rewrote weeks after #202; a **composite action would escape
both actionlint and shellcheck**, since actionlint does not check `action.yml`
files at all; a reusable workflow is a separate *job*, so it cannot run inside
the container matrix leg.

The script gets **whole-file** shellcheck — stronger than the per-snippet
coverage inline YAML gets.

**Provably verbatim.** The six `run:` bodies were pulled out mechanically and
diffed against the assembled functions; review re-derived it independently.
Three byte-identical, three differing by exactly four intended deltas: the policy
heredoc and `openssl rand` became helpers, the `GITHUB_ENV` token handoff is
gone, and `ca` gained a `write_policy` so it runs standalone. No assertion,
threshold or exit path weakened.

## Two traps handled

`actionlint.yml` gains `shellcheck scripts/*.sh` — unquoted glob, so an emptied
`scripts/` fails rather than passes (verified: exits 2). And ci.yml's `changes`
filter gains `scripts/**`, or a script-only change would stop retriggering the
docker job that runs it.

## arm64, and what "blocking" means

Runs in the existing `ubuntu-24.04-arm` matrix leg — proven in three shipped
releases, no emulation, no new job. Against the **pulled digest ref**, so it
smokes the registry's actual bytes rather than a local sibling.

Push-by-digest puts both images in ghcr **before** any smoke can run — inherent,
not reorderable. A failure fails the leg, so `container-manifest` never runs and
no `:$VERSION` or `:latest` ever points at the bytes. **The broken digest remains
in the registry, unreferenced and tag-invisible** — the same residue a failed
`container-manifest` leaves today. Accepted, and recorded in release.yml and
AGENTS.md so it is not re-litigated.

The sibling constraint is intact: `needs:` values are byte-identical to the
parent, so a smoke failure blocks the manifest and never `publish`.

## Verification

Five mutations re-run **on arm64** through the extracted script; review killed
four independently with correct attribution. The digest-ref form was proven
directly rather than assumed, leaving the tag-only delta at ~10 reviewable lines.

Review confirmed the one thing that could not be worked around: actionlint
rejects `${{ steps.build.outputs.digest }}` in a job-level `env:`, so the single
surviving `GITHUB_ENV` write is necessary, not stylistic.

Methodological note for anyone re-running the set: a busybox-at-`/bin/sh`
mutation *appears* to pass, because the dynamically linked binary cannot exec at
all. The valid form is an alpine base.

Review: MERGE-SAFE.
