### PR TITLE
test(otel): stop guessing a dead port

### DIFF
--- a/crates/bugwarden/tests/common/mod.rs
+++ b/crates/bugwarden/tests/common/mod.rs
@@ -1,32 +1,9 @@
 //! Shared helpers for bugwarden integration tests.
-
-/// Connect-time failure that wiremock's 127.0.0.1 pool cannot serve (#115).
-///
-/// The address is `127.0.0.1:1`. Port 1 is privileged: a non-root
-/// wiremock listener binds `127.0.0.1:0` and cannot occupy it, so a
-/// pooled listener from another test cannot answer this request. The
-/// load-bearing assertion is `port() < 1024` — a bind-then-drop of an
-/// ephemeral port fails the helper. A 500 ms TCP probe refuses to
-/// return an address that accepted or timed out; the URL is built from
-/// the probed socket so the two cannot drift.
-pub fn refused_base_url() -> String {
-    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 1));
-    assert!(
-        addr.port() < 1024,
-        "I12 transport tests must use a privileged port; wiremock binds 127.0.0.1:0 (#115)"
-    );
-    match std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(500)) {
-        Ok(_) => panic!(
-            "{addr} accepted a connection; I12 tests need a refused address \
-             that wiremock's 127.0.0.1:0 pool cannot occupy (#115)"
-        ),
-        Err(e) if e.kind() == std::io::ErrorKind::TimedOut => panic!(
-            "{addr} timed out; refusing to point the 30s client at an address \
-             that would hang the test (#115)"
-        ),
-        Err(_) => format!("http://{addr}"),
-    }
-}
+//!
+//! Only what every `mod common;` binary uses belongs here; anything
+//! narrower goes in a sibling file included by `#[path]`, or it is
+//! `dead_code` in the binaries that skip it (#167, #214). The refused
+//! address moved to `common/refused.rs` for that reason (#229).
 
 /// Bound on the I12 client calls. Loopback refuse is immediate; a hang
 /// here is a proxy or routing defect, not a 30s client timeout.

--- a/crates/bugwarden/tests/common/refused.rs
+++ b/crates/bugwarden/tests/common/refused.rs
@@ -1,0 +1,40 @@
+//! An address that refuses every connection and no test in this suite can
+//! occupy, for the harnesses that need a connect-time failure (#115, #229).
+//!
+//! Included by `#[path]` from each user rather than declared in
+//! `common/mod.rs`: that module is compiled into every test binary that
+//! says `mod common;`, so a helper only some of them use would be
+//! `dead_code` in the rest, which `-D warnings` rejects (#167, #214).
+//! `REFUSED_CONNECT_BUDGET` stayed behind because only the guard-client
+//! harnesses bound a call with it.
+
+/// Connect-time failure nothing in this process can answer (#115, #229).
+///
+/// The address is `127.0.0.1:1`. Port 1 is privileged: a non-root test
+/// process cannot bind it, so neither wiremock's `127.0.0.1:0` pool nor a
+/// stranger racing an ephemeral port can answer this request. The
+/// load-bearing assertion is `port() < 1024` — a bind-then-drop of an
+/// ephemeral port fails the helper. A 500 ms TCP probe refuses to
+/// return an address that accepted or timed out; the URL is built from
+/// the probed socket so the two cannot drift.
+///
+/// Scheme and authority only: a caller needing a path (`/v1/logs` for
+/// the OTLP export) appends its own.
+pub fn refused_base_url() -> String {
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 1));
+    assert!(
+        addr.port() < 1024,
+        "these tests must use a privileged port; wiremock binds 127.0.0.1:0 (#115, #229)"
+    );
+    match std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(500)) {
+        Ok(_) => panic!(
+            "{addr} accepted a connection; these tests need a refused address \
+             that wiremock's 127.0.0.1:0 pool cannot occupy (#115)"
+        ),
+        Err(e) if e.kind() == std::io::ErrorKind::TimedOut => panic!(
+            "{addr} timed out; refusing to point a 30s client at an address \
+             that would hang the test (#115)"
+        ),
+        Err(_) => format!("http://{addr}"),
+    }
+}

--- a/crates/bugwarden/tests/otel_wiremock.rs
+++ b/crates/bugwarden/tests/otel_wiremock.rs
@@ -31,6 +31,8 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[path = "common/pinned_cli.rs"]
 mod pinned_cli;
+#[path = "common/refused.rs"]
+mod refused;
 
 use pinned_cli::pinned;
 
@@ -527,23 +529,19 @@ async fn the_exported_body_is_the_file_record_byte_for_byte() {
     );
 }
 
