### PR TITLE
fix(server): cap client strings in tracing lines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,9 @@ are never a justification for undoing them.
   process calls. Bound network operations with the client's configured
   timeout.
 - Tracing goes to stderr always — stdout belongs to the stdio transport.
+  A client string in a tracing field goes through `Capped`, on the audit
+  record's 1024-char boundary; a client-sized id array is logged as a count
+  plus a `MAX_ASSESS_IDS` head.
 
 ## Tests and Dependencies
 

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -325,7 +325,8 @@ const PARAM_ALLOWLIST: &[&str] = &[
 ];
 
 /// Cap on recorded string values AND on object key names; see
-/// [`PARAM_ALLOWLIST`].
+/// [`PARAM_ALLOWLIST`]. Also on every tracing field that formats a client
+/// string ([`Capped`], #240).
 const PARAM_VALUE_MAX_CHARS: usize = 1024;
 
 /// Reserved key under which one recorded object holds its over-cap and
@@ -350,13 +351,14 @@ fn truncated(value: &Value) -> Value {
     }
 }
 
-/// `value` truncated to [`PARAM_VALUE_MAX_CHARS`] characters — the one
-/// rule every RECORDED string obeys: an audited parameter leaf
-/// ([`truncated`]), an over-cap key's prefix ([`recorded_object`]), a
-/// recorded client identity, a recorded TOOL NAME and a recorded
-/// JSON-RPC REQUEST ID alike. A second copy of the rule would have to be
-/// remembered beside it (#191); every site that records an audited
-/// string goes through this instead.
+/// `value` truncated to [`PARAM_VALUE_MAX_CHARS`] characters, owned —
+/// the one rule every recorded CLIENT string obeys, `trace` aside
+/// (parsed, never capped): an audited parameter leaf ([`truncated`]), an
+/// over-cap key's prefix ([`recorded_object`]), a recorded client
+/// identity, a recorded TOOL NAME and a recorded JSON-RPC REQUEST ID
+/// alike. The cut itself is [`Capped::as_str`] (#191, #240): tracing
+/// fields take [`Capped`], every site that records a client string takes
+/// this.
 ///
 /// The tool name is capped in the RECORD only (#243): a call the router
 /// will not serve is recorded like any other, so the name is client text
@@ -370,12 +372,47 @@ fn truncated(value: &Value) -> Value {
 /// the reply to its request by it, and the reply is rmcp's — written off
 /// the id it parsed, which no code of ours touches.
 fn capped(value: &str) -> String {
-    // A string of at most 1024 BYTES has at most 1024 chars; the cheap
-    // length check skips the char walk for the common case.
-    if value.len() > PARAM_VALUE_MAX_CHARS {
-        value.chars().take(PARAM_VALUE_MAX_CHARS).collect()
-    } else {
-        value.to_string()
+    Capped(value).as_str().to_string()
+}
+
+/// [`capped`] as a tracing field: `%Capped(&p.query)` formats the first
+/// [`PARAM_VALUE_MAX_CHARS`] characters in place, allocating nothing.
+///
+/// The tracing path reaches the same operator and the same collector as
+/// the audit record, so a client string left raw there undoes the bar
+/// `call_tool`'s record enforces on the same call (#240). It cuts
+/// SILENTLY, no marker, exactly as the record's own cut does. [`capped`]
+/// delegates here, so there is one cut to remember (#191); the unit
+/// tests pin both at the boundary.
+struct Capped<'a>(&'a str);
+
+impl<'a> Capped<'a> {
+    /// The leading at-most-[`PARAM_VALUE_MAX_CHARS`]-char slice.
+    fn as_str(&self) -> &'a str {
+        // A string of at most 1024 BYTES has at most 1024 chars; the cheap
+        // length check skips the char walk for the common case.
+        if self.0.len() <= PARAM_VALUE_MAX_CHARS {
+            return self.0;
+        }
+        match self.0.char_indices().nth(PARAM_VALUE_MAX_CHARS) {
+            Some((end, _)) => &self.0[..end],
+            // Over the byte bound but under the char one: multi-byte text.
+            None => self.0,
+        }
+    }
+}
+
+impl std::fmt::Display for Capped<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// So an `Option<Capped>` field keeps the `Some("…")` / `None` shape the
+/// bare `?p.resolution` printed before the cap.
+impl std::fmt::Debug for Capped<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self.as_str(), f)
     }
 }
 
