### PR TITLE
test(server): scrub the proxy variables from a spawned binary

### DIFF
--- a/crates/bugwarden/tests/binary_user_agent.rs
+++ b/crates/bugwarden/tests/binary_user_agent.rs
@@ -23,6 +23,10 @@ mod scrub_env;
 /// hanging the suite until CI's own timeout kills it.
 const REPLY_TIMEOUT: Duration = Duration::from_secs(20);
 
+/// Port 9 is discard: a child that inherited a proxy pointing here cannot
+/// reach the mock, so the two tests below fail instead of quietly passing.
+const DEAD_PROXY: &str = "http://127.0.0.1:9";
+
 /// The shared scrub list less the two HTTP bearer tokens: this file spawns
 /// stdio children, which bind no listener and ignore both
 /// (`a_stdio_start_ignores_the_bearer_tokens`). Derived rather
@@ -78,6 +82,11 @@ async fn upstream_requests_of_a_real_run(
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null());
+    // A dead proxy, pinned in before the scrub takes it back out: without
+    // it, dropping a proxy name from `AMBIENT_VARS` breaks no test (#239).
+    for var in scrub_env::PROXY_PIN_VARS {
+        cmd.env(var, DEAD_PROXY);
+    }
     for var in scrubbed_env() {
         cmd.env_remove(var);
     }

--- a/crates/bugwarden/tests/common/pinned_cli.rs
+++ b/crates/bugwarden/tests/common/pinned_cli.rs
@@ -13,6 +13,16 @@
 //! Not `std::env::remove_var`: libtest runs a binary's tests on parallel
 //! threads, so mutating the process environment races every other test in
 //! the binary (`tests/env_config.rs`).
+//!
+//! So clap fallbacks are all this drops, and every in-process test still
+//! runs in the developer's own environment. `http_proxy` and its seven
+//! siblings are the sharp edge: bugwarden leaves them honored deliberately
+//! (DESIGN.md, TLS stack and outbound network behavior) and applies no
+//! loopback bypass, so an ambient proxy routes even a wiremock call on
+//! 127.0.0.1 and fails these harnesses loudly (#239). `common/scrub_env.rs`
+//! closes that for a *spawned* child; in-process it stays an assumption,
+//! because the paragraph above rules out the only fix inside the binary
+//! (#247 tracks the outside ones).
 
 /// A command line carrying only what `Cli` requires, for the probe below.
 const MINIMAL_ARGV: &[&str] = &["bugwarden", "--bugzilla-server", "https://bugzilla.example"];

--- a/crates/bugwarden/tests/common/scrub_env.rs
+++ b/crates/bugwarden/tests/common/scrub_env.rs
@@ -1,5 +1,13 @@
 //! The ambient environment a spawned `bugwarden` must not inherit, and the
-//! walker that holds the list to every variable the binary reads (#237).
+//! walker that holds the list to the variables something can enumerate
+//! (#237).
+//!
+//! What the list is actually held to: clap's `env` fallbacks and
+//! [`bugwarden::otel::ENV_VARS`] are swept from the symbols themselves, the
+//! by-name population against a caller's own list, and the four proxy names
+//! an `http://` mock can observe are pinned behaviourally
+//! ([`PROXY_PIN_VARS`]). The remaining four proxy names and `RUST_LOG` are
+//! listed on trust — no check fails if they are dropped.
 //!
 //! Included by `#[path]` from each user rather than declared in
 //! `common/mod.rs`: that module compiles into every test binary that says
@@ -19,9 +27,17 @@ pub const HTTP_TOKEN_VARS: &[&str] = &[
     bugwarden::http_auth::READ_TOKEN_VAR,
 ];
 
+/// The proxy names a spawning test pins to a dead proxy before scrubbing,
+/// so dropping one from [`AMBIENT_VARS`] fails a test rather than nothing.
+/// Only these four: an `http://` mock never consults `https_proxy`,
+/// `HTTPS_PROXY`, `NO_PROXY` or `no_proxy`, so those stay listed on trust.
+#[allow(dead_code, reason = "only the binary_user_agent includer pins")]
+pub const PROXY_PIN_VARS: &[&str] = &["ALL_PROXY", "all_proxy", "HTTP_PROXY", "http_proxy"];
+
 /// Every environment variable the binary reads, cleared before each spawn:
 /// an ambient value would change exactly what is under test. The spawned leg
