### PR TITLE
test(server): share the ambient scrub list

### DIFF
--- a/crates/bugwarden/src/otel.rs
+++ b/crates/bugwarden/src/otel.rs
@@ -97,9 +97,10 @@ pub const LOGS_PROTOCOL_VAR: &str = "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL";
 /// Every environment variable this module reads.
 ///
 /// These are read by the module, not by `Cli`, so clap's own
-/// `get_env` sweep cannot see them. `tests/binary_user_agent.rs` holds its
-/// environment scrub list to this list as well, so a variable added here
-/// cannot go on reaching a spawned test binary from the developer's shell.
+/// `get_env` sweep cannot see them. `tests/common/scrub_env.rs` holds the
+/// shared scrub list to this list, walked from every spawning binary, so a
+/// variable added here cannot go on reaching a spawned test binary from the
+/// developer's shell.
 pub const ENV_VARS: [&str; 7] = [
     ENDPOINT_VAR,
     HEADERS_VAR,

--- a/crates/bugwarden/tests/binary_shutdown.rs
+++ b/crates/bugwarden/tests/binary_shutdown.rs
@@ -92,6 +92,10 @@ fn the_scrub_list_covers_every_environment_fallback() {
         .filter(|env| !AMBIENT_VARS.contains(&env.as_str()))
         .collect();
     assert!(
+        !AMBIENT_VARS.is_empty() && cmd.get_arguments().any(|arg| arg.get_env().is_some()),
+        "the check is only evidence while both lists are non-empty"
+    );
+    assert!(
         unscrubbed.is_empty(),
         "these environment fallbacks reach the spawned binary: {unscrubbed:?}"
     );

--- a/crates/bugwarden/tests/binary_shutdown.rs
+++ b/crates/bugwarden/tests/binary_shutdown.rs
@@ -44,6 +44,9 @@ use tokio::process::Child;
 use tokio::process::ChildStdin;
 use tokio::process::Command;
 
+#[path = "common/scrub_env.rs"]
+mod scrub_env;
+
 #[path = "common/startup_line.rs"]
 mod startup_line;
 
@@ -54,65 +57,13 @@ use startup_line::HTTP_READY;
 /// default 10s grace, so a "it will die eventually" path cannot pass.
 const EXIT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Every environment variable the binary reads, cleared before each spawn.
-const AMBIENT_VARS: &[&str] = &[
-    "BUGZILLA_SERVER",
-    "BUGZILLA_API_KEY",
-    "BUGZILLA_API_KEY_FILE",
-    "BUGWARDEN_POLICY",
-    "BUGWARDEN_AUDIT_CONFIG",
-    "BUGWARDEN_HTTP_TOKEN",
-    "BUGWARDEN_HTTP_READ_TOKEN",
-    "BUGZILLA_USE_AUTH_HEADER",
-    "MCP_TRANSPORT",
-    "MCP_HOST",
-    "MCP_PORT",
-    "MCP_ALLOWED_HOSTS",
-    "MCP_READ_ONLY",
-    "MCP_API_KEY_HEADER",
-    "RUST_LOG",
-    "OTEL_EXPORTER_OTLP_ENDPOINT",
-    "OTEL_EXPORTER_OTLP_HEADERS",
-    "OTEL_EXPORTER_OTLP_PROTOCOL",
-    "OTEL_SERVICE_NAME",
-    "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
-    "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
-    "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
-];
-
-/// The scrub list is only as good as its coverage of `Cli`.
+/// Each binary runs the walker itself, so a single-binary
+/// `cargo test --test binary_shutdown` still proves what its scrub claims.
 #[test]
 fn the_scrub_list_covers_every_environment_fallback() {
-    let mut cmd = bugwarden::config::command();
-    cmd.build();
-    let unscrubbed: Vec<String> = cmd
-        .get_arguments()
-        .filter_map(clap::Arg::get_env)
-        .map(|env| env.to_string_lossy().into_owned())
-        .filter(|env| !AMBIENT_VARS.contains(&env.as_str()))
-        .collect();
-    assert!(
-        !AMBIENT_VARS.is_empty() && cmd.get_arguments().any(|arg| arg.get_env().is_some()),
-        "the check is only evidence while both lists are non-empty"
-    );
-    assert!(
-        unscrubbed.is_empty(),
-        "these environment fallbacks reach the spawned binary: {unscrubbed:?}"
-    );
-    for var in [
-        bugwarden::http_auth::WRITE_TOKEN_VAR,
-        bugwarden::http_auth::READ_TOKEN_VAR,
-    ] {
-        assert!(AMBIENT_VARS.contains(&var), "{var} must be scrubbed");
-    }
-    let unscrubbed_otel: Vec<&str> = bugwarden::otel::ENV_VARS
-        .iter()
-        .copied()
-        .filter(|var| !AMBIENT_VARS.contains(var))
-        .collect();
-    assert!(
-        unscrubbed_otel.is_empty(),
-        "these OTLP variables reach the spawned binary: {unscrubbed_otel:?}"
+    scrub_env::assert_the_scrub_list_covers_every_environment_fallback(
+        scrub_env::AMBIENT_VARS,
+        scrub_env::HTTP_TOKEN_VARS,
     );
 }
 
@@ -144,7 +95,7 @@ impl Server {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        for var in AMBIENT_VARS {
+        for var in scrub_env::AMBIENT_VARS {
             cmd.env_remove(var);
         }
         cmd.env("RUST_LOG", "info");

--- a/crates/bugwarden/tests/binary_user_agent.rs
+++ b/crates/bugwarden/tests/binary_user_agent.rs
@@ -16,79 +16,32 @@ use tokio::process::Command;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+#[path = "common/scrub_env.rs"]
+mod scrub_env;
+
 /// Bounded so a binary that never answers fails this test rather than
 /// hanging the suite until CI's own timeout kills it.
 const REPLY_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// The ambient environment must not reach the child: every one of these is
-/// read by `Cli`, or — the `OTEL_*` set — by `bugwarden::otel` outside
-/// clap entirely (`RUST_LOG` only muddies the captured stderr). Scrubbed as
-/// one set rather than per test — the http-only knobs are inert for a stdio
-/// run today, and pruning them is how the list falls behind `Cli` again.
-/// `the_scrub_list_covers_every_environment_fallback` holds it to every
-/// `env`-backed flag AND to every variable the otel module names, so adding
-/// one in either population cannot quietly leave a hole here.
-const SCRUBBED_ENV: [&str; 20] = [
-    "BUGZILLA_SERVER",
-    "BUGZILLA_API_KEY",
-    "BUGZILLA_API_KEY_FILE",
-    "BUGZILLA_USE_AUTH_HEADER",
-    "BUGWARDEN_POLICY",
-    "BUGWARDEN_AUDIT_CONFIG",
-    "MCP_TRANSPORT",
-    "MCP_HOST",
-    "MCP_PORT",
-    "MCP_ALLOWED_HOSTS",
-    "MCP_API_KEY_HEADER",
-    "MCP_READ_ONLY",
-    "RUST_LOG",
-    // Read by the otel module, not by `Cli`: a developer exporting to a
-    // collector would otherwise have every spawned child export too, and
-    // an unreachable one would slow this test down for no reason.
-    "OTEL_EXPORTER_OTLP_ENDPOINT",
-    "OTEL_EXPORTER_OTLP_HEADERS",
-    "OTEL_EXPORTER_OTLP_PROTOCOL",
-    "OTEL_SERVICE_NAME",
-    // The signal-specific trio, which the OTLP spec makes override the
-    // three above — so leaving them ambient would override the test's own
-    // world, not merely add to it.
-    "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
-    "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
-    "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
-];
+/// The shared scrub list less the two HTTP bearer tokens: this file spawns
+/// stdio children, which bind no listener and ignore both
+/// (`a_stdio_start_ignores_the_bearer_tokens`). Derived rather
+/// than re-typed, so the omission stays a stated choice and not a drift.
+fn scrubbed_env() -> Vec<&'static str> {
+    scrub_env::AMBIENT_VARS
+        .iter()
+        .copied()
+        .filter(|var| !scrub_env::HTTP_TOKEN_VARS.contains(var))
+        .collect()
+}
 
-/// The scrub list above is only as good as its coverage of `Cli`, and a
-/// flag added with an `env` fallback would otherwise go on reaching the
-/// child from the developer's or the runner's environment.
+/// Each binary runs the walker itself, so a single-binary
+/// `cargo test --test binary_user_agent` still proves what its scrub claims.
 #[test]
 fn the_scrub_list_covers_every_environment_fallback() {
-    let mut cmd = bugwarden::config::command();
-    cmd.build();
-    let unscrubbed: Vec<String> = cmd
-        .get_arguments()
-        .filter_map(clap::Arg::get_env)
-        .map(|env| env.to_string_lossy().into_owned())
-        .filter(|env| !SCRUBBED_ENV.contains(&env.as_str()))
-        .collect();
-    assert!(
-        !SCRUBBED_ENV.is_empty() && cmd.get_arguments().any(|arg| arg.get_env().is_some()),
-        "the check is only evidence while both lists are non-empty"
-    );
-    assert!(
-        unscrubbed.is_empty(),
-        "these environment fallbacks reach the spawned binary: {unscrubbed:?}"
-    );
-
-    // The second population: variables read outside clap, which the sweep
-    // above cannot see because no `Arg` carries them.
-    let unscrubbed: Vec<&str> = bugwarden::otel::ENV_VARS
-        .into_iter()
-        .filter(|var| !SCRUBBED_ENV.contains(var))
-        .collect();
-    assert!(
-        unscrubbed.is_empty(),
-        "these otel variables reach the spawned binary: {unscrubbed:?}"
-    );
+    // Empty `by_name`: the bearer tokens are exactly what `scrubbed_env`
+    // drops, so demanding them back would contradict the derivation.
+    scrub_env::assert_the_scrub_list_covers_every_environment_fallback(&scrubbed_env(), &[]);
 }
 
 /// The identity this build must present. Spelled out rather than read from
@@ -125,7 +78,7 @@ async fn upstream_requests_of_a_real_run(
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null());
-    for var in SCRUBBED_ENV {
+    for var in scrubbed_env() {
         cmd.env_remove(var);
     }
     let mut child = cmd.spawn().expect("the built binary must start");

--- a/crates/bugwarden/tests/common/pinned_cli.rs
+++ b/crates/bugwarden/tests/common/pinned_cli.rs
@@ -21,9 +21,9 @@ const MINIMAL_ARGV: &[&str] = &["bugwarden", "--bugzilla-server", "https://bugzi
 ///
 /// `Arg::env` snapshots the variable when the command is built, so the
 /// reset covers fields added to `Cli` after this line was written — which
-/// is the point. The sibling `AMBIENT_VARS` list in `http_auth_wiremock.rs`
-/// solves the other half of the same problem and is deliberately not
-/// shared: it scrubs the environment of a *spawned* binary, and doing that
+/// is the point. `common/scrub_env.rs` solves the other half of the same
+/// problem for every spawning binary, and the two stay separate: that list
+/// scrubs the environment of a *spawned* child, and doing the same
 /// in-process would race every other test in the binary.
 fn pin_environment(cmd: clap::Command) -> clap::Command {
     cmd.mut_args(|arg| arg.env(None::<&'static str>))

--- a/crates/bugwarden/tests/common/scrub_env.rs
+++ b/crates/bugwarden/tests/common/scrub_env.rs
@@ -1,0 +1,103 @@
+//! The ambient environment a spawned `bugwarden` must not inherit, and the
+//! walker that holds the list to every variable the binary reads (#237).
+//!
+//! Included by `#[path]` from each user rather than declared in
+//! `common/mod.rs`: that module compiles into every test binary that says
+//! `mod common;`, so a helper only some of them use would be `dead_code` in
+//! the rest, which `-D warnings` rejects (#167, #214, #222, #229).
+//!
+//! Not the merge `common/pinned_cli.rs` rules out. That one refuses to scrub
+//! the *real* environment in-process, because libtest runs a binary's tests
+//! on parallel threads; sharing a `const` scrubs nothing.
+
+/// The two HTTP bearer tokens, read by `bugwarden::http_auth` and not by
+/// clap — no `get_env` sweep can reach them, hence the by-name arm of the
+/// walker below. Named as a set so a stdio-only spawn can say which two it
+/// drops instead of writing a third list.
+pub const HTTP_TOKEN_VARS: &[&str] = &[
+    bugwarden::http_auth::WRITE_TOKEN_VAR,
+    bugwarden::http_auth::READ_TOKEN_VAR,
+];
+
+/// Every environment variable the binary reads, cleared before each spawn:
+/// an ambient value would change exactly what is under test. The spawned leg
+/// only; `pinned_cli` covers the in-process one.
+///
+/// Scrubbed as one set rather than per test — a knob inert for one
+/// transport is still a knob, and pruning is how the list falls behind
+/// `Cli`. The two bearer tokens are spelled out rather than taken from
+/// [`HTTP_TOKEN_VARS`], which would make the walker's by-name check
+/// tautological.
+pub const AMBIENT_VARS: &[&str] = &[
+    "BUGZILLA_SERVER",
+    "BUGZILLA_API_KEY",
+    "BUGZILLA_API_KEY_FILE",
+    "BUGWARDEN_POLICY",
+    "BUGWARDEN_AUDIT_CONFIG",
+    "BUGWARDEN_HTTP_TOKEN",
+    "BUGWARDEN_HTTP_READ_TOKEN",
+    "BUGZILLA_USE_AUTH_HEADER",
+    "MCP_TRANSPORT",
+    "MCP_HOST",
+    "MCP_PORT",
+    "MCP_ALLOWED_HOSTS",
+    "MCP_READ_ONLY",
+    "MCP_API_KEY_HEADER",
+    "RUST_LOG",
+    // Read by the otel module, not by `Cli`: a developer exporting to a
+    // collector would otherwise have every spawned child export too, and
+    // an unreachable one would slow the tests down for no reason.
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_HEADERS",
+    "OTEL_EXPORTER_OTLP_PROTOCOL",
+    "OTEL_SERVICE_NAME",
+    // The signal-specific trio, which the OTLP spec makes override the
+    // three above — so leaving them ambient would override the test's own
+    // world, not merely add to it.
+    "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+    "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
+];
+
+/// Assert `scrubbed` covers every environment variable a spawned binary
+/// reads, so a flag or a variable added later cannot quietly go on reaching
+/// the child from the runner's environment and changing what is measured.
+///
+/// Three populations, because no single sweep sees them all: clap's `env`
+/// fallbacks, [`bugwarden::otel::ENV_VARS`] (read outside clap, so no `Arg`
+/// carries them), and `by_name` — variables nothing enumerates at all.
+/// Pass [`HTTP_TOKEN_VARS`] for `by_name`, or `&[]` from a caller whose
+/// list omits them on purpose.
+pub fn assert_the_scrub_list_covers_every_environment_fallback(
+    scrubbed: &[&str],
+    by_name: &[&str],
+) {
+    let mut cmd = bugwarden::config::command();
+    cmd.build();
+    let unscrubbed: Vec<String> = cmd
+        .get_arguments()
+        .filter_map(clap::Arg::get_env)
+        .map(|env| env.to_string_lossy().into_owned())
+        .filter(|env| !scrubbed.contains(&env.as_str()))
+        .collect();
+    assert!(
+        !scrubbed.is_empty() && cmd.get_arguments().any(|arg| arg.get_env().is_some()),
+        "the check is only evidence while both lists are non-empty"
+    );
+    assert!(
+        unscrubbed.is_empty(),
+        "these environment fallbacks reach the spawned binary: {unscrubbed:?}"
+    );
+    for var in by_name {
+        assert!(scrubbed.contains(var), "{var} must be scrubbed");
+    }
+    let unscrubbed_otel: Vec<&str> = bugwarden::otel::ENV_VARS
+        .iter()
+        .copied()
+        .filter(|var| !scrubbed.contains(var))
+        .collect();
+    assert!(
+        unscrubbed_otel.is_empty(),
+        "these OTLP variables reach the spawned binary: {unscrubbed_otel:?}"
+    );
+}

--- a/crates/bugwarden/tests/http_auth_wiremock.rs
+++ b/crates/bugwarden/tests/http_auth_wiremock.rs
@@ -121,6 +121,10 @@ fn the_scrub_list_covers_every_environment_fallback() {
         .filter(|env| !AMBIENT_VARS.contains(&env.as_str()))
         .collect();
     assert!(
+        !AMBIENT_VARS.is_empty() && cmd.get_arguments().any(|arg| arg.get_env().is_some()),
+        "the check is only evidence while both lists are non-empty"
+    );
+    assert!(
         unscrubbed.is_empty(),
         "these environment fallbacks reach the spawned binary: {unscrubbed:?}"
     );

--- a/crates/bugwarden/tests/http_auth_wiremock.rs
+++ b/crates/bugwarden/tests/http_auth_wiremock.rs
@@ -55,6 +55,9 @@ mod raw_post;
 #[path = "common/pinned_cli.rs"]
 mod pinned_cli;
 
+#[path = "common/scrub_env.rs"]
+mod scrub_env;
+
 #[path = "common/startup_line.rs"]
 mod startup_line;
 
@@ -78,70 +81,13 @@ const READ_TOKEN: &str = "fedcba9876543210fedcba9876543210";
 /// the suite until CI's own timeout kills it.
 const EXIT_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// Every environment variable the binary reads, cleared before each spawn:
-/// an ambient value would change exactly what is under test. The spawned
-/// leg only; `pinned` above covers the in-process one.
-const AMBIENT_VARS: &[&str] = &[
-    "BUGZILLA_SERVER",
-    "BUGZILLA_API_KEY",
-    "BUGZILLA_API_KEY_FILE",
-    "BUGWARDEN_POLICY",
-    "BUGWARDEN_AUDIT_CONFIG",
-    "BUGWARDEN_HTTP_TOKEN",
-    "BUGWARDEN_HTTP_READ_TOKEN",
-    "BUGZILLA_USE_AUTH_HEADER",
-    "MCP_TRANSPORT",
-    "MCP_HOST",
-    "MCP_PORT",
-    "MCP_ALLOWED_HOSTS",
-    "MCP_READ_ONLY",
-    "MCP_API_KEY_HEADER",
-    "RUST_LOG",
-    "OTEL_EXPORTER_OTLP_ENDPOINT",
-    "OTEL_EXPORTER_OTLP_HEADERS",
-    "OTEL_EXPORTER_OTLP_PROTOCOL",
-    "OTEL_SERVICE_NAME",
-    "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
-    "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
-    "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
-];
-
-/// The scrub list is only as good as its coverage of `Cli`; a flag added
-/// with an `env` fallback would otherwise reach the spawned binary from the
-/// runner's environment and change what these tests measure. The two bearer
-/// tokens are not clap arguments, so they are checked by name.
+/// Each binary runs the walker itself, so a single-binary
+/// `cargo test --test http_auth_wiremock` still proves what its scrub claims.
 #[test]
 fn the_scrub_list_covers_every_environment_fallback() {
-    let mut cmd = bugwarden::config::command();
-    cmd.build();
-    let unscrubbed: Vec<String> = cmd
-        .get_arguments()
-        .filter_map(clap::Arg::get_env)
-        .map(|env| env.to_string_lossy().into_owned())
-        .filter(|env| !AMBIENT_VARS.contains(&env.as_str()))
-        .collect();
-    assert!(
-        !AMBIENT_VARS.is_empty() && cmd.get_arguments().any(|arg| arg.get_env().is_some()),
-        "the check is only evidence while both lists are non-empty"
-    );
-    assert!(
-        unscrubbed.is_empty(),
-        "these environment fallbacks reach the spawned binary: {unscrubbed:?}"
-    );
-    for var in [
-        bugwarden::http_auth::WRITE_TOKEN_VAR,
-        bugwarden::http_auth::READ_TOKEN_VAR,
-    ] {
-        assert!(AMBIENT_VARS.contains(&var), "{var} must be scrubbed");
-    }
-    let unscrubbed_otel: Vec<&str> = bugwarden::otel::ENV_VARS
-        .iter()
-        .copied()
-        .filter(|var| !AMBIENT_VARS.contains(var))
-        .collect();
-    assert!(
-        unscrubbed_otel.is_empty(),
-        "these OTLP variables reach the spawned binary: {unscrubbed_otel:?}"
+    scrub_env::assert_the_scrub_list_covers_every_environment_fallback(
+        scrub_env::AMBIENT_VARS,
+        scrub_env::HTTP_TOKEN_VARS,
     );
 }
 
@@ -696,7 +642,7 @@ async fn run_binary(args: &[&str], env: &[(&str, &str)]) -> (Option<i32>, String
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
-    for var in AMBIENT_VARS {
+    for var in scrub_env::AMBIENT_VARS {
         cmd.env_remove(var);
     }
     for (key, value) in env {
@@ -850,12 +796,12 @@ async fn the_shipped_binary_wires_the_read_token_to_the_read_surface() {
         // Piped, not null: the startup line is both the readiness barrier
         // and the only report of the port the kernel chose.
         .stderr(Stdio::piped());
-    for var in AMBIENT_VARS {
+    for var in scrub_env::AMBIENT_VARS {
         cmd.env_remove(var);
     }
     cmd.env("BUGWARDEN_HTTP_TOKEN", WRITE_TOKEN)
         .env("BUGWARDEN_HTTP_READ_TOKEN", READ_TOKEN)
-        // AMBIENT_VARS scrubbed RUST_LOG; the barrier needs that line.
+        // The scrub took RUST_LOG with it; the barrier needs that line.
         .env("RUST_LOG", "info");
     cmd.kill_on_drop(true);
     let mut child = cmd.spawn().expect("the built binary must start");

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2750,8 +2750,9 @@ wired, `server.rs` and `main.rs` are the reference.
   refuses, with `Ok(true)`/`Ok(false)` anchors so the parity assertion
   cannot pass on two flags that are both unset. Two structural siblings
   keep it from rotting: a `config.rs` unit test fails when any argument
-  lacks an `env` fallback, and `binary_user_agent.rs` holds its child-env
-  scrub list to that same set.
+  lacks an `env` fallback, and `tests/common/scrub_env.rs` holds the
+  shared child-env scrub list to that same set, asserted from every
+  spawning binary.
 - Audit tests (crates/bugwarden/tests/audit_wiremock.rs + #[cfg(test)] in
   server.rs and audit.rs): one record per call for EVERY routed tool,
   refusal paths and protocol errors included; the refusal map is total


### PR DESCRIPTION
Closes #237.

Two commits. The first guards the scrub-list walker against an empty list (a `for` over nothing passes vacuously). The second moves `AMBIENT_VARS` and the walker into `tests/common/scrub_env.rs`, `#[path]`-included like `startup_line.rs`, and derives `binary_user_agent`'s narrower set as `AMBIENT_VARS` less `HTTP_TOKEN_VARS` instead of re-typing it. Each binary keeps its own `#[test]` naming the list it scrubs, so a single-binary run still proves what that harness claims. No assertion changed.

Mutation: dropping `MCP_PORT` fails all three walkers; dropping `BUGWARDEN_HTTP_TOKEN` fails the two http harnesses and leaves the stdio one green, the split the three files had before.

Reviewed adversarially before opening; nits (three stale pointers in `otel.rs`, DESIGN.md and `binary_user_agent.rs`) folded in.
