### PR TITLE
fix(server): reserve _len in a recorded object

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,19 +990,20 @@ same 1024-character boundary, but relocated rather than truncated: an
 over-cap key never becomes a key in the record, it moves into its
 object's server-reserved `_overlong_keys` array, whose shape is
 `[{"prefix": <the first 1024 chars>, "key_chars": N, "value": …}]`. A
-client key spelled `_overlong_keys` is routed into that array too rather
-than passed through, so the name is only ever server-written.
-`request.tool` carries client text too: a call naming a
-tool this server does not serve is recorded before it is refused, so the
-name is truncated on that same boundary; every served name is far
-shorter, so a served record is unchanged. `request.id` is client text as
-well — a JSON-RPC id the client picked: the record keeps its first 1024
-characters while the reply still echoes the full id — the cap is on the
-record, never on the wire. Every client-chosen string a record carries is
-bounded: capped at 1024 characters — allowlisted `params` values, key
-prefixes, `request.tool`, the self-declared `client.name` and
-`client.version`, `request.id` — or, for `trace`, parsed into fixed-width
-hex ids.
+client key spelled `_overlong_keys` — or `_len`, the withheld-content
+marker itself — is routed into that array too rather than passed through,
+at any depth, so neither reserved name is ever client-written: a marker
+meaning "content withheld" must not be forgeable by content.
+`request.tool` carries client text too: a call naming a tool this server
+does not serve is recorded before it is refused, so the name is truncated
+on that same boundary; every served name is far shorter, so a served
+record is unchanged. `request.id` is client text as well — a JSON-RPC id
+the client picked: the record keeps its first 1024 characters while the
+reply still echoes the full id — the cap is on the record, never on the
+wire. Every client-chosen string a record carries is bounded: capped at
+1024 characters — allowlisted `params` values, key prefixes,
+`request.tool`, the self-declared `client.name` and `client.version`,
+`request.id` — or, for `trace`, parsed into fixed-width hex ids.
 
 ```json
 {"v":2,"ts":"2026-02-03T04:05:06.789Z","seq":7,"session":{"id":"sess-1","transport":"http","remote":"192.0.2.7:52611"},"event":"tool_call","client":{"name":"example-agent","version":"1.4.2"},"request":{"tool":"bugs_quicksearch","id":"3","params":{"limit":50,"offset":0,"query":"kernel panic","status":"ALL"}},"guard":{"verdict":"served_filtered","policy_hash":"sha256:58013baa090cf77630373ab50cc5eaf2d679ec5a06e8a336600fc89b23bb8604","suppressed_ids_count":2,"suppressed_other_count":0,"suppressed_ids":[1290040,1290041],"redacted_fields":[],"scan":{"scanned":50,"dropped":2}},"upstream":{"requests":3,"status":200,"latency_ms":48},"outcome":{"class":"ok","duration_ms":52,"response_bytes":6218}}

--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -59,14 +59,15 @@
 //! tiering question does not arise for it. TWO EXCEPTIONS, and the first
 //! is the case a future field is likeliest to hit: [`RequestInfo::params`]
 //! is CLIENT-authored content wherever the allowlist passes it verbatim —
-//! the `_len` and `_overlong_keys` reductions beside it are the
-//! server's — not the server's account of anything, so a value read out
-//! of it is a correlation hint at best and never an identity — a
-//! grouping handle a client was given and handed back included. The
-//! second: [`RequestInfo::tool`] is that account only while the name is
-//! one this server serves, since a call it will not serve is recorded
-//! too — an unknown name is the client's own text, capped for that
-//! reason (#243), and groups records by nothing but itself.
+//! the `_len` and `_overlong_keys` reductions beside it are the server's
+//! (both names reserved at every depth, #241) — not the server's account
+//! of anything, so a value read out of it is a correlation hint at best
+//! and never an identity — a grouping handle a client was given and
+//! handed back included. The second: [`RequestInfo::tool`] is that
+//! account only while the name is one this server serves, since a call
+//! it will not serve is recorded too — an unknown name is the client's
+//! own text, capped for that reason (#243), and groups records by
+//! nothing but itself.
 //!
 //! # What can never appear in a record
 //!
@@ -823,8 +824,10 @@ pub struct RequestInfo {
     /// by the recording call site: identifiers, projections, switches —
     /// parameters whose values the client chose. Verbatim only where
     /// allowlisted: the `_len` and `_overlong_keys` reductions are
-    /// server-written. Bug content fetched from Bugzilla must never be
-    /// placed here; a tool result is not a parameter.
+    /// server-written, both names reserved at every depth so a client
+    /// key spelling either is relocated, never passed through (#241).
+    /// Bug content fetched from Bugzilla must never be placed here; a
+    /// tool result is not a parameter.
     pub params: BTreeMap<String, serde_json::Value>,
 }
 

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -267,9 +267,10 @@ fn audit_refusal(tool: &str) -> CallToolResult {
 /// `{"_len": <serialized byte length>}`, so presence and size are loggable
 /// while content is not. Allowlisted string values are truncated to 1024
 /// characters. KEY NAMES are bounded on the same boundary but RELOCATED,
-/// never truncated in place: a client-chosen key over the cap does not
-/// enter the map as a key at any depth, it moves to the reserved
-/// `_overlong_keys` array behind a capped prefix ([`recorded_object`]).
+/// never truncated in place: a client-chosen key over the cap — or
+/// spelling a reserved name — does not enter the map as a key at any
+/// depth, it moves to the reserved `_overlong_keys` array behind a capped
+/// prefix ([`recorded_object`]).
 /// Neither cap bounds the record's SIZE — element and entry counts are
 /// uncapped, so an allowlisted value's shape can still make a large
 /// record; each bounds the length of any ONE verbatim string, not their
@@ -327,9 +328,13 @@ const PARAM_ALLOWLIST: &[&str] = &[
 /// [`PARAM_ALLOWLIST`].
 const PARAM_VALUE_MAX_CHARS: usize = 1024;
 
-/// Reserved key under which one recorded object holds its over-cap key
-/// names; see [`recorded_object`].
+/// Reserved key under which one recorded object holds its over-cap and
+/// reserved-name keys; see [`recorded_object`].
 const OVERLONG_KEYS: &str = "_overlong_keys";
+
+/// Reserved key carrying a non-allowlisted value's size in place of its
+/// content; written by [`allowlisted`], reserved by [`recorded_object`].
+const RESERVED_LEN: &str = "_len";
 
 /// An allowlisted value with every string [`capped`], at ANY depth: the
 /// client picks the JSON shape, so the bound must not depend on it (#211).
@@ -386,9 +391,11 @@ fn capped(value: &str) -> String {
 /// elements cannot collide, so two keys sharing a 1024-char prefix stay
 /// two faithful entries; plain truncation would fold them into one and
 /// MISREPORT which key was sent, which is why #211 left keys uncapped
-/// rather than truncate them. A client key equal to [`OVERLONG_KEYS`]
-/// routes there too, carrying its own true (short) `key_chars`, so the
-/// reserved name is only ever server-written. Both levels of the map go
+/// rather than truncate them. A client key equal to either reserved name
+/// — [`OVERLONG_KEYS`] or [`RESERVED_LEN`] — routes there too at every
+/// depth, carrying its own true (short) `key_chars`, so neither name is
+/// ever client-written (#241: a withheld-content marker must not be
+/// forgeable by content). Both call sites — top level and nested — go
 /// through here so the rule cannot drift between them (#191).
 fn recorded_object<'a, M: FromIterator<(String, Value)>>(
     fields: impl IntoIterator<Item = (&'a String, &'a Value)>,
@@ -399,7 +406,8 @@ fn recorded_object<'a, M: FromIterator<(String, Value)>>(
     for (key, value) in fields {
         let recorded = record(key, value);
         let key_chars = key.chars().count();
-        if key_chars > PARAM_VALUE_MAX_CHARS || key.as_str() == OVERLONG_KEYS {
+        if key_chars > PARAM_VALUE_MAX_CHARS || matches!(key.as_str(), OVERLONG_KEYS | RESERVED_LEN)
+        {
             overlong.push(json!({
                 "prefix": capped(key),
                 "key_chars": key_chars,
@@ -431,7 +439,7 @@ fn allowlisted(params: Option<&JsonObject>) -> BTreeMap<String, Value> {
             truncated(value)
         } else {
             let len = serde_json::to_vec(value).map(|b| b.len()).unwrap_or(0);
-            json!({ "_len": len })
+            json!({ RESERVED_LEN: len })
         }
     })
 }
@@ -6349,6 +6357,72 @@ mod tests {
         };
         assert_eq!(entry["key_chars"], json!(OVERLONG_KEYS.chars().count()));
         assert_eq!(entry["value"], json!("mine"));
+    }
+
+    #[test]
+    fn a_client_sent_len_marker_cannot_forge_the_reduction() {
+        // #241: `_len` means "content withheld by the server". Under an
+        // allowlisted key the value is copied verbatim, so without the
+        // reservation `{"_len": 5}` records byte-identically to the
+        // reduction a NON-allowlisted key gets, and only PARAM_ALLOWLIST
+        // — which the record does not carry and which moves between
+        // builds — told them apart.
+        let obj: JsonObject = serde_json::from_value(json!({
+            "groups": { RESERVED_LEN: 5 },
+            "custom_fields": { RESERVED_LEN: 5 },
+            "keywords": { RESERVED_LEN: { RESERVED_LEN: 1 } },
+        }))
+        .unwrap();
+        let params = allowlisted(Some(&obj));
+
+        // Allowlisted: the client's key is routed, exactly as a client key
+        // spelled `_overlong_keys` already was (#220).
+        assert!(
+            params["groups"].get(RESERVED_LEN).is_none(),
+            "a verbatim {RESERVED_LEN} would be indistinguishable from the reduction"
+        );
+        let Some([entry]) = params["groups"]
+            .get(OVERLONG_KEYS)
+            .and_then(|v| v.as_array())
+            .map(Vec::as_slice)
+        else {
+            panic!("the client's own {RESERVED_LEN} key belongs under {OVERLONG_KEYS}");
+        };
+        assert_eq!(entry["prefix"], json!(RESERVED_LEN));
+        assert_eq!(entry["key_chars"], json!(RESERVED_LEN.chars().count()));
+        assert_eq!(entry["value"], json!(5), "the value itself is not lost");
+
+        // Non-allowlisted: the reduction is untouched, and it is the ONLY
+        // way `_len` reaches a record — same name, one definition.
+        let len = serde_json::to_vec(&json!({ RESERVED_LEN: 5 }))
+            .unwrap()
+            .len();
+        assert_eq!(params["custom_fields"], json!({ RESERVED_LEN: len }));
+
+        // Routed at every depth, and by the NAME alone: this one's value
+        // is an object, whose own `_len` key is routed while the value is
+        // recorded.
+        assert!(
+            params["keywords"].get(RESERVED_LEN).is_none(),
+            "nested: same rule"
+        );
+        let Some([nested]) = params["keywords"]
+            .get(OVERLONG_KEYS)
+            .and_then(|v| v.as_array())
+            .map(Vec::as_slice)
+        else {
+            panic!("the nested {RESERVED_LEN} key belongs under {OVERLONG_KEYS}");
+        };
+        assert_eq!(nested["key_chars"], json!(RESERVED_LEN.chars().count()));
+        assert_eq!(
+            nested["value"],
+            json!({ OVERLONG_KEYS: [{
+                "prefix": RESERVED_LEN,
+                "key_chars": RESERVED_LEN.chars().count(),
+                "value": 1,
+            }] }),
+            "the client's nested key is routed too, one level further down"
+        );
     }
 
     // The fail-mode scope tests below drive a REAL sink into failure via

--- a/crates/bugwarden/tests/audit_wiremock.rs
+++ b/crates/bugwarden/tests/audit_wiremock.rs
@@ -2078,6 +2078,69 @@ async fn canary_content_never_reaches_the_audit_file() {
 }
 
 #[tokio::test]
+async fn a_client_sent_len_marker_is_distinguishable_on_the_served_path() {
+    // #241, end to end: one call carries `{"_len": 5}` under an
+    // allowlisted key (copied verbatim, so forgeable without the
+    // reservation) and under a non-allowlisted one (reduced by the
+    // server). The allowlisted side must not carry a `_len` the server
+    // did not write: it is told apart by shape, never by the number.
+    // Off-schema keys on bug_url are ignored by serde, so this is the
+    // served path.
+    let mock = MockServer::start().await;
+    mount_fixture(&mock).await;
+    let audited = audited_client_for("", &mock, "test-key").await;
+
+    let _ = call(
+        &audited.client,
+        "bug_url",
+        json!({
+            "bug_id": 7,
+            "groups": { "_len": 5 },
+            "custom_fields": { "_len": 5 },
+        }),
+    )
+    .await;
+
+    let events = read_events(&audited.audit_path);
+    let calls: Vec<&bugwarden::audit::ToolCallEvent> = events
+        .iter()
+        .filter_map(|e| match &e.kind {
+            AuditEventKind::ToolCall(tc) => Some(&**tc),
+            _ => None,
+        })
+        .collect();
+    let [tc] = calls.as_slice() else {
+        panic!("exactly one tool-call record, got {}", calls.len());
+    };
+    assert_eq!(tc.request.tool, "bug_url");
+    assert_eq!(tc.outcome.class, OutcomeClass::Ok, "the served path");
+
+    let allowlisted = &tc.request.params["groups"];
+    assert!(
+        allowlisted.get("_len").is_none(),
+        "a client-sent marker would be indistinguishable from the reduction"
+    );
+    let Some([entry]) = allowlisted
+        .get("_overlong_keys")
+        .and_then(|v| v.as_array())
+        .map(Vec::as_slice)
+    else {
+        panic!("the client's own _len key belongs under _overlong_keys, alone");
+    };
+    assert_eq!(
+        entry,
+        &json!({ "prefix": "_len", "key_chars": 4, "value": 5 }),
+        "it is routed like any reserved name, keeping its true length"
+    );
+    let reduced = serde_json::to_vec(&json!({ "_len": 5 })).unwrap().len();
+    assert_eq!(
+        tc.request.params["custom_fields"],
+        json!({ "_len": reduced }),
+        "the server's own reduction, the only way _len reaches a record"
+    );
+}
+
+#[tokio::test]
 async fn initialize_writes_exactly_one_record_with_the_client_identity() {
     // Recorded unconditionally: auditing on means session starts are in
     // the stream — there is no configuration knob that turns this off.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1189,9 +1189,11 @@ Decisions, all deliberate:
   than a large one — which is why #211 left keys uncapped rather than
   truncate them. The prefix, not a bare length, because which parameter
   was oversized is the diagnostic params are recorded for. A client key
-  spelled `_overlong_keys` routes into the array too, carrying its own
-  true (short) `key_chars`, so the reserved name is only ever
-  server-written. `request.tool` is bounded on that same boundary
+  spelled `_overlong_keys` — or `_len`, the reduction marker itself
+  (#241) — routes into the array too, at every depth, carrying its own
+  true (short) `key_chars`, so neither reserved name is ever
+  client-written: a marker meaning "content withheld" must not be
+  forgeable by content. `request.tool` is bounded on that same boundary
   (#243), by plain truncation: a call the router will not serve is
   recorded before it is refused, so an unknown name is client text of any
   length, while routing, the fail-mode gate and `WRITE_TOOLS` keep
@@ -2869,17 +2871,19 @@ wired, `server.rs` and `main.rs` are the reference.
   over-cap key names RELOCATED at both levels — an end-to-end served
   call carrying an over-cap key top level and under an allowlisted
   object, plus a prefix-sharing pair at each level, asserted per level
-  so half a fix fails; a client key spelled like the reserved marker
-  routed rather than passed through; the boundary itself, in chars not
-  bytes and with at-cap under it; and an ordinary record growing no
-  marker, #220); the recorded tool name truncated on that same boundary
-  at both reachable record sites, in chars not bytes and with at-cap
-  under it, while the every-routed-tool walk above pins each served name
-  byte-identical (#243); the recorded request id truncated on the same
-  boundary at both derivations — over-cap cut to exactly the cap, at-cap
-  kept, chars not bytes, the out-of-contract site too — and end-to-end a
-  4x-cap string id sent by raw per-request POST records exactly 1024
-  chars while the reply echoes the whole id (#248); and trace
+  so half a fix fails; a client key spelled like either reserved marker
+  routed rather than passed through — `_overlong_keys`, and the `_len`
+  reduction itself, that one end to end as well (#241); the boundary
+  itself, in chars not bytes and with at-cap under it; and an ordinary
+  record growing no marker, #220); the recorded tool name truncated on
+  that same boundary at both reachable record sites, in chars not bytes
+  and with at-cap under it, while the every-routed-tool walk above pins
+  each served name byte-identical (#243); the recorded request id
+  truncated on the same boundary at both derivations — over-cap cut to
+  exactly the cap, at-cap kept, chars not bytes, the out-of-contract site
+  too — and end-to-end a 4x-cap string id sent by raw per-request POST
+  records exactly 1024 chars while the reply echoes the whole id (#248);
+  and trace
   enrichment (issue #28) — the strict traceparent parser (the canonical
   W3C value and its flags-00 variant parse into their ids; empty,
   54-byte, 56-byte, and ~1 MiB values, uppercase hex, versions other


### PR DESCRIPTION
`_len` means "content withheld by the server", but under an allowlisted key a client's `{"_len": 5}` was copied verbatim and recorded byte-identically to the reduction a non-allowlisted key gets; only `PARAM_ALLOWLIST` — a compile-time constant the record does not carry — told them apart. A marker meaning "content withheld" must not be forgeable by content.

`_len` now joins `_overlong_keys` as a reserved name in `recorded_object` at every depth: a client key spelling it routes into `_overlong_keys` with its true `key_chars` and recorded value, as `_overlong_keys` itself already did (#220). One `RESERVED_LEN` const feeds both the reservation and the reduction. Unit test at both levels (the nested one carries an object, so routing by name alone is pinned), served-path test end to end. Unchanged wire shape keeps `v`.

Closes #241
