### PR TITLE
test(server): share the startup-line barrier

### DIFF
--- a/crates/bugwarden/tests/binary_shutdown.rs
+++ b/crates/bugwarden/tests/binary_shutdown.rs
@@ -40,11 +40,14 @@ use rmcp::ServiceExt as _;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
-use tokio::io::Lines;
 use tokio::process::Child;
-use tokio::process::ChildStderr;
 use tokio::process::ChildStdin;
 use tokio::process::Command;
+
+#[path = "common/startup_line.rs"]
+mod startup_line;
+
+use startup_line::HTTP_READY;
 
 /// Bounded so a binary that ignores the signal fails this test rather than
 /// hanging the suite until CI's own timeout kills it. Well under docker's
@@ -109,12 +112,7 @@ fn the_scrub_list_covers_every_environment_fallback() {
     );
 }
 
-/// The line the http transport logs once it is bound *and* its signal
-/// handlers are armed; the address that follows is the one the kernel
-/// assigned, which with `--port 0` is the only way to learn it.
-const HTTP_READY: &str = "Starting Bugzilla MCP server on ";
-
-/// The same, for stdio, which has no address.
+/// [`HTTP_READY`]'s counterpart for stdio, which has no address to parse.
 const STDIO_READY: &str = "Starting Bugzilla MCP server on stdio";
 
 /// A spawned binary, its pipes, and every stderr line it has written.
@@ -128,7 +126,7 @@ struct Server {
     /// One reader for the process's whole life. A `BufReader` built per
     /// wait throws away whatever it buffered past the line it matched,
     /// which can swallow the line a later assertion needs.
-    stderr: Lines<BufReader<ChildStderr>>,
+    stderr: startup_line::StderrLines,
     /// Every stderr line read so far, for the assertions and diagnostics.
     log: String,
 }