-/// A port nothing listens on: bind it, learn the number, drop it.
-fn dead_endpoint() -> String {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("a free port");
-    let addr = listener.local_addr().expect("an address");
-    drop(listener);
-    format!("http://{addr}")
-}
-
 #[tokio::test]
 async fn a_dead_collector_fails_the_sink_and_open_mode_accounts_with_gaps() {
     // Revised 2026-08-18: a configured collector is load-bearing. Under
     // the `open` fail mode (the stdio default) serving continues — as it
     // does for a failing FILE — but the sink reports failure and the
     // undelivered window lands in `audit_gap` records, never silently.
+    // The endpoint refuses by construction: the bind-then-drop ephemeral
+    // port this used to take could be won by a stranger, and one answering
+    // 2xx keeps the sink healthy — the outage this test is about never
+    // happens (#229).
     let mock = MockServer::start().await;
     mount_bugzilla(&mock).await;
-    let served = exporting_server(&mock, Some(&dead_endpoint())).await;
+    let served = exporting_server(&mock, Some(&refused::refused_base_url())).await;
 
     let result = call(&served.client, "bug_info", json!({ "bug_ids": [7] }), None).await;
     assert_ne!(

--- a/crates/bugwarden/tests/preflight_wiremock.rs
+++ b/crates/bugwarden/tests/preflight_wiremock.rs
@@ -31,6 +31,8 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[path = "common/pinned_cli.rs"]
 mod pinned_cli;
+#[path = "common/refused.rs"]
+mod refused;
 
 use pinned_cli::pinned;
 
@@ -277,7 +279,7 @@ async fn preflight_transport_error_does_not_leak_the_api_key_i12() {
     // the whoami lookup fails at the transport level, where the
     // unsanitized error would carry the request URL with api_key=... in
     // it. Nothing in the preflight error text may contain the key.
-    let base = common::refused_base_url();
+    let base = refused::refused_base_url();
 
     let cfg: Arc<Cli> = Arc::new(pinned(&[
         "bugwarden",

--- a/crates/bugwarden/tests/tools_wiremock.rs
+++ b/crates/bugwarden/tests/tools_wiremock.rs
@@ -37,6 +37,8 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[path = "common/pinned_cli.rs"]
 mod pinned_cli;
+#[path = "common/refused.rs"]
+mod refused;
 
 use pinned_cli::pinned;
 
@@ -2521,7 +2523,7 @@ async fn whoami_transport_error_does_not_leak_the_api_key_i12() {
     // the whoami lookup (and everything after it) fails at the transport
     // level, where the unsanitized error would carry the request URL with
     // api_key=... in it. Nothing the client sees may contain the key.
-    let base = common::refused_base_url();
+    let base = refused::refused_base_url();
 
     let cfg: Arc<Cli> = Arc::new(pinned(&[
         "bugwarden",


### PR DESCRIPTION
Closes #229.

`otel_wiremock.rs`'s `dead_endpoint()` bound `127.0.0.1:0`, learned the number and
dropped it — the last bind-then-drop in the tests after #173 and #222. It wants a
port that is *dead*, so the exposure is the inverse of those: a stranger
answering 2xx makes a test that asserts failure meet a success.

Replaced with the in-repo precedent, `refused_base_url()`'s privileged port 1,
which `common/mod.rs` already documents as the reason bind-then-drop is avoided.
Fits the OTLP path: `resolve()` appends `/v1/logs`, and `otel.rs`'s own unit
tests already export to that address for a dead collector.

## The issue's severity argument was wrong — corrected in its body

It claimed this fails quietly. It does not: `wait_failing(&served.audit, true)`
asserts the sink *reaches* failure, so a 2xx squatter panics at that barrier
before the `audit_gap`, `dropped()` and bounded-shutdown assertions run. Same
loud shape as #173 and #222. The residual is that the panic blames the audit
sink rather than a port collision, sending the reader to the wrong subsystem.

## The mutation that matters

"A squatter can no longer be constructed" is a negative — it proves only that an
unprivileged process cannot bind port 1 (`ip_unprivileged_port_start` = 1024),
not that the test still bites. Review built the constructible one: a **live
wiremock answering 200 on `/v1/logs`**, against which the test fails at the
barrier in 8.43s. The test discriminates a reachable collector from an
unreachable one; this is not a weaker test than it replaced.

Review also flipped `note_delivery(&self.healthy, false)` → `true` in
`flush_audit`'s error arm: that mutant **survives** the integration test, which
reaches `failing()` through loss accounting rather than the health flag, and is
killed by the unit test `an_unreachable_collector_loses_audit_records_loudly_not_as_drops`.
No hole — but the two paths are covered independently, not redundantly.

Timing has ~16× margin: refusal measured at 0.2ms, health flips on the first
failed flush one `BATCH_INTERVAL` (500ms) later, against an 8s budget.
`EXPORT_TIMEOUT` only bites on a hang, which `refused_base_url`'s own probe
panics on first.

## Placement

The helper moved to `tests/common/refused.rs`, taken by `#[path]`.
`otel_wiremock.rs` does not declare `mod common;`, and adding it would make the
sibling `REFUSED_CONNECT_BUDGET` dead code under `-D warnings` (#167, #214).
`common/mod.rs` keeps the budget const, still used by both binaries that compile
it. No test assertion changed.

Review: merge as-is. Eight AGENTS.md commands re-run independently, suite 30×.
