### PR TITLE
test(core): pin the guard.rs mutants #244 left loose

### DIFF
--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -1132,6 +1132,65 @@ mod tests {
     }
 
     #[test]
+    fn a_change_survives_when_both_of_its_halves_do() {
+        // `anything_left` accumulates over added AND removed: two survivors
+        // must not cancel each other out and drop a change the client is
+        // entitled to see.
+        let history = json!([{
+            "when": "2026-01-01T00:00:00Z",
+            "who": "a@b",
+            "changes": [
+                { "field_name": "depends_on", "added": "10", "removed": "11" }
+            ]
+        }]);
+        let allowed: BTreeSet<u64> = [10, 11].into_iter().collect();
+        let out = Guard::scrub_history(history, BASE, &allowed);
+        assert_eq!(
+            out[0]["changes"].as_array().map(Vec::len),
+            Some(1),
+            "a change whose added AND removed both survive is kept: {out}"
+        );
+        assert_eq!(out[0]["changes"][0]["added"], json!("10"));
+        assert_eq!(out[0]["changes"][0]["removed"], json!("11"));
+    }
+
+    #[test]
+    fn a_field_that_cannot_carry_a_bug_id_is_left_alone() {
+        // Free text naming a bug number is a recorded I14 limit, not something
+        // to rewrite: treating every history field as id-bearing would edit a
+        // summary and drop a numeric field's change outright.
+        let history = json!([{
+            "when": "2026-01-01T00:00:00Z",
+            "who": "a@b",
+            "changes": [
+                { "field_name": "summary",
+                  "added": "crash when opening 666, 777",
+                  "removed": "crash on open" },
+                { "field_name": "estimated_time", "added": "666", "removed": "0" }
+            ]
+        }]);
+        let out = Guard::scrub_history(history, BASE, &BTreeSet::new());
+        let changes = out[0]["changes"]
+            .as_array()
+            .expect("the entry keeps its changes");
+        assert_eq!(
+            changes.len(),
+            2,
+            "no change on a field that cannot name a bug may be dropped: {out}"
+        );
+        assert_eq!(
+            changes[0]["added"],
+            json!("crash when opening 666, 777"),
+            "free text passes through verbatim, bug numbers and all"
+        );
+        assert_eq!(
+            changes[1]["added"],
+            json!("666"),
+            "a number in a non-id field is not a bug id"
+        );
+    }
+
+    #[test]
     fn history_ids_are_found_in_both_directions_and_in_see_also_urls() {
         let history = json!([{
             "changes": [
@@ -1281,6 +1340,19 @@ mod tests {
                  it is blanked (I4)"
             );
         }
+    }
+
+    #[test]
+    fn the_link_disclosure_fan_out_bound_is_eight_assess_batches() {
+        // Pins MAX_ASSESS_IDS itself: eight batches of it is the 200-id I14
+        // link fan-out bound. Only guard_wiremock's
+        // `disclosable_fetches_at_most_the_link_fan_out_bound` holds
+        // `Guard::disclosable` to that number, on the wire.
+        assert_eq!(
+            Guard::MAX_ASSESS_IDS * 8,
+            200,
+            "the I14 link fan-out bound is 200 ids per disclosure fetch"
+        );
     }
 
     #[test]

--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -1245,6 +1245,45 @@ mod tests {
     }
 
     #[test]
+    fn a_bare_id_in_a_link_field_is_blanked_unless_it_is_disclosable() {
+        // Defence in depth (I14): the REST API documents these fields as id
+        // ARRAYS, but an instance answering with a bare scalar must not slip
+        // the id past the scrub. Looped over the constant, so a field added
+        // to LINKED_ID_FIELDS later is covered without editing this test.
+        let allowed: BTreeSet<u64> = [7].into_iter().collect();
+        for field in Guard::LINKED_ID_FIELDS {
+            let mut hidden = json!({ "id": 1 });
+            hidden[*field] = json!(7);
+            Guard::scrub_bug_links(&mut hidden, BASE, &BTreeSet::new());
+            assert_eq!(
+                hidden[*field],
+                Value::Null,
+                "a hidden bug named by a bare {field} must be blanked (I14)"
+            );
+            assert_eq!(hidden["id"], json!(1), "the bug's own id is untouched");
+
+            let mut shown = json!({ "id": 1 });
+            shown[*field] = json!(7);
+            Guard::scrub_bug_links(&mut shown, BASE, &allowed);
+            assert_eq!(
+                shown[*field],
+                json!(7),
+                "a disclosable bug named by a bare {field} must survive"
+            );
+
+            let mut odd = json!({ "id": 1 });
+            odd[*field] = json!("7");
+            Guard::scrub_bug_links(&mut odd, BASE, &allowed);
+            assert_eq!(
+                odd[*field],
+                Value::Null,
+                "a scalar in {field} that is no id at all cannot be cleared, so \
+                 it is blanked (I4)"
+            );
+        }
+    }
+
+    #[test]
     fn see_also_matching_is_anchored_to_this_instance() {
         // A host that merely starts with ours, or a path that merely contains
         // an id, must not be mistaken for a local bug link.

--- a/crates/bugwarden-core/tests/guard_wiremock.rs
+++ b/crates/bugwarden-core/tests/guard_wiremock.rs
@@ -1128,6 +1128,312 @@ async fn quicksearch_window_accounting_accumulates_across_chunks() {
     assert!(!ids.contains(&10) && !ids.contains(&230));
 }
 
+#[tokio::test]
+async fn quicksearch_window_zero_limit_touches_nothing_at_any_offset() {
+    // `needed` is non-zero as soon as the offset is, so at a non-zero offset
+    // the `limit == 0` test is the only thing that can stop the scan. An
+    // empty page must still cost nothing. No mock is mounted, so any
+    // upstream request fails the call outright.
+    let server = MockServer::start().await;
+    let g = guard(EMBARGO_POLICY);
+    let window = g
+        .quicksearch_window(&client(&server), KEY, &search("q", 0, 5), None)
+        .await
+        .expect("a zero limit at a non-zero offset is not an error");
+    assert!(window.bugs.is_empty());
+    assert_eq!(
+        window.scanned, 0,
+        "limit 0 scans nothing, whatever the offset"
+    );
+    assert_eq!(
+        requests_to(&server).await,
+        0,
+        "limit 0 must not contact Bugzilla, whatever the offset"
+    );
+}
+
+#[tokio::test]
+async fn quicksearch_window_stops_the_moment_the_scan_target_is_full() {
+    // One SEARCH_SCAN_CHUNK of fully visible bugs already meets the quantised
+    // target for every window inside it; a second request would be upstream
+    // load no page the client can ask for accounts for.
+    let server = MockServer::start().await;
+    corpus_counted(&server, 1_000, &[]).await;
+    let g = guard(EMBARGO_POLICY);
+    let got = g
+        .quicksearch_window(&client(&server), KEY, &search("q", 200, 0), None)
+        .await
+        .expect("search succeeds")
+        .bugs;
+    assert_eq!(ids_of(&got), (1..=200).collect::<Vec<u64>>());
+    assert_eq!(
+        requests_to(&server).await,
+        1,
+        "a full 200-row chunk fills the 200-row target in ONE request"
+    );
+}
+
+#[tokio::test]
+async fn quicksearch_window_row_bound_holds_when_pages_overrun_the_chunk() {
+    // SEARCH_SCAN_MAX has to bind on its own. Rows-per-request is the
+    // server's choice, so one that answers with more rows than it was asked
+    // for reaches 2000 examined rows in four requests — well inside the
+    // 10-request bound — and the scan must stop at the ceiling, not one
+    // request past it.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(|req: &Request| {
+            let q: std::collections::HashMap<_, _> = req.url.query_pairs().collect();
+            let offset: u64 = q.get("offset").and_then(|v| v.parse().ok()).unwrap_or(0);
+            // 500 hidden rows whatever `limit` asked for: nothing is ever
+            // visible, so only a bound can end the scan.
+            let rows: Vec<Value> = (offset + 1..=offset + 500)
+                .map(|id| bug(id, &["embargo-security"], OLD))
+                .collect();
+            ResponseTemplate::new(200).set_body_json(json!({ "bugs": rows }))
+        })
+        .mount(&server)
+        .await;
+    let g = guard(EMBARGO_POLICY);
+    let window = g
+        .quicksearch_window(&client(&server), KEY, &search("q", 50, 0), None)
+        .await
+        .expect("search succeeds");
+    assert!(window.bugs.is_empty(), "everything was hidden");
+    assert_eq!(
+        window.scanned, 2_000,
+        "SEARCH_SCAN_MAX rows examined and no more"
+    );
+    assert_eq!(
+        requests_to(&server).await,
+        4,
+        "4 x 500 rows reaches the row ceiling before the request ceiling"
+    );
+}
+
+#[tokio::test]
+async fn quicksearch_window_never_asks_for_more_rows_than_its_budget() {
+    // The chunk is clamped to what is LEFT of SEARCH_SCAN_MAX, so no single
+    // request can carry the scan past the ceiling. A conformant upstream
+    // never reaches the clamp — nine requests of at most 200 rows leave
+    // `scanned` at 1800 at most, and a full 200 still fits — so only a
+    // server that overruns the chunk it was given drives `scanned` close
+    // enough for the clamp to bite, and the `limit` it then sends pins it.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(|req: &Request| {
+            let q: std::collections::HashMap<_, _> = req.url.query_pairs().collect();
+            let offset: u64 = q.get("offset").and_then(|v| v.parse().ok()).unwrap_or(0);
+            // 1950 hidden rows whatever `limit` asked for, leaving 50 of the
+            // 2000-row budget for the next request.
+            let rows: Vec<Value> = (offset + 1..=offset + 1_950)
+                .map(|id| bug(id, &["embargo-security"], OLD))
+                .collect();
+            ResponseTemplate::new(200).set_body_json(json!({ "bugs": rows }))
+        })
+        .mount(&server)
+        .await;
+    let g = guard(EMBARGO_POLICY);
+    let window = g
+        .quicksearch_window(&client(&server), KEY, &search("q", 50, 0), None)
+        .await
+        .expect("search succeeds");
+    assert!(window.bugs.is_empty(), "everything was hidden");
+
+    let limits: Vec<String> = server
+        .received_requests()
+        .await
+        .expect("the mock records requests")
+        .iter()
+        .map(|r| {
+            r.url
+                .query_pairs()
+                .find(|(k, _)| k == "limit")
+                .map(|(_, v)| v.into_owned())
+                .unwrap_or_default()
+        })
+        .collect();
+    assert_eq!(
+        limits,
+        vec!["200".to_string(), "50".to_string()],
+        "the second request may ask for only the 50 rows left of the budget"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// the scan's server-side accounting line (I3: the count is never the
+// client's — this log and the audit record's `guard.scan` are where an
+// operator sees it)
+// ---------------------------------------------------------------------------
+
+/// What `quicksearch_window` logs when the scan actually withheld something.
+const WITHHELD_LINE: &str = "quicksearch: withheld policy-denied bugs";
+
+thread_local! {
+    /// Where the calling thread's capture accumulates. `None` means this
+    /// thread is not capturing and its events go on the floor.
+    static CAPTURED: std::cell::RefCell<Option<Vec<String>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// The `message` field of one event.
+struct Message(String);
+
+impl tracing::field::Visit for Message {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.0 = format!("{value:?}");
+        }
+    }
+}
+
+/// Records the message of every `bugwarden_core` event on the capturing
+/// thread. Hand-rolled rather than pulled in from tracing-subscriber: all it
+/// has to answer is whether one line was emitted. Everything else keeps the
+/// `Interest::never()` short-circuit it had before the subscriber existed.
+struct CaptureSubscriber;
+
+impl tracing::Subscriber for CaptureSubscriber {
+    fn enabled(&self, meta: &tracing::Metadata<'_>) -> bool {
+        meta.target().starts_with("bugwarden_core")
+    }
+
+    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+
+    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+
+    fn event(&self, event: &tracing::Event<'_>) {
+        let mut message = Message(String::new());
+        event.record(&mut message);
+        let Message(message) = message;
+        // `try_with`: a thread may still log while its thread-locals are
+        // being torn down, and that must not panic.
+        let _ = CAPTURED.try_with(move |slot| {
+            if let Some(lines) = slot.borrow_mut().as_mut() {
+                lines.push(message);
+            }
+        });
+    }
+
+    fn enter(&self, _: &tracing::span::Id) {}
+
+    fn exit(&self, _: &tracing::span::Id) {}
+}
+
+/// Install the capture as this test binary's process-wide default, once.
+///
+/// It cannot be a `with_default` scope: a callsite's `Interest` is cached the
+/// first time it is hit, from the registering thread's default subscriber, so
+/// a parallel test with no subscriber of its own can cache `Interest::never()`
+/// first and the macro then short-circuits forever after (the binary crate hit
+/// this as issue #92). The explicit rebuild fixes up whatever was cached
+/// before this ran.
+fn install_capture() {
+    static INSTALLED: std::sync::Once = std::sync::Once::new();
+    INSTALLED.call_once(|| {
+        tracing::subscriber::set_global_default(CaptureSubscriber)
+            .expect("the capture must be this test binary's only global default");
+        tracing::callsite::rebuild_interest_cache();
+    });
+}
+
+/// Run `f`, returning what this crate logged on the calling thread meanwhile.
+/// `#[tokio::test]` is single-threaded, so the whole future stays here.
+async fn messages_logged_by<T>(f: impl std::future::Future<Output = T>) -> Vec<String> {
+    install_capture();
+    CAPTURED.with(|slot| *slot.borrow_mut() = Some(Vec::new()));
+    let _ = f.await;
+    CAPTURED.with(|slot| slot.borrow_mut().take().unwrap_or_default())
+}
+
+#[tokio::test]
+async fn the_scan_logs_withheld_bugs_only_when_it_withheld_something() {
+    // The drop count never reaches the client (I3): this debug line and the
+    // audit record's `guard.scan` are where it surfaces. One emitted when
+    // nothing was dropped is a false report of a withholding, not a
+    // harmless extra log.
+    let hiding = MockServer::start().await;
+    corpus(&hiding, 10, &[3]).await;
+    let g = guard(EMBARGO_POLICY);
+    let logged = messages_logged_by(async {
+        g.quicksearch_window(&client(&hiding), KEY, &search("q", 5, 0), None)
+            .await
+            .expect("search succeeds");
+    })
+    .await;
+    assert!(
+        logged.iter().any(|m| m.contains(WITHHELD_LINE)),
+        "a scan that dropped a bug must say so: {logged:?}"
+    );
+
+    let clean = MockServer::start().await;
+    corpus(&clean, 10, &[]).await;
+    let logged = messages_logged_by(async {
+        g.quicksearch_window(&client(&clean), KEY, &search("q", 5, 0), None)
+            .await
+            .expect("search succeeds");
+    })
+    .await;
+    assert!(
+        !logged.iter().any(|m| m.contains(WITHHELD_LINE)),
+        "a scan that dropped nothing must not claim it did: {logged:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// disclosable: the I14 link fan-out bound
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn disclosable_fetches_at_most_the_link_fan_out_bound() {
+    // A tracker bug can name hundreds of others, so the one batched
+    // disclosure fetch takes at most MAX_ASSESS_IDS * 8 = 200 ids and the
+    // excess is simply not disclosable (I4). Nothing but the request the
+    // guard sends shows that bound, so it is pinned there.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": [] })))
+        .mount(&server)
+        .await;
+    let g = guard(EMBARGO_POLICY);
+    let ids: std::collections::BTreeSet<u64> = (1..=201).collect();
+    let out = g.disclosable(&client(&server), KEY, &ids, None).await;
+    assert!(out.is_empty(), "an empty envelope discloses nothing (I4)");
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("the mock records requests");
+    assert_eq!(
+        requests.len(),
+        1,
+        "one batched request, whatever the id count"
+    );
+    let query: std::collections::HashMap<_, _> = requests[0].url.query_pairs().collect();
+    let sent: Vec<&str> = query
+        .get("id")
+        .expect("the disclosure fetch carries an id list")
+        .split(',')
+        .collect();
+    assert_eq!(
+        sent.len(),
+        Guard::MAX_ASSESS_IDS * 8,
+        "201 linked ids must be cut to the 200-id fan-out bound"
+    );
+    assert_eq!(
+        (sent.first(), sent.last()),
+        (Some(&"1"), Some(&"200")),
+        "the bound keeps the lowest 200 ids"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // whoami + resolve_caller (identity resolution for created_by_me)
 // ---------------------------------------------------------------------------

--- a/crates/bugwarden/tests/tools_wiremock.rs
+++ b/crates/bugwarden/tests/tools_wiremock.rs
@@ -3084,6 +3084,43 @@ async fn bug_info_projected_link_fields_are_still_scrubbed() {
 }
 
 #[tokio::test]
+async fn bug_info_scalar_link_fields_are_scrubbed_like_arrays() {
+    // I14 defence in depth: the REST API documents every LINKED_ID_FIELDS
+    // slot as an id ARRAY, but an instance answering with a BARE id must not
+    // hand that id to the client. Every field at once and looped over the
+    // constant, so one added to it later is covered here too.
+    for (slot, linked, expected) in [
+        (json!(9), vec![], Value::Null),
+        (json!(9), vec![world_readable_bug(9)], json!(9)),
+        (json!("9"), vec![world_readable_bug(9)], Value::Null),
+    ] {
+        let mut bug = detailed_bug(7);
+        for field in Guard::LINKED_ID_FIELDS {
+            bug[*field] = slot.clone();
+        }
+        let mock = MockServer::start().await;
+        mount_bug_and_padding(&mock, bug).await;
+        Mock::given(method("GET"))
+            .and(path("/rest/bug"))
+            .and(query_param("id", "9"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "bugs": linked })))
+            .mount(&mock)
+            .await;
+        let client = client_for("", &mock).await;
+
+        let served = call(&client, "bug_info", json!({ "bug_ids": [7] })).await;
+        assert!(!is_error(&served), "bug_info failed: {}", text_of(&served));
+        let served: Value = serde_json::from_str(&text_of(&served)).expect("bug_info returns JSON");
+        for field in Guard::LINKED_ID_FIELDS {
+            assert_eq!(
+                served["bugs"][0][*field], expected,
+                "a bare {slot} in {field} must be served as {expected} (I14)"
+            );
+        }
+    }
+}
+
+#[tokio::test]
 async fn bug_info_projection_never_changes_a_restricted_entry() {
     // A denied id produces the uniform restricted entry regardless of
     // projection params (I2) — the projection loop must not touch it.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2538,7 +2538,13 @@ wired, `server.rs` and `main.rs` are the reference.
   silently-ignored-key class of typo), and an unknown `identity_source`
   value is rejected; `resolve_caller` under `declared` returns the login
   with ZERO HTTP requests (pinned against both `/rest/whoami` and
-  `/rest/valid_login` with `expect(0)`).
+  `/rest/valid_login` with `expect(0)`); and I14 link scrubbing — a bare
+  SCALAR in a `LINKED_ID_FIELDS` slot, which is what an instance answering
+  where the REST API documents an ARRAY gives us, is blanked unless that id
+  is disclosable and blanked outright when it is no id at all, looped over
+  the constant so a field added to it later is covered too (served
+  counterpart in `tools_wiremock.rs`; the arm was the fail-open half of
+  #244).
 - Unit tests (#[cfg(test)] in crates/bugwarden/src/server.rs): assemble_bug_info
   re-classification — a body embargoed after the verdict is refused, a body
   that now earns only summary is downgraded, a body granting neither read nor

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -65,10 +65,12 @@ Dependency direction: `bugwarden -> bugwarden-core`, never the reverse.
   that was DENIED must not be whitelisted, or asking about a hidden bug
   reveals it through the links of one the client may read.
   Known limits, deliberate: free-text comments naming a bug number are not
-  touched (unfixable without destroying comments); the duplicate-marker match
-  covers both stock templates but not localised/customised ones; and an
-  instance reachable under a second hostname is not recognised in see_also
-  (scheme and case are).
+  touched (unfixable without destroying comments); a history change to a
+  free-text field (summary, whiteboard) is not touched either, since
+  `is_id_bearing_history_field` decides what gets scrubbed; the
+  duplicate-marker match covers both stock templates but not
+  localised/customised ones; and an instance reachable under a second
+  hostname is not recognised in see_also (scheme and case are).
 - **I5** Private content (`is_private: true`) is returned only when policy
   `global.allow_private_comments = true` AND the call sets
   `include_private = true`. This one switch governs private comments,
@@ -2581,12 +2583,22 @@ wired, `server.rs` and `main.rs` are the reference.
   not read as end-of-results and the scan keeps going to fill the window, a
   1-row page cap still bounds the scan at 10 requests, id-less rows are dropped,
   rows repeated across chunks are served once, exhaustion and scan truncation look alike, zero limit
-  touches nothing (and accounts for nothing), the returned objects are the
-  classified ones, and the scan accounting (issue #29) — `scanned` counts
-  every upstream row examined and `dropped` is exactly the verdict-dropped
-  ids, overshoot-region denials included, id-less rows and deduped repeats
-  excluded, and both accumulate across chunks (a multi-chunk corpus with a
-  drop in each chunk pins the per-chunk `extend`/`+=`);
+  touches nothing (and accounts for nothing) at a non-zero offset as well as at
+  0 — where `needed` is non-zero, so the limit test alone stops the scan — a
+  full chunk of visible bugs fills the quantised target in exactly ONE request,
+  the 2000-row ceiling binds on its own against a server free to answer with
+  more rows than it was asked for (four 500-row pages, well inside the
+  10-request bound), no request asks for more rows than the budget has left
+  (`limit` 200, then 50 once 1950 of the 2000 rows are scanned), the
+  withheld-bugs debug line is emitted when and only when the scan dropped
+  something (its count never reaches the client, I3 — the log and the audit
+  record's `guard.scan` are where an operator sees it), `disclosable` cuts 201
+  linked ids to the MAX_ASSESS_IDS * 8 = 200 fan-out bound in ONE request, the
+  returned objects are the classified ones, and the scan accounting (issue #29)
+  — `scanned` counts every upstream row examined and `dropped` is exactly the
+  verdict-dropped ids, overshoot-region denials included, id-less rows and
+  deduped repeats excluded, and both accumulate across chunks (a multi-chunk
+  corpus with a drop in each chunk pins the per-chunk `extend`/`+=`);
   assess() deny for embargoed group; min-age deny; one request per distinct
   id whatever the answer (nonexistent vs withheld cost the same), repeated
   ids fetched once, no batch to poison; per-id


### PR DESCRIPTION
The twelve `guard.rs` survivors from the first mutants run (#244), each killed by a named test.

First commit: `scrub_bug_links`' scalar arm — a bare id in a `LINKED_ID_FIELDS` slot — had no test at either level, and the `false` mutant of its guard is fail-open (a policy-denied id served whole, I14). Unit and served tests loop over `LINKED_ID_FIELDS`.

Second commit: the nine `quicksearch_window`/`disclosable`/`scrub_history` bounds and accumulators. Notable: the chunk clamp at `:349` is unreachable with a conformant upstream (`2000 - scanned >= 200` at every request start), so its test uses a mock that returns more rows than asked; the withheld-bugs log line gets a hand-rolled global `Subscriber` (the `Interest`-cache reason `testlog.rs` records as #92). I14's known-limits list now names the free-text history limit the new test pins. The six cargo-mutants timeouts are panic-hangs in served handlers, not loops — a per-call deadline in the test helper is #254.

Closes #244