@@ -149,7 +147,7 @@ impl Server {
         cmd.kill_on_drop(true);
         let mut child = cmd.spawn().expect("the built binary must start");
         let stdin = child.stdin.take();
-        let stderr = BufReader::new(child.stderr.take().expect("stderr is piped")).lines();
+        let stderr = startup_line::stderr_lines(&mut child);
         Self {
             child,
             stdin,
@@ -161,38 +159,12 @@ impl Server {
     /// Read stderr until a line contains `needle`, and return that line.
     /// The startup lines are the readiness barriers: see the module docs.
     async fn wait_for_stderr(&mut self, needle: &str) -> String {
-        let found = tokio::time::timeout(EXIT_TIMEOUT, async {
-            while let Some(line) = self.next_stderr_line().await {
-                if line.contains(needle) {
-                    return Some(line);
-                }
-            }
-            None
-        })
-        .await;
-        match found {
-            Ok(Some(line)) => line,
-            Ok(None) => panic!(
-                "the child's stderr ended before {needle:?}: {log}",
-                log = self.log
-            ),
-            Err(_) => panic!(
-                "timed out waiting for {needle:?} on the child's stderr: {log}",
-                log = self.log
-            ),
-        }
+        startup_line::wait_for_line(&mut self.stderr, &mut self.log, needle, EXIT_TIMEOUT).await
     }
 
     /// Next stderr line, recorded in `log`; `None` at EOF.
     async fn next_stderr_line(&mut self) -> Option<String> {
-        let line = self
-            .stderr
-            .next_line()
-            .await
-            .expect("the child's stderr must be readable")?;
-        self.log.push_str(&line);
-        self.log.push('\n');
-        Some(line)
+        startup_line::next_logged_line(&mut self.stderr, &mut self.log).await
     }
 
     fn pid(&self) -> u32 {
@@ -256,18 +228,7 @@ async fn spawn_http() -> (Server, SocketAddr) {
         "--insecure-no-auth",
     ]);
     let line = server.wait_for_stderr(HTTP_READY).await;
-    let (_, addr) = line
-        .split_once(HTTP_READY)
-        .expect("wait_for_stderr matched the needle");
-    let addr: SocketAddr = addr
-        .trim()
-        .parse()
-        .unwrap_or_else(|e| panic!("the startup line must name the bound address: {line}: {e}"));
-    assert!(
-        addr.ip().is_loopback() && addr.port() != 0,
-        "the startup line must carry the loopback address the kernel \
-         assigned, not the requested port 0: {line}"
-    );
+    let addr = startup_line::parse_bound_addr(&line);
     wait_for_tcp(addr).await;
     (server, addr)
 }

--- a/crates/bugwarden/tests/common/startup_line.rs
+++ b/crates/bugwarden/tests/common/startup_line.rs
@@ -1,0 +1,97 @@
+//! The shipped binary's own startup line, which is the readiness barrier for
+//! every test that spawns it (#173, #222, #230).
+//!
+//! Included by `#[path]` from each user rather than declared in
+//! `common/mod.rs`: that module is compiled into every test binary that says
+//! `mod common;`, so a helper only two of them use would be `dead_code` in
+//! the rest, which `-D warnings` rejects.
+//!
+//! Nothing here owns the reader or picks the timeout, because the two callers
+//! need opposite policies past the barrier and neither can be the shared
+//! default. `binary_shutdown::Server` keeps one reader for the process's
+//! life — a `BufReader` built per wait throws away whatever it buffered past
+//! the match, which can swallow the line a later assertion needs — while
+//! `http_auth_wiremock` hands its reader to a drain, because its child keeps
+//! serving past the barrier and an unread pipe becomes backpressure. So the
+//! shared part is the needle plus wait-and-parse; ownership and budget stay
+//! with the caller.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use tokio::io::AsyncBufReadExt as _;
+use tokio::io::BufReader;
+use tokio::io::Lines;
+use tokio::process::Child;
+use tokio::process::ChildStderr;
+
+/// The line the http transport logs once it is bound *and* its signal
+/// handlers are armed; the address that follows is the one the kernel
+/// assigned, which under `--port 0` is the only way to learn it.
+pub const HTTP_READY: &str = "Starting Bugzilla MCP server on ";
+
+/// A spawned child's stderr, read a line at a time.
+pub type StderrLines = Lines<BufReader<ChildStderr>>;
+
+/// Take the child's piped stderr as a line reader.
+pub fn stderr_lines(child: &mut Child) -> StderrLines {
+    BufReader::new(child.stderr.take().expect("stderr is piped")).lines()
+}
+
+/// Next stderr line, recorded in `log`; `None` at EOF.
+pub async fn next_logged_line(lines: &mut StderrLines, log: &mut String) -> Option<String> {
+    let line = lines
+        .next_line()
+        .await
+        .expect("the child's stderr must be readable")?;
+    log.push_str(&line);
+    log.push('\n');
+    Some(line)
+}
+
+/// Read stderr until a line contains `needle`, and return that line.
+///
+/// Both failures dump everything read so far, so a renamed startup line
+/// fails with the log that names it rather than a bare timeout.
+pub async fn wait_for_line(
+    lines: &mut StderrLines,
+    log: &mut String,
+    needle: &str,
+    budget: Duration,
+) -> String {
+    let found = tokio::time::timeout(budget, async {
+        while let Some(line) = next_logged_line(lines, log).await {
+            if line.contains(needle) {
+                return Some(line);
+            }
+        }
+        None
+    })
+    .await;
+    match found {
+        Ok(Some(line)) => line,
+        Ok(None) => panic!("the child's stderr ended before {needle:?}: {log}"),
+        Err(_) => panic!("timed out waiting for {needle:?} on the child's stderr: {log}"),
+    }
+}
+
+/// The address an [`HTTP_READY`] `line` names.
+///
+/// The kernel picked it under `--port 0`, so a line still carrying the
+/// requested `0` — or an address off loopback — means the barrier matched
+/// something that is not the child's real listener.
+pub fn parse_bound_addr(line: &str) -> SocketAddr {
+    let addr: SocketAddr = line
+        .split_once(HTTP_READY)
+        .expect("the wait matched the needle")
+        .1
+        .trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("the startup line must name the bound address: {line}: {e}"));
+    assert!(
+        addr.ip().is_loopback() && addr.port() != 0,
+        "the startup line must carry the loopback address the kernel \
+         assigned, not the requested port 0: {line}"
+    );
+    addr
+}

--- a/crates/bugwarden/tests/http_auth_wiremock.rs
+++ b/crates/bugwarden/tests/http_auth_wiremock.rs
@@ -45,8 +45,6 @@ use rmcp::transport::streamable_http_server::{
 use rmcp::transport::StreamableHttpClientTransport;
 use rmcp::ServiceExt as _;
 use serde_json::{json, Value};
-use tokio::io::AsyncBufReadExt as _;
-use tokio::io::BufReader;
 use tokio::process::Child;
 use wiremock::matchers::{any, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -56,6 +54,9 @@ mod raw_post;
 
 #[path = "common/pinned_cli.rs"]
 mod pinned_cli;
+
+#[path = "common/startup_line.rs"]
+mod startup_line;
 
 use pinned_cli::pinned;
 
@@ -804,11 +805,6 @@ async fn every_startup_misconfiguration_refuses_before_the_port_is_bound() {
     drop(occupied);
 }
 
-/// The line the http transport logs once it is bound; the address that
-/// follows is the one the kernel assigned, which under `--port 0` is the
-/// only way to learn it.
-const HTTP_READY: &str = "Starting Bugzilla MCP server on ";
-
 /// Wait for the child's own startup line and return the address it bound.
 ///
 /// The barrier this replaces was a bind-then-drop `free_port()` plus a
@@ -820,44 +816,19 @@ const HTTP_READY: &str = "Starting Bugzilla MCP server on ";
 /// process that keeps it — and a line only the child can write is the
 /// readiness proof the probe was not.
 async fn bound_addr(child: &mut Child) -> SocketAddr {
-    let mut stderr = BufReader::new(child.stderr.take().expect("stderr is piped")).lines();
+    let mut stderr = startup_line::stderr_lines(child);
     let mut log = String::new();
-    let found = tokio::time::timeout(EXIT_TIMEOUT, async {
-        while let Some(line) = stderr
-            .next_line()
-            .await
-            .expect("the child's stderr must be readable")
-        {
-            log.push_str(&line);
-            log.push('\n');
-            if line.contains(HTTP_READY) {
-                return Some(line);
-            }
-        }
-        None
-    })
+    let line = startup_line::wait_for_line(
+        &mut stderr,
+        &mut log,
+        startup_line::HTTP_READY,
+        EXIT_TIMEOUT,
+    )
     .await;
-    let line = match found {
-        Ok(Some(line)) => line,
-        Ok(None) => panic!("the child's stderr ended before it bound a port: {log}"),
-        Err(_) => panic!("timed out waiting for the child's startup line: {log}"),
-    };
     // Nothing reads stderr after this, but the child keeps logging and a
     // full pipe would block it mid-request: one reader for its whole life.
     tokio::spawn(async move { while matches!(stderr.next_line().await, Ok(Some(_))) {} });
-    let addr: SocketAddr = line
-        .split_once(HTTP_READY)
-        .expect("the wait matched the needle")
-        .1
-        .trim()
-        .parse()
-        .unwrap_or_else(|e| panic!("the startup line must name the bound address: {line}: {e}"));
-    assert!(
-        addr.ip().is_loopback() && addr.port() != 0,
-        "the startup line must carry the loopback address the kernel \
-         assigned, not the requested port 0: {line}"
-    );
-    addr
+    startup_line::parse_bound_addr(&line)
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #230.

`HTTP_READY` — the needle matching `main.rs`'s startup line — sat in two test
files against one producer, each with its own spawn-and-parse harness.

## Both of the issue's premises were wrong, in opposite directions

**The divergence it named does not exist.** Both copies already asserted
`is_loopback() && port != 0` in byte-identical wording; `git log -S` puts that
assertion in `7650b00`, #173's own commit, so #222 copied rather than added it.
What actually diverged is the timeout budget (5s vs 20s), the two panic texts,
and `binary_shutdown`'s extra `wait_for_tcp` probe — the first and third
legitimately per-caller. The issue body has been corrected.

**The cost it named does not materialise either.** #230 predicted extraction
"means reshaping `Server::spawn`". It does not: every shared function *borrows*
the line reader and takes the budget as an argument, so neither stderr-ownership
policy has to become a shared default. `Server::spawn`'s signature and ownership
are untouched.

## The seam

`crates/bugwarden/tests/common/startup_line.rs`, `#[path]`-included by both —
the pattern #167/#214/#222 used to dodge `common/mod.rs`'s dead-code trap.
`binary_shutdown::Server` still keeps one reader for the process's life;
`http_auth_wiremock::bound_addr` still hands its reader to a drain between the
wait and the parse. Callers −90/+22, shared +97.

The gain is one diagnostic instead of two, and one place for the next sanity
check to land.

## Mutation

Renaming the producer (`main.rs:300`, "server on" → "server at") fails 3 tests
in `binary_shutdown` and 1 in `http_auth_wiremock`, all four with the same
message and the child's log attached. Review added two more against the shared
assert — logging the requested `127.0.0.1:0`, and a non-loopback address — each
failing 3+1 on the arm it targets. The two stdio tests correctly stay green.

Review: merge as-is, no claim disproved. It replicated all eight AGENTS.md
commands, 25× per suite, and confirmed the swallowing hazard cannot recur —
no per-wait `BufReader` exists anywhere in the new code.
