### PR TITLE
fix(server): cap the request id a record carries

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,7 +995,14 @@ than passed through, so the name is only ever server-written.
 `request.tool` carries client text too: a call naming a
 tool this server does not serve is recorded before it is refused, so the
 name is truncated on that same boundary; every served name is far
-shorter, so a served record is unchanged.
+shorter, so a served record is unchanged. `request.id` is client text as
+well — a JSON-RPC id the client picked: the record keeps its first 1024
+characters while the reply still echoes the full id — the cap is on the
+record, never on the wire. Every client-chosen string a record carries is
+bounded: capped at 1024 characters — allowlisted `params` values, key
+prefixes, `request.tool`, the self-declared `client.name` and
+`client.version`, `request.id` — or, for `trace`, parsed into fixed-width
+hex ids.
 
 ```json
 {"v":2,"ts":"2026-02-03T04:05:06.789Z","seq":7,"session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"event":"tool_call","client":{"name":"example-agent","version":"1.4.2"},"request":{"tool":"bugs_quicksearch","id":"3","params":{"limit":50,"offset":0,"query":"kernel panic","status":"ALL"}},"guard":{"verdict":"served_filtered","policy_hash":"sha256:58013baa090cf77630373ab50cc5eaf2d679ec5a06e8a336600fc89b23bb8604","suppressed_ids_count":2,"suppressed_other_count":0,"suppressed_ids":[1290040,1290041],"redacted_fields":[],"scan":{"scanned":50,"dropped":2}},"upstream":{"requests":3,"status":200,"latency_ms":48},"outcome":{"class":"ok","duration_ms":52,"response_bytes":6218}}

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -77,13 +77,17 @@
 //! [`RequestInfo::params`]: it is fed exclusively through an allowlist
 //! of client-authored parameter keys at the recording call site, and
 //! data fetched from Bugzilla never passes through it.
-//! [`RequestInfo::tool`] is client text too whenever it names a tool
-//! this server does not serve, and is capped there (#243), as the
-//! self-declared identity is (#191); `request.id` is the one
-//! client-chosen string still recorded unbounded (#248). [`AuditError`]
-//! follows the same rule — it names the failed
+//! [`AuditError`] follows the same rule — it names the failed
 //! operation and carries the underlying I/O error, never the record that
 //! failed to be written, so it stays safe to surface in diagnostics.
+//!
+//! Every client-chosen string a record does carry is bounded at the
+//! recording call site: allowlisted `params` values and over-cap key
+//! prefixes (#211, #220), the self-declared identity (#191),
+//! [`RequestInfo::tool`] — client text whenever it names a tool this
+//! server does not serve (#243) — and [`RequestInfo::id`] (#248) are
+//! capped at 1024 characters; `trace` is parsed to fixed-width hex ids
+//! instead.
 //!
 //! # Ordering, durability, and blocking
 //!
@@ -801,6 +805,11 @@ pub struct RequestInfo {
     /// CLIENT-chosen, so a correlation hint and never an identity:
     /// nothing stops two callers picking the same id, or one caller
     /// reusing one.
+    ///
+    /// A JSON-RPC string id is client text of any length, so the
+    /// recording call site caps it at 1024 characters; the reply still
+    /// echoes the full id, since the cap is on the record and never on
+    /// the wire (#248).
     ///
     /// Records are per-ATTEMPT, not per intended call. A client that
     /// loses a response and re-issues the call does so under a new id,

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -345,12 +345,13 @@ fn truncated(value: &Value) -> Value {
     }
 }
 
-/// `value` truncated to [`PARAM_VALUE_MAX_CHARS`] characters — the ONE
-/// place the cap is applied, to an audited parameter leaf ([`truncated`]),
-/// to an over-cap key's prefix ([`recorded_object`]), to a recorded client
-/// identity and to a recorded TOOL NAME alike. Two copies of the rule
-/// would have to be remembered together (#191); every site that records
-/// an audited string goes through this instead.
+/// `value` truncated to [`PARAM_VALUE_MAX_CHARS`] characters — the one
+/// rule every RECORDED string obeys: an audited parameter leaf
+/// ([`truncated`]), an over-cap key's prefix ([`recorded_object`]), a
+/// recorded client identity, a recorded TOOL NAME and a recorded
+/// JSON-RPC REQUEST ID alike. A second copy of the rule would have to be
+/// remembered beside it (#191); every site that records an audited
+/// string goes through this instead.
 ///
 /// The tool name is capped in the RECORD only (#243): a call the router
 /// will not serve is recorded like any other, so the name is client text
@@ -359,6 +360,10 @@ fn truncated(value: &Value) -> Value {
 /// served record moves and only an unknown name is ever shortened — and
 /// "an unknown name of at least 1024 chars" is the whole of what such a
 /// record has to say.
+///
+/// The request id is capped in the record only (#248): JSON-RPC pairs
+/// the reply to its request by it, and the reply is rmcp's — written off
+/// the id it parsed, which no code of ours touches.
 fn capped(value: &str) -> String {
     // A string of at most 1024 BYTES has at most 1024 chars; the cheap
     // length check skips the char walk for the common case.
@@ -4250,7 +4255,7 @@ impl ServerHandler for BugWarden {
                     trace: None,
                     request: audit::RequestInfo {
                         tool: capped(&request.name),
-                        id: Some(context.id.to_string()),
+                        id: Some(capped(&context.id.to_string())),
                         params: allowlisted(request.arguments.as_ref()),
                     },
                     guard: None,
@@ -4289,7 +4294,9 @@ impl ServerHandler for BugWarden {
         let tool = request.name.to_string();
         let session = self.session_info(&context, &audit);
         let client = client_of(&context);
-        let request_id = Some(context.id.to_string());
+        // Record-only cap: rmcp answers off the id it parsed, so nothing
+        // here can shorten the reply's (#248).
+        let request_id = Some(capped(&context.id.to_string()));
         // Allowlist BEFORE dispatch: the record needs the params after
         // the router has consumed the request, and allowlisting first
         // avoids cloning free-text and blob values that would be reduced
@@ -7265,10 +7272,12 @@ mod tests {
         // parameter value. The BOUNDARY is pinned here because only a unit
         // test sees `PARAM_VALUE_MAX_CHARS`: at the cap is under it, one
         // char over is cut, and 600 multi-byte chars in 1200 bytes stay
-        // whole — a 4x-cap probe alone survives both a byte cap and a `>=`
-        // boundary. The last row is the out-of-contract site, which reads
-        // `request.name` rather than the routing copy: same channel, one
-        // site over, and it records before it refuses.
+        // whole — a 4x-cap probe alone survives a byte cap; the at-cap row
+        // pins which side the boundary falls, not a mutant (a `>=` in
+        // `capped()` cuts an at-cap value to itself). The last row is the
+        // out-of-contract site, which reads `request.name` rather than the
+        // routing copy: same channel, one site over, and it records before
+        // it refuses.
         let over = "z".repeat(PARAM_VALUE_MAX_CHARS * 4);
         let at_cap = "z".repeat(PARAM_VALUE_MAX_CHARS);
         let one_over = "z".repeat(PARAM_VALUE_MAX_CHARS + 1);
@@ -7329,6 +7338,75 @@ mod tests {
                 got == want,
                 "{why}: recorded {} chars of a {}-char name",
                 got.chars().count(),
+                sent.chars().count()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn every_record_site_caps_a_client_chosen_request_id() {
+        // #248: `request.id` is the JSON-RPC id the CLIENT picked, and a
+        // string one arrives off the wire at any length — the channel
+        // #243 closed for the tool name, one field over. The BOUNDARY is
+        // pinned here because only a unit test sees
+        // `PARAM_VALUE_MAX_CHARS`: an over-cap id is cut to EXACTLY the
+        // cap (an off-by-one dies on it), one at the cap is left alone,
+        // and 600 multi-byte chars in 1200 bytes stay whole, which a byte
+        // cap would cut to 512. The last row is the out-of-contract site,
+        // which builds its own `RequestInfo` and records before it
+        // refuses.
+        let over = "z".repeat(PARAM_VALUE_MAX_CHARS * 4);
+        let at_cap = "z".repeat(PARAM_VALUE_MAX_CHARS);
+        let one_over = "z".repeat(PARAM_VALUE_MAX_CHARS + 1);
+        let multibyte = "é".repeat(600);
+        let cut: String = over.chars().take(PARAM_VALUE_MAX_CHARS).collect();
+        let dir = tempfile::tempdir().unwrap();
+        let (audit, audit_path) = audit_state(dir.path(), FailMode::Open);
+        let (cfg, guard, bz) = parts("");
+        let server = BugWarden::new(cfg, guard, bz)
+            .expect("server must build")
+            .with_audit(Arc::clone(&audit));
+        let peer = peer_of(&server).await;
+
+        let rows: [(&str, &str, bool, &str); 5] = [
+            (&over, &cut, false, "an over-cap id is cut to the cap"),
+            (&at_cap, &at_cap, false, "exactly at the cap is not over it"),
+            (&one_over, &cut, false, "one char over the cap is cut"),
+            (
+                &multibyte,
+                &multibyte,
+                false,
+                "600 chars in 1200 bytes stays whole: the cap counts chars",
+            ),
+            (&over, &cut, true, "the out-of-contract site caps it too"),
+        ];
+        for (sent, _, out_of_contract, _) in rows {
+            let mut context =
+                RequestContext::<RoleServer>::new(RequestId::String(Arc::from(sent)), peer.clone());
+            if out_of_contract {
+                context.meta = per_request_meta(ProtocolVersion::V_2025_06_18, None);
+            }
+            ServerHandler::call_tool(
+                &server,
+                CallToolRequestParams::new("no_such_tool".to_string()),
+                context,
+            )
+            .await
+            .expect_err("refused either way, and the refusal is not what moves");
+        }
+
+        let events = read_audit_events(&audit_path);
+        let calls = tool_calls(&events);
+        assert_eq!(
+            calls.len(),
+            rows.len(),
+            "one record per call, refused or not"
+        );
+        for (call, (sent, want, _, why)) in calls.iter().zip(rows) {
+            assert!(
+                call.request.id.as_deref() == Some(want),
+                "{why}: recorded {:?} chars of a {}-char id",
+                call.request.id.as_deref().map(|id| id.chars().count()),
                 sent.chars().count()
             );
         }

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -1539,6 +1539,92 @@ async fn a_per_request_call_records_the_client_it_declares() {
     );
 }
 
+/// The record's cap on `request.id`, in characters (#248). Not importable:
+/// `PARAM_VALUE_MAX_CHARS` is private to `server.rs`, where the unit test
+/// pins the boundary; this end-to-end pins the NUMBER a deployment writes.
+const RECORDED_ID_MAX_CHARS: usize = 1024;
+
+#[tokio::test]
+async fn a_record_caps_a_string_request_id_the_reply_still_echoes() {
+    // #248 over a real transport, which is the only place both halves are
+    // visible at once: a JSON-RPC string id is client text of any length,
+    // so the RECORD keeps its first 1024 chars, while the REPLY must
+    // still carry the whole id — JSON-RPC pairs a response to its request
+    // by it, so capping on the wire would break the client that sent it.
+    // No rmcp client can send one (`Peer` mints its ids from an
+    // `AtomicU32Provider`), hence the raw POST; the per-request lifecycle
+    // needs no handshake, so the file it writes holds exactly this call.
+    // Inlined rather than widening `per_request_post`: one caller wants
+    // an id of its own, as `per_request_call_with_canary` below wants a
+    // header of its own.
+    let sent = "z".repeat(RECORDED_ID_MAX_CHARS * 4);
+    let want = "z".repeat(RECORDED_ID_MAX_CHARS);
+    let mock = MockServer::start().await;
+    let dir = tempfile::tempdir().expect("audit temp dir");
+    let file = key_file("srv-key\n");
+    let (addr, audit_path) = served_with_audit(&mock, &dir, &file).await;
+
+    let response = mcp_post(addr, None)
+        .header("MCP-Protocol-Version", PER_REQUEST_REVISION)
+        .header("Mcp-Method", "tools/call")
+        .header("Mcp-Name", "bug_info")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": sent,
+            "method": "tools/call",
+            "params": {
+                "name": "bug_info",
+                "arguments": { "bug_ids": [7] },
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": PER_REQUEST_REVISION,
+                    "io.modelcontextprotocol/clientCapabilities": {},
+                },
+            }
+        }))
+        .send()
+        .await
+        .expect("the per-request POST must reach the server");
+    assert!(
+        response.status().is_success(),
+        "an over-cap id is a servable request, got {}",
+        response.status()
+    );
+    let body = response.text().await.expect("a body");
+    assert!(
+        body.contains("a plain bug"),
+        "the call must really be served, or the record proves nothing: {body}"
+    );
+    // Honest caveat: this half pins the SDK, not our code — rmcp answers
+    // off the id it parsed, so no handler-side change in bugwarden could
+    // fail it. It guards an rmcp bump, or a response-rewriting layer that
+    // moved the cap onto the wire.
+    assert!(
+        body.contains(&format!("\"id\":\"{sent}\"")),
+        "the reply must echo the FULL id: the cap is on the record, never \
+         on the wire"
+    );
+
+    let events = audit_events(&audit_path);
+    let [record] = events.as_slice() else {
+        panic!("exactly one record for one call, got {}", events.len());
+    };
+    let AuditEventKind::ToolCall(event) = &record.kind else {
+        panic!("expected a tool_call record, got {:?}", record.kind);
+    };
+    let recorded = event
+        .request
+        .id
+        .as_deref()
+        .expect("a served record carries the request id");
+    assert_eq!(
+        recorded.chars().count(),
+        RECORDED_ID_MAX_CHARS,
+        "a {}-char id is recorded at the cap",
+        sent.chars().count()
+    );
+    assert_eq!(recorded, want, "and as the id's own prefix");
+}
+
 #[tokio::test]
 async fn a_forged_session_id_is_not_copied_into_a_served_record() {
     // The C3 hazard, widened by adoption from refusals to SERVED calls: on

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1197,12 +1197,18 @@ Decisions, all deliberate:
   relocating — one string cannot collide with a sibling the way two map
   keys sharing a prefix do — and no served name is near the cap, so no
   served record moves and the only names ever shortened are the ones that
-  are not ours.
+  are not ours. `request.id` is truncated on that boundary too (#248):
+  a JSON-RPC string id is client-chosen text of any length, and the cap
+  is on the RECORD only — the reply still echoes the FULL id rmcp parsed
+  off the frame. With it every client-chosen string a record carries is
+  bounded: capped at 1024 characters, or, for `trace`, parsed to
+  fixed-width hex ids.
 - **The params caps bound content, not record size — and a total cap is a
   decided no** (#220). Array element and map entry counts are uncapped, so
   an allowlisted value's SHAPE can still make a large record; what bounds
-  one is the transport — over http the POST body cap (4 MiB floor), over
-  stdio nothing (#234, open) — not the allowlist. Capping the
+  one is the transport's request cap — the POST body over http, one frame
+  over stdio (`BoundedLines`, #234), 4 MiB at the floor — not the
+  allowlist. Capping the
   params map's total serialized size instead is DECIDED AGAINST on the
   `tracestate` terms below: it bounds one field of a record nothing else
   bounds, so it advertises a guarantee it does not give, and it buys even
@@ -2851,7 +2857,11 @@ wired, `server.rs` and `main.rs` are the reference.
   marker, #220); the recorded tool name truncated on that same boundary
   at both reachable record sites, in chars not bytes and with at-cap
   under it, while the every-routed-tool walk above pins each served name
-  byte-identical (#243); and trace
+  byte-identical (#243); the recorded request id truncated on the same
+  boundary at both derivations — over-cap cut to exactly the cap, at-cap
+  kept, chars not bytes, the out-of-contract site too — and end-to-end a
+  4x-cap string id sent by raw per-request POST records exactly 1024
+  chars while the reply echoes the whole id (#248); and trace
   enrichment (issue #28) — the strict traceparent parser (the canonical
   W3C value and its flags-00 variant parse into their ids; empty,
   54-byte, 56-byte, and ~1 MiB values, uppercase hex, versions other


### PR DESCRIPTION
`request.id` copied a client-chosen JSON-RPC string id verbatim — the last client-authored string in an audit record with no bound (#220 closed param keys, #243 the tool name). Both derivations in `call_tool` now go through `capped()`; the reply still echoes the full id, since rmcp answers off the id it parsed.

Tests: a unit table over both record sites (over-cap cut to exactly 1024, at-cap kept, chars not bytes, the out-of-contract site), and an end-to-end raw per-request POST with a 4×cap string id — the record holds 1024 chars, the reply the whole id. Drive-by: the DESIGN bullet still saying "over stdio nothing" (stdio has bounded a frame since #234).

Closes #248