@@ -825,6 +862,13 @@ fn too_many_ids(ids: &[u64]) -> Option<CallToolResult> {
             Guard::MAX_ASSESS_IDS
         ))
     })
+}
+
+/// The head of a client-sized id array that belongs on a tracing line: at
+/// most [`Guard::MAX_ASSESS_IDS`], the bound `too_many_ids` refuses past.
+/// Log it beside a `_len` count of the whole array (#240, #258).
+fn logged_ids(ids: &[u64]) -> &[u64] {
+    &ids[..ids.len().min(Guard::MAX_ASSESS_IDS)]
 }
 
 /// Keep the first `head` and last `tail` items of a list, dropping the
@@ -2502,9 +2546,6 @@ impl BugWarden {
         Parameters(p): Parameters<BugInfoParams>,
         ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-        tracing::info!(bug_ids = ?p.bug_ids, "tool: bug_info");
-        let key = self.api_key(&ctx)?;
-
         // Deduplicate while preserving request order.
         let mut seen = BTreeSet::new();
         let ids: Vec<u64> = p
@@ -2513,6 +2554,15 @@ impl BugWarden {
             .copied()
             .filter(|id| seen.insert(*id))
             .collect();
+        // The first `MAX_ASSESS_IDS` distinct ids: exactly the set served,
+        // or the head of a call refused whole (`too_many_ids`); the count
+        // is the raw array's, which is client-sized (#240).
+        tracing::info!(
+            bug_ids_len = p.bug_ids.len(),
+            bug_ids = ?logged_ids(&ids),
+            "tool: bug_info"
+        );
+        let key = self.api_key(&ctx)?;
         if ids.is_empty() {
             note_refused(&ctx);
             return Ok(err_text("At least one bug id must be provided"));
@@ -2858,12 +2908,12 @@ impl BugWarden {
         ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         tracing::info!(
-            query = %p.query,
-            status = %p.status,
-            include_fields = %p.include_fields,
+            query = %Capped(&p.query),
+            status = %Capped(&p.status),
+            include_fields = %Capped(&p.include_fields),
             limit = p.limit,
             offset = p.offset,
-            group_by = p.group_by.as_deref().unwrap_or(""),
+            group_by = ?Capped(p.group_by.as_deref().unwrap_or("")),
             "tool: bugs_quicksearch"
         );
         // Validated before the upstream call: a malformed projection should
@@ -3009,8 +3059,8 @@ impl BugWarden {
         ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         tracing::info!(
-            product = %p.product,
-            component = %p.component,
+            product = %Capped(&p.product),
+            component = %Capped(&p.component),
             custom_field_count = p.custom_fields.as_ref().map_or(0, |cf| cf.len()),
             "tool: create_bug"
         );
@@ -3085,7 +3135,7 @@ impl BugWarden {
             // 0 decides nothing — caller identity is deliberately None so
             // the refused path keeps costing exactly one upstream request.
             let _ = self.assess(&key, &[0], None).await;
-            tracing::info!(product = %p.product, "guard denied bug creation");
+            tracing::info!(product = %Capped(&p.product), "guard denied bug creation");
             note_refused(&ctx);
             return Ok(err_text(Guard::create_denial()));
         }
@@ -3122,7 +3172,7 @@ impl BugWarden {
     ) -> Result<CallToolResult, McpError> {
         tracing::info!(
             bug_id = p.bug_id,
-            file_name = %p.file_name,
+            file_name = %Capped(&p.file_name),
             is_private = p.is_private,
             "tool: add_attachment"
         );
@@ -3220,8 +3270,8 @@ impl BugWarden {
     ) -> Result<CallToolResult, McpError> {
         tracing::info!(
             bug_id = p.bug_id,
-            status = %p.status,
-            resolution = ?p.resolution,
+            status = %Capped(&p.status),
+            resolution = ?p.resolution.as_deref().map(Capped),
             "tool: update_bug_status"
         );
         let key = self.api_key(&ctx)?;
@@ -3264,7 +3314,11 @@ impl BugWarden {
         Parameters(p): Parameters<AssignBugParams>,
         ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-        tracing::info!(bug_id = p.bug_id, assignee = %p.assignee, "tool: assign_bug");
+        tracing::info!(
+            bug_id = p.bug_id,
+            assignee = %Capped(&p.assignee),
+            "tool: assign_bug"
+        );
         let key = self.api_key(&ctx)?;
         let caller = self.guard.resolve_caller(&self.bz, &key).await;
         if let Some(denied) = self
@@ -3301,15 +3355,15 @@ impl BugWarden {
         ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         // priority/severity/resolution are benign instance vocabulary and
-        // stay value-logged; every other param is logged as presence or
-        // count only — summaries, whiteboards and URLs can carry embargoed
-        // content, and the server log must not become a content sink (the
-        // audit stream's boundary rule, applied to tracing).
+        // stay value-logged (capped, #240); every other param is logged as
+        // presence or count only — summaries, whiteboards and URLs can carry
+        // embargoed content, and the server log must not become a content
+        // sink (the audit stream's boundary rule, applied to tracing).
         tracing::info!(
             bug_id = p.bug_id,
-            priority = ?p.priority,
-            severity = ?p.severity,
-            resolution = ?p.resolution,
+            priority = ?p.priority.as_deref().map(Capped),
+            severity = ?p.severity.as_deref().map(Capped),
+            resolution = ?p.resolution.as_deref().map(Capped),
             summary = p.summary.is_some(),
             url = p.url.is_some(),
             whiteboard = p.whiteboard.is_some(),
@@ -3446,12 +3500,20 @@ impl BugWarden {
         Parameters(p): Parameters<UpdateBugDependenciesParams>,
         ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
+        // Four client-sized arrays sharing one `MAX_ASSESS_IDS` budget,
+        // and `too_many_ids` refuses only further down: a count plus a head
+        // no longer than that budget keeps the line bounded by its fields
+        // (#258).
         tracing::info!(
             bug_id = p.bug_id,
-            blocks_add = ?p.blocks_add,
-            blocks_remove = ?p.blocks_remove,
-            depends_on_add = ?p.depends_on_add,
-            depends_on_remove = ?p.depends_on_remove,
+            blocks_add_len = p.blocks_add.as_ref().map_or(0, Vec::len),
+            blocks_add = ?p.blocks_add.as_deref().map(logged_ids),
+            blocks_remove_len = p.blocks_remove.as_ref().map_or(0, Vec::len),
+            blocks_remove = ?p.blocks_remove.as_deref().map(logged_ids),
+            depends_on_add_len = p.depends_on_add.as_ref().map_or(0, Vec::len),
+            depends_on_add = ?p.depends_on_add.as_deref().map(logged_ids),
+            depends_on_remove_len = p.depends_on_remove.as_ref().map_or(0, Vec::len),
+            depends_on_remove = ?p.depends_on_remove.as_deref().map(logged_ids),
             "tool: update_bug_dependencies"
         );
 
@@ -3552,7 +3614,11 @@ impl BugWarden {
         Parameters(p): Parameters<AddCcParams>,
         ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-        tracing::info!(bug_id = p.bug_id, cc_email = %p.cc_email, "tool: add_cc_to_bug");
+        tracing::info!(
+            bug_id = p.bug_id,
+            cc_email = %Capped(&p.cc_email),
+            "tool: add_cc_to_bug"
+        );
         let key = self.api_key(&ctx)?;
         let caller = self.guard.resolve_caller(&self.bz, &key).await;
         if let Some(denied) = self
@@ -4176,7 +4242,7 @@ impl ServerHandler for BugWarden {
             info.protocol_version = request.protocol_version.clone();
         } else {
             tracing::warn!(
-                client_requested = %request.protocol_version,
+                client_requested = %Capped(request.protocol_version.as_str()),
                 server_fallback = %info.protocol_version,
                 "client requested unsupported protocol version; falling back to server default"
             );
@@ -6242,6 +6308,31 @@ mod tests {
             "at the cap, nothing is cut"
         );
         assert_eq!(capped(&at_cap), at_cap, "and neither path cuts it");
+    }
+
+    #[test]
+    fn a_tracing_field_cuts_at_the_audited_1024_char_boundary() {
+        // #240: `capped` delegates to `Capped`, so pinning the wrapper
+        // either side of the boundary — not just over it — is what holds
+        // the tracing path to the record's cap. Multi-byte on purpose: an
+        // ASCII probe cannot tell a char cap from a byte one.
+        for chars in [
+            PARAM_VALUE_MAX_CHARS - 1,
+            PARAM_VALUE_MAX_CHARS,
+            PARAM_VALUE_MAX_CHARS + 1,
+        ] {
+            let value = "é".repeat(chars);
+            assert_eq!(
+                Capped(&value).to_string().chars().count(),
+                chars.min(PARAM_VALUE_MAX_CHARS),
+                "{chars} chars must be cut at the cap in chars, never at a byte boundary"
+            );
+        }
+        // Silently, with no marker of its own, as an audited string is cut.
+        let over = "z".repeat(PARAM_VALUE_MAX_CHARS + 1);
+        assert_eq!(Capped(&over).to_string(), "z".repeat(PARAM_VALUE_MAX_CHARS));
+        // Debug keeps the shape a `?p.resolution` field printed uncapped.
+        assert_eq!(format!("{:?}", Some(Capped("FIXED"))), "Some(\"FIXED\")");
     }
 
     #[test]

--- a/crates/bugwarden/tests/binary_tracing_caps.rs
+++ b/crates/bugwarden/tests/binary_tracing_caps.rs
@@ -1,0 +1,429 @@
+//! What the SHIPPED BINARY's tracing lines carry of a client's own strings
+//! and id arrays (issues #240, #258).
+//!
+//! The audit record caps every client string at 1024 chars before it
+//! reaches the JSONL file or the OTLP audit stream; the `info!` line the
+//! handler opens with used to carry the same text raw, to the same
+//! operator and the same collector. That is a whole-channel defect, so
+//! this drives the real executable: only a process proves the line clears
+//! the DEFAULT filter `main` installs (`RUST_LOG` scrubbed, never set
+//! back) and reaches the stderr writer; `testlog` runs at TRACE under its
+//! own writer and proves neither.
+//!
+//! Coverage contract (each of these mutations must fail a test here):
+//! - any `Capped` field formatted from its parameter instead of the
+//!   wrapper — one [`Site`] row per field, the handshake `warn!` that is
+//!   not a tool parameter included;
+//! - a wrapper cutting at cap-1, cap+1, or on a byte boundary, which is
+//!   why every probe is multi-byte;
+//! - `bug_info` or `update_bug_dependencies` logging an id array whole, or
+//!   a head without the count that says how long the array really was.
+
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use bugwarden_core::guard::Guard;
+use serde_json::json;
+use tokio::io::AsyncWriteExt as _;
+use tokio::process::Command;
+
+#[path = "common/scrub_env.rs"]
+mod scrub_env;
+
+#[path = "common/startup_line.rs"]
+mod startup_line;
+
+/// Bounded so a binary that never logs the line fails this test rather than
+/// hanging the suite until CI's own timeout kills it.
+const LOG_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// The cap, spelled out: `server::PARAM_VALUE_MAX_CHARS` is private, and a
+/// test that reads the constant it is testing agrees with any value.
+const CAP: usize = 1024;
+
+/// A revision the server serves, so the handshake is unremarkable
+/// everywhere except the row testing an unsupported one.
+const SUPPORTED_VERSION: &str = "2025-11-25";
+
+/// Each binary runs the walker itself, so a single-binary
+/// `cargo test --test binary_tracing_caps` still proves what its scrub claims.
+#[test]
+fn the_scrub_list_covers_every_environment_fallback() {
+    scrub_env::assert_the_scrub_list_covers_every_environment_fallback(
+        scrub_env::AMBIENT_VARS,
+        scrub_env::HTTP_TOKEN_VARS,
+    );
+}
+
+/// Drive one client message sequence through the real executable over
+/// stdio and return the first stderr line containing `needle`.
+///
+/// Bugzilla is deliberately unreachable: the lines under test are logged
+/// before any upstream call, or — the create denial — after one that can
+/// only fail, so the handshake, the call and the line happen in order
+/// without a mock. stdout goes to /dev/null: the replies are not the
+/// subject.
+async fn log_line(
+    protocol_version: &str,
+    policy: Option<&Path>,
+    call: Option<(&str, serde_json::Value)>,
+    needle: &str,
+) -> String {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_bugwarden"));
+    cmd.args(["--transport", "stdio"])
+        .args(["--bugzilla-server", "https://bugzilla.example.invalid"])
+        .args(["--api-key", "test-key"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    if let Some(path) = policy {
+        cmd.arg("--policy").arg(path);
+    }
+    // Scrubbed and NOT set back: `RUST_LOG` included, so these lines are
+    // read at the level `main` falls back to. A line that only appears
+    // under a raised level is not what this issue is about.
+    for var in scrub_env::AMBIENT_VARS {
+        cmd.env_remove(var);
+    }
+    let mut child = cmd.spawn().expect("the built binary must start");
+    let mut stderr = startup_line::stderr_lines(&mut child);
+    let mut stdin = child.stdin.take().expect("stdin is piped");
+    let mut messages = vec![json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": protocol_version,
+            "capabilities": {},
+            "clientInfo": { "name": "binary-tracing-caps-test", "version": "0" }
+        }
+    })];
+    if let Some((tool, arguments)) = call {
+        messages.push(json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }));
+        messages.push(json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": { "name": tool, "arguments": arguments }
+        }));
+    }
+    for message in messages {
+        stdin
+            .write_all(format!("{message}\n").as_bytes())
+            .await
+            .expect("the child must accept input");
+    }
+    // Holds `stdin` open until the line arrives: EOF ends the child's serve
+    // loop and `kill_on_drop` finishes it off on return, which together can
+    // retire the child before the reader has what it came for.
+    let mut log = String::new();
+    let line = startup_line::wait_for_line(&mut stderr, &mut log, needle, LOG_TIMEOUT).await;
+    drop(stdin);
+    line
+}
+
+/// [`log_line`] for the ordinary case: a served handshake, one tool call,
+/// the default allow-all policy.
+async fn tool_call_log_line(tool: &str, arguments: serde_json::Value, needle: &str) -> String {
+    log_line(SUPPORTED_VERSION, None, Some((tool, arguments)), needle).await
+}
+
+/// The value the tracing line gives `field`; `ends_with` is `None` when the
+/// field is the last one on its line.
+fn logged_field<'a>(line: &'a str, field: &str, ends_with: Option<&str>) -> &'a str {
+    let after = line
+        .split_once(field)
+        .unwrap_or_else(|| panic!("the line must carry a {field} field: {line}"))
+        .1;
+    match ends_with {
+        None => after,
+        Some(end) => match after.split_once(end) {
+            Some((value, _)) => value,
+            None => panic!("the {field} field must be followed by {end}: {line}"),
+        },
+    }
+}
+
+/// The ids an array field logged, `field` being everything up to its first
+/// id.
+fn logged_ids(line: &str, field: &str) -> Vec<u64> {
+    logged_field(line, field, Some("]"))
+        .split(", ")
+        .map(|id| id.parse().unwrap_or_else(|e| panic!("{id:?}: {e}: {line}")))
+        .collect()
+}
+
+/// One tracing field that formats a client string, and the call that puts
+/// it on stderr. `field` and `ends_with` bracket the value: a `%Capped`
+/// field prints bare, an `?Option<Capped>` one prints `Some("…")`.
+struct Site {
+    /// `None` for the handshake `warn!`, whose probe is the declared
+    /// protocol version rather than a tool argument.
+    tool: Option<&'static str>,
+    arguments: serde_json::Value,
+    /// A policy the guard refuses, for the line only a refusal reaches.
+    policy: Option<&'static str>,
+    needle: &'static str,
+    field: &'static str,
+    ends_with: Option<&'static str>,
+}
+
+/// Denies every product, so `create_bug` reaches its refusal line. No other
+/// row needs a policy: the guard is consulted after the field under test is
+/// already formatted.
+const DENY_ALL: &str = "[[rule]]\nname = \"deny-all\"\naction = \"deny\"\n\
+                        [rule.match]\nproducts = [\"*\"]\n";
+
+/// Every field in `server.rs` that formats a client string, with the
+/// smallest call that logs it and the probe in that field alone.
+fn sites(probe: &str) -> Vec<Site> {
+    vec![
+        Site {
+            tool: Some("bugs_quicksearch"),
+            arguments: json!({ "query": probe }),
+            policy: None,
+            needle: "tool: bugs_quicksearch",
+            field: "query=",
+            ends_with: Some(" status="),
+        },
+        Site {
+            tool: Some("bugs_quicksearch"),
+            arguments: json!({ "query": "kernel", "status": probe }),
+            policy: None,
+            needle: "tool: bugs_quicksearch",
+            field: "status=",
+            ends_with: Some(" include_fields="),
+        },
+        Site {
+            tool: Some("bugs_quicksearch"),
+            arguments: json!({ "query": "kernel", "include_fields": probe }),
+            policy: None,
+            needle: "tool: bugs_quicksearch",
+            field: "include_fields=",
+            ends_with: Some(" limit="),
+        },
+        Site {
+            tool: Some("bugs_quicksearch"),
+            arguments: json!({ "query": "kernel", "group_by": probe }),
+            policy: None,
+            needle: "tool: bugs_quicksearch",
+            // Debug-formatted, so it stays quoted like the bare `&str`
+            // field it replaced.
+            field: "group_by=\"",
+            ends_with: Some("\""),
+        },
+        Site {
+            tool: Some("create_bug"),
+            arguments: json!({
+                "product": probe, "component": "kernel",
+                "summary": "s", "version": "v"
+            }),
+            policy: None,
+            needle: "tool: create_bug",
+            field: "product=",
+            ends_with: Some(" component="),
+        },
+        Site {
+            tool: Some("create_bug"),
+            arguments: json!({
+                "product": "openSUSE", "component": probe,
+                "summary": "s", "version": "v"
+            }),
+            policy: None,
+            needle: "tool: create_bug",
+            field: "component=",
+            ends_with: Some(" custom_field_count="),
+        },
+        Site {
+            tool: Some("create_bug"),
+            arguments: json!({
+                "product": probe, "component": "kernel",
+                "summary": "s", "version": "v"
+            }),
+            policy: Some(DENY_ALL),
+            needle: "guard denied bug creation",
+            field: "product=",
+            ends_with: None,
+        },
+        Site {
+            tool: Some("add_attachment"),
+            arguments: json!({
+                "bug_id": 1, "data": "", "file_name": probe,
+                "summary": "s", "content_type": "text/plain"
+            }),
+            policy: None,
+            needle: "tool: add_attachment",
+            field: "file_name=",
+            ends_with: Some(" is_private="),
+        },
+        Site {
+            tool: Some("update_bug_status"),
+            arguments: json!({ "bug_id": 1, "status": probe }),
+            policy: None,
+            needle: "tool: update_bug_status",
+            field: "status=",
+            ends_with: Some(" resolution="),
+        },
+        Site {
+            tool: Some("update_bug_status"),
+            arguments: json!({ "bug_id": 1, "status": "RESOLVED", "resolution": probe }),
+            policy: None,
+            needle: "tool: update_bug_status",
+            field: "resolution=Some(\"",
+            ends_with: Some("\")"),
+        },
+        Site {
+            tool: Some("assign_bug"),
+            arguments: json!({ "bug_id": 1, "assignee": probe }),
+            policy: None,
+            needle: "tool: assign_bug",
+            field: "assignee=",
+            ends_with: None,
+        },
+        Site {
+            tool: Some("update_bug_fields"),
+            arguments: json!({ "bug_id": 1, "priority": probe }),
+            policy: None,
+            needle: "tool: update_bug_fields",
+            field: "priority=Some(\"",
+            ends_with: Some("\")"),
+        },
+        Site {
+            tool: Some("update_bug_fields"),
+            arguments: json!({ "bug_id": 1, "severity": probe }),
+            policy: None,
+            needle: "tool: update_bug_fields",
+            field: "severity=Some(\"",
+            ends_with: Some("\")"),
+        },
+        Site {
+            tool: Some("update_bug_fields"),
+            arguments: json!({ "bug_id": 1, "resolution": probe }),
+            policy: None,
+            needle: "tool: update_bug_fields",
+            field: "resolution=Some(\"",
+            ends_with: Some("\")"),
+        },
+        Site {
+            tool: Some("add_cc_to_bug"),
+            arguments: json!({ "bug_id": 1, "cc_email": probe }),
+            policy: None,
+            needle: "tool: add_cc_to_bug",
+            field: "cc_email=",
+            ends_with: None,
+        },
+        Site {
+            // rmcp logs the same message text with the version raw (#260),
+            // so this row selects on the target.
+            tool: None,
+            arguments: json!({}),
+            policy: None,
+            needle: "bugwarden::server: client requested unsupported",
+            field: "client_requested=",
+            ends_with: Some(" server_fallback="),
+        },
+    ]
+}
+
+/// `toml` where the spawned child can read it.
+fn policy_file(toml: &str) -> PathBuf {
+    let path = Path::new(env!("CARGO_TARGET_TMPDIR")).join("tracing_caps_policy.toml");
+    std::fs::write(&path, toml).expect("the policy file must be writable");
+    path
+}
+
+#[tokio::test]
+async fn every_tracing_field_that_formats_a_client_string_is_cut_to_the_cap() {
+    // Multi-byte: an ASCII probe cannot tell a char cap from a byte one,
+    // and a byte cut is one of the two ways the shared wrapper can drift.
+    let probe = "é".repeat(CAP * 4);
+    for site in sites(&probe) {
+        let policy = site.policy.map(policy_file);
+        let version = if site.tool.is_some() {
+            SUPPORTED_VERSION
+        } else {
+            probe.as_str()
+        };
+        let call = site.tool.map(|tool| (tool, site.arguments));
+        let line = log_line(version, policy.as_deref(), call, site.needle).await;
+        let value = logged_field(&line, site.field, site.ends_with);
+        // EXACTLY the cap, not "at most": an off-by-one cut is a second
+        // rule that has to be remembered next to the audit record's, which
+        // is the thing #191 and this share a definition to prevent.
+        assert_eq!(
+            value.chars().count(),
+            CAP,
+            "{} on {:?} must reach stderr as exactly {CAP} chars: {line}",
+            site.field,
+            site.needle
+        );
+        assert!(
+            value.chars().all(|c| c == 'é'),
+            "and as a prefix of what the client actually sent: {line}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn bug_ids_reach_stderr_as_a_raw_count_and_a_distinct_head() {
+    // The head stops where `too_many_ids` refuses; the count says how long
+    // the array really was.
+    let mut repeated: Vec<u64> = vec![7; Guard::MAX_ASSESS_IDS];
+    repeated.push(8);
+    for (sent, head) in [
+        (
+            (1..=Guard::MAX_ASSESS_IDS as u64 + 5).collect::<Vec<u64>>(),
+            (1..=Guard::MAX_ASSESS_IDS as u64).collect::<Vec<u64>>(),
+        ),
+        // Positional over the raw array, this head would be 25 sevens and
+        // would omit the served id 8.
+        (repeated, vec![7, 8]),
+    ] {
+        let line =
+            tool_call_log_line("bug_info", json!({ "bug_ids": sent }), "tool: bug_info").await;
+        assert!(
+            line.contains(&format!("bug_ids_len={}", sent.len())),
+            "the count is what the whole array used to say: {line}"
+        );
+        assert_eq!(
+            logged_ids(&line, "bug_ids=["),
+            head,
+            "and the head is exactly the distinct ids the call may serve: {line}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn every_dependency_array_reaches_stderr_as_a_count_and_a_head() {
+    // Four client-sized arrays on one line, each refused only further down
+    // (#258).
+    let sent = Guard::MAX_ASSESS_IDS + 5;
+    let list = |base: u64| (base..base + sent as u64).collect::<Vec<u64>>();
+    let line = tool_call_log_line(
+        "update_bug_dependencies",
+        json!({
+            "bug_id": 1,
+            "blocks_add": list(1000),
+            "blocks_remove": list(2000),
+            "depends_on_add": list(3000),
+            "depends_on_remove": list(4000),
+        }),
+        "tool: update_bug_dependencies",
+    )
+    .await;
+    for (field, base) in [
+        ("blocks_add", 1000),
+        ("blocks_remove", 2000),
+        ("depends_on_add", 3000),
+        ("depends_on_remove", 4000),
+    ] {
+        assert!(
+            line.contains(&format!("{field}_len={sent}")),
+            "{field} must carry the count of the whole array: {line}"
+        );
+        assert_eq!(
+            logged_ids(&line, &format!("{field}=Some([")),
+            (base..base + Guard::MAX_ASSESS_IDS as u64).collect::<Vec<u64>>(),
+            "and no more of it than the guard's own bound: {line}"
+        );
+    }
+}

--- a/crates/bugwarden/tests/common/startup_line.rs
+++ b/crates/bugwarden/tests/common/startup_line.rs
@@ -1,20 +1,22 @@
-//! The shipped binary's own startup line, which is the readiness barrier for
-//! every test that spawns it (#173, #222, #230).
+//! The shipped binary's own startup line, the readiness barrier for the
+//! tests that need the child bound before they act (#173, #222, #230), plus
+//! the stderr line reader every spawning test shares.
 //!
 //! Included by `#[path]` from each user rather than declared in
 //! `common/mod.rs`: that module is compiled into every test binary that says
-//! `mod common;`, so a helper only two of them use would be `dead_code` in
+//! `mod common;`, so a helper only some of them use would be `dead_code` in
 //! the rest, which `-D warnings` rejects.
 //!
-//! Nothing here owns the reader or picks the timeout, because the two callers
-//! need opposite policies past the barrier and neither can be the shared
-//! default. `binary_shutdown::Server` keeps one reader for the process's
-//! life — a `BufReader` built per wait throws away whatever it buffered past
-//! the match, which can swallow the line a later assertion needs — while
-//! `http_auth_wiremock` hands its reader to a drain, because its child keeps
-//! serving past the barrier and an unread pipe becomes backpressure. So the
-//! shared part is the needle plus wait-and-parse; ownership and budget stay
-//! with the caller.
+//! Nothing here owns the reader or picks the timeout, because the three
+//! includers need different policies past the barrier and no one of them can
+//! be the shared default. `binary_shutdown::Server` keeps one reader for the
+//! process's life — a `BufReader` built per wait throws away whatever it
+//! buffered past the match, which can swallow the line a later assertion
+//! needs — while `http_auth_wiremock` hands its reader to a drain, because
+//! its child keeps serving past the barrier and an unread pipe becomes
+//! backpressure, and `binary_tracing_caps` throws child and reader away
+//! after one line. So the shared part is the needle plus wait-and-parse;
+//! ownership and budget stay with the caller.
 
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -28,6 +30,7 @@ use tokio::process::ChildStderr;
 /// The line the http transport logs once it is bound *and* its signal
 /// handlers are armed; the address that follows is the one the kernel
 /// assigned, which under `--port 0` is the only way to learn it.
+#[allow(dead_code, reason = "only the http includers wait on this barrier")]
 pub const HTTP_READY: &str = "Starting Bugzilla MCP server on ";
 
 /// A spawned child's stderr, read a line at a time.
@@ -80,6 +83,7 @@ pub async fn wait_for_line(
 /// The kernel picked it under `--port 0`, so a line still carrying the
 /// requested `0` — or an address off loopback — means the barrier matched
 /// something that is not the child's real listener.
+#[allow(dead_code, reason = "only the http includers have an address to parse")]
 pub fn parse_bound_addr(line: &str) -> SocketAddr {
     let addr: SocketAddr = line
         .split_once(HTTP_READY)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1207,6 +1207,14 @@ Decisions, all deliberate:
   off the frame. With it every client-chosen string a record carries is
   bounded: capped at 1024 characters, or, for `trace`, parsed to
   fixed-width hex ids.
+
+  The server's own `tracing` lines answer to the same 1024-char bound
+  (#240): every field formatting a client string goes through `Capped`,
+  which shares one cut with `capped`, and `bug_info` and
+  `update_bug_dependencies` log their id arrays as a count plus a head no
+  longer than `MAX_ASSESS_IDS`. Same operator, same collector — a bound
+  the record enforces and the handler's own `info!` line undoes is not a
+  bound.
 - **The params caps bound content, not record size — and a total cap is a
   decided no** (#220). Array element and map entry counts are uncapped, so
   an allowlisted value's SHAPE can still make a large record; what bounds
@@ -1771,10 +1779,12 @@ names an endpoint.
   peak (three copies of the batch's bytes); at the ceiling, ≈192 GiB and
   ≈256 GiB. Over stdio the same `max_request_body_bytes` bounds a frame
   (`BoundedLines`, #234), so the per-stream figures are identical. The
-  diagnostics queue is the same shape and not smaller — at the default
-  `info` level `bug_info` debug-formats the client's whole `bug_ids`
-  array — but it DROPS what it cannot hold, where the audit queue refuses
-  and closes the fail-mode gate.
+  diagnostics queue is the same shape and not smaller. Since #240 the
+  server's OWN lines are bounded by their field count rather than by the
+  call (`error = %e` aside, #261), but rmcp's are not — its handshake and
+  notification lines print the client's frame whole (#260) — so the queue
+  stays unsized by record too. It DROPS what it cannot hold, where the audit queue refuses and
+  closes the fail-mode gate.
 - **Decided-no: byte-bounding the queue (#235).** A byte budget (a
   `Semaphore` acquired per record in `accept`, released when the batch
   drops) would refuse audit records — and so close the gate for the whole


### PR DESCRIPTION
The audit record caps every client string at 1024 chars (#191); the handler's own `info!` line carried the same text raw, and `call_tool` writes the record only after the handler returns — same operator, same collector, so the record's bound was undone one line earlier.

`Capped` is that cut as a tracing field (formats in place, no allocation); `capped()` delegates to it, so there is one cut. Sixteen sites now go through it; `bug_info` and `update_bug_dependencies` log their id arrays as a raw count plus the first `MAX_ASSESS_IDS` distinct ids (#258). Still raw on purpose: rmcp's own handshake/notification lines (#260) and `error = %e` (#261).

Evidence: a spawned-binary table, one row per site, where reverting any site fails its own row and no other (16/16); multi-byte probes so a byte cut dies; cargo-mutants over `Capped`/`capped`/`logged_ids` 10/10 caught.

Closes #240
Closes #258