-/// only; `pinned_cli` covers the in-process one.
+/// only, and only the child's copy — `pinned_cli` covers what an in-process
+/// parse sees, and nothing covers a harness's own reqwest client.
 ///
 /// Scrubbed as one set rather than per test — a knob inert for one
 /// transport is still a knob, and pruning is how the list falls behind
@@ -44,6 +60,21 @@ pub const AMBIENT_VARS: &[&str] = &[
     "MCP_READ_ONLY",
     "MCP_API_KEY_HEADER",
     "RUST_LOG",
+    // Read by hyper-util's proxy matcher under reqwest, not by `Cli`:
+    // neither client opts out, and bugwarden leaves them honored
+    // deliberately (DESIGN.md, TLS stack and outbound network behavior) for
+    // an operator behind a corporate proxy — so an ambient one routes a
+    // spawned child's Bugzilla calls through it, with no loopback bypass
+    // (#239). Listed in the matcher's own order and case, uppercase first,
+    // which is also its precedence.
+    "ALL_PROXY",
+    "all_proxy",
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "NO_PROXY",
+    "no_proxy",
     // Read by the otel module, not by `Cli`: a developer exporting to a
     // collector would otherwise have every spawned child export too, and
     // an unreachable one would slow the tests down for no reason.
@@ -68,6 +99,10 @@ pub const AMBIENT_VARS: &[&str] = &[
 /// carries them), and `by_name` — variables nothing enumerates at all.
 /// Pass [`HTTP_TOKEN_VARS`] for `by_name`, or `&[]` from a caller whose
 /// list omits them on purpose.
+///
+/// The proxy names are in none of the three — nothing enumerates them, and
+/// a by-name arm would only check the list against itself. [`PROXY_PIN_VARS`]
+/// covers the observable four instead; the other four go unchecked.
 pub fn assert_the_scrub_list_covers_every_environment_fallback(
     scrubbed: &[&str],
     by_name: &[&str],

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -91,10 +91,10 @@ use pinned_cli::pinned;
 /// No clap `env` fallback reaches this `Cli`: [`pinned`] drops them
 /// wholesale rather than overwriting a list of named fields — the list is
 /// what drifted in #190, having lost `read_only` while still claiming to be
-/// complete. That is the whole of the claim; the rest of the environment
-/// still reaches these tests, and `http_proxy` alone fails most of them,
-/// since neither reqwest client here sets `.no_proxy()`. `key_file` is then
-/// the only field a caller varies.
+/// complete. That is the whole of the claim; what the rest of the
+/// environment still does to an in-process test — `http_proxy` above all —
+/// is stated once in `common/pinned_cli.rs` (#239). `key_file` is then the
+/// only field a caller varies.
 fn http_cli(mock: &MockServer, key_file: Option<&std::path::Path>) -> Arc<Cli> {
     let uri = mock.uri();
     let mut cli: Cli = pinned(&[


### PR DESCRIPTION
Closes #239.

The eight proxy variables hyper-util's matcher reads (`ALL_PROXY`/`HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`, both cases) join the shared scrub list from #250. The production behaviour is deliberate (DESIGN.md, outbound network) and stays; this is test-side only.

The mutation is pinned rather than hand-run: `binary_user_agent`'s spawn helper sets the four `http://`-relevant variables to `http://127.0.0.1:9` right before the scrub loop removes them, so dropping any of them from the list fails both of its spawning tests. The other four are in the list on trust — an `http://` mock never consults them — and the docs say so.

What this does not cover, stated in `scrub_env.rs` and `pinned_cli.rs`: harnesses that speak HTTP in-process (`binary_shutdown`'s live-session test, seven in `http_auth_wiremock`) still fail under an ambient proxy. #247 tracks the fix outside the binary.

Reviewed adversarially before opening; nits (reqwest version attribution, evidence list, pointer to DESIGN.md rather than `lib.rs`, the pin) folded in. The pin lives in `binary_user_agent` rather than `http_auth_wiremock` as the review suggested, because it is the only spawning harness whose child reaches Bugzilla — in `http_auth_wiremock` the mutation was inert.
