### PR TITLE
fix(server): cap the tool name a record carries

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,10 @@ object's server-reserved `_overlong_keys` array, whose shape is
 `[{"prefix": <the first 1024 chars>, "key_chars": N, "value": …}]`. A
 client key spelled `_overlong_keys` is routed into that array too rather
 than passed through, so the name is only ever server-written.
+`request.tool` carries client text too: a call naming a
+tool this server does not serve is recorded before it is refused, so the
+name is truncated on that same boundary; every served name is far
+shorter, so a served record is unchanged.
 
 ```json
 {"v":2,"ts":"2026-02-03T04:05:06.789Z","seq":7,"session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"event":"tool_call","client":{"name":"example-agent","version":"1.4.2"},"request":{"tool":"bugs_quicksearch","id":"3","params":{"limit":50,"offset":0,"query":"kernel panic","status":"ALL"}},"guard":{"verdict":"served_filtered","policy_hash":"sha256:58013baa090cf77630373ab50cc5eaf2d679ec5a06e8a336600fc89b23bb8604","suppressed_ids_count":2,"suppressed_other_count":0,"suppressed_ids":[1290040,1290041],"redacted_fields":[],"scan":{"scanned":50,"dropped":2}},"upstream":{"requests":3,"status":200,"latency_ms":48},"outcome":{"class":"ok","duration_ms":52,"response_bytes":6218}}

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -56,13 +56,17 @@
 //! reader promote a claim into a fact. The REST of a record — verdicts,
 //! rule names, counts, timings, the tool called — is the server's own
 //! account of what it did rather than a claim about anybody, so the
-//! tiering question does not arise for it. ONE EXCEPTION, and it is the
-//! case a future field is likeliest to hit: [`RequestInfo::params`] is
-//! CLIENT-authored content wherever the allowlist passes it verbatim —
+//! tiering question does not arise for it. TWO EXCEPTIONS, and the first
+//! is the case a future field is likeliest to hit: [`RequestInfo::params`]
+//! is CLIENT-authored content wherever the allowlist passes it verbatim —
 //! the `_len` and `_overlong_keys` reductions beside it are the
 //! server's — not the server's account of anything, so a value read out
 //! of it is a correlation hint at best and never an identity — a
-//! grouping handle a client was given and handed back included.
+//! grouping handle a client was given and handed back included. The
+//! second: [`RequestInfo::tool`] is that account only while the name is
+//! one this server serves, since a call it will not serve is recorded
+//! too — an unknown name is the client's own text, capped for that
+//! reason (#243), and groups records by nothing but itself.
 //!
 //! # What can never appear in a record
 //!
@@ -72,7 +76,11 @@
 //! content (summaries, comments, attachments). The one open field is
 //! [`RequestInfo::params`]: it is fed exclusively through an allowlist
 //! of client-authored parameter keys at the recording call site, and
-//! data fetched from Bugzilla never passes through it. [`AuditError`]
+//! data fetched from Bugzilla never passes through it.
+//! [`RequestInfo::tool`] is client text too whenever it names a tool
+//! this server does not serve, and is capped there (#243), as the
+//! self-declared identity is (#191); `request.id` is the one
+//! client-chosen string still recorded unbounded (#248). [`AuditError`]
 //! follows the same rule — it names the failed
 //! operation and carries the underlying I/O error, never the record that
 //! failed to be written, so it stays safe to surface in diagnostics.
@@ -783,7 +791,10 @@ impl TraceContext {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RequestInfo {
-    /// MCP tool name.
+    /// MCP tool name, capped at 1024 characters by the recording call
+    /// site: a call the router will not serve is recorded before it is
+    /// refused, so this is CLIENT-authored text whenever it is not one
+    /// of the served names (#243).
     pub tool: String,
     /// JSON-RPC request id, when the transport exposes one.
     ///

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -346,10 +346,19 @@ fn truncated(value: &Value) -> Value {
 }
 
 /// `value` truncated to [`PARAM_VALUE_MAX_CHARS`] characters — the ONE
-/// place the cap is applied, to an audited parameter leaf ([`truncated`])
-/// and to a recorded client identity alike. Two copies of the rule would
-/// have to be remembered together (#191); every site that records an
-/// audited string goes through this instead.
+/// place the cap is applied, to an audited parameter leaf ([`truncated`]),
+/// to an over-cap key's prefix ([`recorded_object`]), to a recorded client
+/// identity and to a recorded TOOL NAME alike. Two copies of the rule
+/// would have to be remembered together (#191); every site that records
+/// an audited string goes through this instead.
+///
+/// The tool name is capped in the RECORD only (#243): a call the router
+/// will not serve is recorded like any other, so the name is client text
+/// of any length, while routing, the fail-mode gate and [`WRITE_TOOLS`]
+/// keep matching the raw one. No served name is near the cap, so no
+/// served record moves and only an unknown name is ever shortened — and
+/// "an unknown name of at least 1024 chars" is the whole of what such a
+/// record has to say.
 fn capped(value: &str) -> String {
     // A string of at most 1024 BYTES has at most 1024 chars; the cheap
     // length check skips the char walk for the common case.
@@ -4240,7 +4249,7 @@ impl ServerHandler for BugWarden {
                     },
                     trace: None,
                     request: audit::RequestInfo {
-                        tool: request.name.to_string(),
+                        tool: capped(&request.name),
                         id: Some(context.id.to_string()),
                         params: allowlisted(request.arguments.as_ref()),
                     },
@@ -4274,6 +4283,9 @@ impl ServerHandler for BugWarden {
                 .call(ToolCallContext::new(self, request, context))
                 .await;
         };
+        // Raw: the router, the fail-mode gate and `WRITE_TOOLS` must match
+        // the name the client actually sent. Every record site below caps
+        // it instead (#243).
         let tool = request.name.to_string();
         let session = self.session_info(&context, &audit);
         let client = client_of(&context);
@@ -4326,8 +4338,10 @@ impl ServerHandler for BugWarden {
             let event = audit::AuditEventKind::ToolCall(Box::new(audit::ToolCallEvent {
                 client,
                 trace: trace.clone(),
+                // Capped like every record site, though the `has_route`
+                // above means this one only ever sees a served name.
                 request: audit::RequestInfo {
-                    tool: tool.clone(),
+                    tool: capped(&tool),
                     id: request_id,
                     params,
                 },
@@ -4409,7 +4423,7 @@ impl ServerHandler for BugWarden {
             client,
             trace,
             request: audit::RequestInfo {
-                tool: tool.clone(),
+                tool: capped(&tool),
                 id: request_id,
                 params,
             },
@@ -7239,6 +7253,83 @@ mod tests {
                 client.version.as_deref().map(|v| v.chars().count()),
                 Some(PARAM_VALUE_MAX_CHARS),
                 "the version is capped too — it is client text on the same terms"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn every_record_site_caps_a_client_chosen_tool_name() {
+        // #243: a call the router will not serve is recorded like any
+        // other, so `request.tool` is client text of any length — the
+        // channel #191 closed for a declared identity and #211 for a
+        // parameter value. The BOUNDARY is pinned here because only a unit
+        // test sees `PARAM_VALUE_MAX_CHARS`: at the cap is under it, one
+        // char over is cut, and 600 multi-byte chars in 1200 bytes stay
+        // whole — a 4x-cap probe alone survives both a byte cap and a `>=`
+        // boundary. The last row is the out-of-contract site, which reads
+        // `request.name` rather than the routing copy: same channel, one
+        // site over, and it records before it refuses.
+        let over = "z".repeat(PARAM_VALUE_MAX_CHARS * 4);
+        let at_cap = "z".repeat(PARAM_VALUE_MAX_CHARS);
+        let one_over = "z".repeat(PARAM_VALUE_MAX_CHARS + 1);
+        let multibyte = "é".repeat(600);
+        let cut: String = over.chars().take(PARAM_VALUE_MAX_CHARS).collect();
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz)
+            .expect("server must build")
+            .with_audit(Arc::clone(&audit));
+        let peer = peer_of(&server).await;
+
+        let rows: [(&str, &str, bool, &str); 5] = [
+            (
+                &over,
+                &cut,
+                false,
+                "an over-cap unknown name is cut to the cap",
+            ),
+            (&at_cap, &at_cap, false, "exactly at the cap is not over it"),
+            (&one_over, &cut, false, "one char over the cap is cut"),
+            (
+                &multibyte,
+                &multibyte,
+                false,
+                "600 chars in 1200 bytes stays whole: the cap counts chars",
+            ),
+            (&over, &cut, true, "the out-of-contract site caps it too"),
+        ];
+        for (id, (sent, _, out_of_contract, _)) in rows.iter().enumerate() {
+            let mut context = RequestContext::<RoleServer>::new(
+                RequestId::Number(i64::try_from(id).expect("five rows")),
+                peer.clone(),
+            );
+            if *out_of_contract {
+                context.meta = per_request_meta(ProtocolVersion::V_2025_06_18, None);
+            }
+            ServerHandler::call_tool(
+                &server,
+                CallToolRequestParams::new((*sent).to_string()),
+                context,
+            )
+            .await
+            .expect_err("refused either way, and the refusal is not what moves");
+        }
+
+        let events = read_audit_events(&audit_path);
+        let calls = tool_calls(&events);
+        assert_eq!(
+            calls.len(),
+            rows.len(),
+            "one record per call, refused or not"
+        );
+        for (call, (sent, want, _, why)) in calls.iter().zip(rows) {
+            let got = call.request.tool.as_str();
+            assert!(
+                got == want,
+                "{why}: recorded {} chars of a {}-char name",
+                got.chars().count(),
+                sent.chars().count()
             );
         }
     }

--- a/crates/bugwarden/tests/audit_wiremock.rs
+++ b/crates/bugwarden/tests/audit_wiremock.rs
@@ -391,6 +391,8 @@ async fn every_routed_tool_writes_exactly_one_record_per_call() {
         // `None` on every real call with the suite green. Checked here
         // because this is the one test that walks the whole router.
         let tc = last_tool_call(&events);
+        // Byte-identical for every SERVED name, which is what keeps the
+        // record cap on that same string invisible here (#243).
         assert_eq!(tc.request.tool, tool.name);
         assert!(
             tc.request.id.as_deref().is_some_and(|id| !id.is_empty()),
@@ -602,6 +604,11 @@ async fn a_default_decided_call_records_the_literal_default_rule() {
     );
 }
 
+/// `server::PARAM_VALUE_MAX_CHARS`, which is private. Mirrored rather
+/// than inferred so the end-to-end record pins the cap's VALUE (#191) and
+/// not merely the fact that something shortened the name.
+const RECORDED_MAX_CHARS: usize = 1024;
+
 #[tokio::test]
 async fn unknown_and_stripped_tools_error_identically_and_still_record() {
     let mock = MockServer::start().await;
@@ -625,6 +632,9 @@ async fn unknown_and_stripped_tools_error_identically_and_still_record() {
         format!("{without:?}"),
         "auditing must not change the protocol error"
     );
+    // Held against the oversized name below: the refusal names no tool,
+    // so it cannot vary with one.
+    let unknown_refusal = format!("{with_audit:?}");
     let events = read_events(&audited.audit_path);
     assert_eq!(events.len(), 2, "initialize + the failed call");
     let tc = last_tool_call(&events);
@@ -664,6 +674,44 @@ async fn unknown_and_stripped_tools_error_identically_and_still_record() {
     assert_eq!(tc.outcome.class, OutcomeClass::Error);
     // The comment body is not allowlisted even on this path.
     assert_eq!(tc.request.params["comment"], json!({ "_len": 4 }));
+
+    // #243: an unknown name is unbounded client text on its way into the
+    // file and the OTLP export, and it is recorded whatever it is. Four
+    // times the cap, through the real transport.
+    let huge = "z".repeat(RECORDED_MAX_CHARS * 4);
+    let with_audit = audited
+        .client
+        .call_tool(CallToolRequestParams::new(huge.clone()))
+        .await
+        .expect_err("an unknown tool is a protocol error whatever its length");
+    let without = plain
+        .call_tool(CallToolRequestParams::new(huge.clone()))
+        .await
+        .expect_err("an unknown tool is a protocol error whatever its length");
+    assert_eq!(
+        format!("{with_audit:?}"),
+        format!("{without:?}"),
+        "auditing must not change the protocol error"
+    );
+    assert_eq!(
+        format!("{with_audit:?}"),
+        unknown_refusal,
+        "and the same refusal a short unknown name gets: no echo of the name"
+    );
+    let events = read_events(&audited.audit_path);
+    assert_eq!(events.len(), 4, "one record for the oversized name too");
+    let tc = last_tool_call(&events);
+    assert_eq!(tc.outcome.class, OutcomeClass::Error);
+    assert_eq!(
+        tc.request.tool.chars().count(),
+        RECORDED_MAX_CHARS,
+        "the recorded name is cut to the cap, not merely shortened"
+    );
+    assert_eq!(
+        tc.request.tool,
+        huge.chars().take(RECORDED_MAX_CHARS).collect::<String>(),
+        "and it is that prefix verbatim — capped() appends no marker"
+    );
 }
 
 /// Policy hiding every bug in a `Secret*` product.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1185,7 +1185,15 @@ Decisions, all deliberate:
   was oversized is the diagnostic params are recorded for. A client key
   spelled `_overlong_keys` routes into the array too, carrying its own
   true (short) `key_chars`, so the reserved name is only ever
-  server-written.
+  server-written. `request.tool` is bounded on that same boundary
+  (#243), by plain truncation: a call the router will not serve is
+  recorded before it is refused, so an unknown name is client text of any
+  length, while routing, the fail-mode gate and `WRITE_TOOLS` keep
+  matching the RAW name. Truncating is enough where a key needed
+  relocating — one string cannot collide with a sibling the way two map
+  keys sharing a prefix do — and no served name is near the cap, so no
+  served record moves and the only names ever shortened are the ones that
+  are not ours.
 - **The params caps bound content, not record size — and a total cap is a
   decided no** (#220). Array element and map entry counts are uncapped, so
   an allowlisted value's SHAPE can still make a large record; what bounds
@@ -2827,7 +2835,10 @@ wired, `server.rs` and `main.rs` are the reference.
   so half a fix fails; a client key spelled like the reserved marker
   routed rather than passed through; the boundary itself, in chars not
   bytes and with at-cap under it; and an ordinary record growing no
-  marker, #220); and trace
+  marker, #220); the recorded tool name truncated on that same boundary
+  at both reachable record sites, in chars not bytes and with at-cap
+  under it, while the every-routed-tool walk above pins each served name
+  byte-identical (#243); and trace
   enrichment (issue #28) — the strict traceparent parser (the canonical
   W3C value and its flags-00 variant parse into their ids; empty,
   54-byte, 56-byte, and ~1 MiB values, uppercase hex, versions other


### PR DESCRIPTION
Closes #243.

`request.tool` in an audit record is client text whenever the name is one this server does not serve — the call is recorded before it is refused — and it was the one record string with no bound. `capped()` now applies at all three `RequestInfo` sites; the raw `request.name` still drives routing, `gate_applies` and `WRITE_TOOLS`, so no guard sees a truncated name. No schema change; served records are byte-identical.

Tests: a unit walk over five rows (4×cap, at cap, one over, 600 multi-byte chars in 1200 bytes, and the out-of-contract site) pins the boundary and the char-not-byte measure; the `audit_wiremock` end-to-end call pins that the record is cut and the refusal text is the uniform one.

Reviewed adversarially before opening; the review's nits (two overstated "only client text" sentences in `audit.rs` and the README, the missing one-over row) are folded in. #248 (`request.id`) is the remaining unbounded client-chosen string and the docs now say so.
