### PR TITLE
fix(stdio): a probe must not pick the lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,12 @@ revision it declares in its own `_meta`:
   enough, and a client naming one gets the served list back from the server
   before it ever reaches this decision.
 
+`server/discover` is a probe, and it chooses neither lifecycle. Over stdio and
+HTTP alike a client may follow it with `initialize` for a session, or with
+`_meta`-carrying requests for the handshake-free lifecycle — and a probe the
+server refuses, because it names a revision outside the list above or is
+missing its required `_meta` keys, refuses that one request and nothing else.
+
 The advertised capability set is tools only: bugwarden registers no MCP
 prompts and no MCP resources. `summarize_bug` is a tool that returns prompt
 text, not an MCP prompt.

--- a/crates/bugwarden/src/main.rs
+++ b/crates/bugwarden/src/main.rs
@@ -16,6 +16,7 @@ use bugwarden::audit::{
 use bugwarden::http_auth::{self, HttpEnv};
 use bugwarden::http_session::AuditedSessionManager;
 use bugwarden::otel::{self, OtelEnv, Pipeline};
+use bugwarden::stdio::DiscoverAnswering;
 use bugwarden::{config, server};
 use bugwarden_core::{guard::Guard, policy::Policy};
 use clap::Parser;
@@ -233,13 +234,37 @@ async fn main() -> anyhow::Result<()> {
                 // which the service reports as an ordinary close, so this
                 // flag is the only thing that tells the two apart below.
                 let over_cap = stdin.over_cap();
+                // `server/discover` is answered by the transport, never by
+                // rmcp's lifecycle picker: rmcp commits the session to the
+                // handshake-free lifecycle on the first non-`initialize`
+                // frame, sticking a flag it offers no way to clear (#267).
+                // Built before `serve` consumes `server`.
+                let transport = DiscoverAnswering::framed(stdin, stdout, server.clone());
+                // An answered probe leaves rmcp waiting for the first
+                // COMMITTING frame, so a client that only probed and hung
+                // up closes the stream inside `initialize`'s wait, where
+                // rmcp reports `ConnectionClosed` rather than a clean end.
+                let probed = transport.answered();
                 tracing::info!("Starting Bugzilla MCP server on stdio");
                 let service = tokio::select! {
-                    result = server.serve((stdin, stdout)) => {
-                        result.inspect_err(|e| {
+                    result = server.serve(transport) => match result {
+                        Ok(service) => service,
+                        // A probe-only client is a peer hangup, not a
+                        // serving failure: exit 0, as before #267. Not a
+                        // refused frame though — that closes the same way
+                        // and must stay a failure exit.
+                        Err(rmcp::service::ServerInitializeError::ConnectionClosed(_))
+                            if probed.load(Ordering::Acquire)
+                                && !over_cap.load(Ordering::Acquire) =>
+                        {
+                            tracing::info!("peer hung up after a server/discover probe");
+                            return Ok(());
+                        }
+                        Err(e) => {
                             tracing::error!("serving error: {:?}", e);
-                        })?
-                    }
+                            return Err(e.into());
+                        }
+                    },
                     () = &mut shutdown => {
                         tracing::info!("received shutdown signal");
                         // serve() is already blocked in tokio::io::stdin()'s

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -40,14 +40,15 @@ use crate::stdio::BoundedLines;
 /// the list bounds is precisely which DECLARED revisions `initialize`,
 /// per-request `_meta` and `server/discover` may agree to; it does not
 /// decide which request lifecycle the transport routes to — see
-/// [`lifecycle_of`].
+/// [`lifecycle_of`]. Read here and, for the stdio discover answer rmcp no
+/// longer gives, in [`crate::stdio::DiscoverAnswering`] (#267).
 ///
 /// `2026-07-28` is served as of issue #34 stage 2. Its handshake-free
 /// requests carry the calling client in their own `_meta`, which
 /// [`client_of`] reads, so a record on that path names the caller or names
 /// nobody — never the SDK placeholder rmcp synthesises for a peer that
 /// never handshook (#34 §3c).
-const SUPPORTED_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
+pub(crate) const SUPPORTED_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
     ProtocolVersion::V_2024_11_05,
     ProtocolVersion::V_2025_03_26,
     ProtocolVersion::V_2025_06_18,

--- a/crates/bugwarden/src/stdio.rs
+++ b/crates/bugwarden/src/stdio.rs
@@ -1,4 +1,5 @@
-//! Frame bound for the stdio transport.
+//! What wraps rmcp's stdio transport: a frame bound ([`BoundedLines`])
+//! and a `server/discover` answer ([`DiscoverAnswering`]).
 //!
 //! rmcp's `AsyncRwTransport` reads a newline-delimited frame with
 //! `read_until(b'\n', &mut self.line_buf)` into a `Vec<u8>` it never
@@ -20,14 +21,29 @@
 //! `receive() -> None`, i.e. a silent close indistinguishable from a clean
 //! peer hangup, so the trip is also published through [`BoundedLines::over_cap`]
 //! for `main` to turn into a non-zero exit.
+//!
+//! [`DiscoverAnswering`] is the other half: rmcp reads the stdio lifecycle
+//! off the first frame, so a `server/discover` probe committed the session
+//! to the handshake-free lifecycle before it was answered (#267). Both are
+//! transport-level because both are: the frame never reaches a handler.
 
+use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::task::{ready, Context, Poll};
 
-use tokio::io::{AsyncRead, ReadBuf};
+use rmcp::model::{
+    ClientJsonRpcMessage, ClientRequest, DiscoverResult, ErrorData as McpError, GetMeta as _,
+    ProtocolVersion, RequestId, ServerJsonRpcMessage, ServerResult,
+};
+use rmcp::transport::async_rw::AsyncRwTransport;
+use rmcp::transport::Transport;
+use rmcp::{RoleServer, ServerHandler as _};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use crate::server::{BugWarden, SUPPORTED_PROTOCOL_VERSIONS};
 
 /// An [`AsyncRead`] that fails once a newline-delimited frame exceeds
 /// `cap` bytes.
@@ -148,6 +164,187 @@ impl<R: AsyncRead + Unpin> AsyncRead for BoundedLines<R> {
             return Poll::Ready(Err(this.trip()));
         }
         Poll::Ready(Ok(()))
+    }
+}
+
+/// One reply's write, boxed so it can outlive the `receive` that queued
+/// it. See [`DiscoverAnswering::receive`].
+type QueuedSend<E> = Pin<Box<dyn Future<Output = Result<(), E>> + Send>>;
+
+/// A [`Transport`] that answers `server/discover` itself and hands rmcp
+/// every other frame untouched.
+///
+/// `server/discover` is a probe, but over stdio rmcp lets it CHOOSE the
+/// session lifecycle before anyone answers it: `serve_server_with_ct_inner`
+/// (rmcp 3.1.4 `service/server.rs:510-577`) takes any first non-`ping`
+/// frame that is not `initialize` as a commitment to the handshake-free
+/// lifecycle and calls `Peer::require_request_metadata()` (`:562`) — a
+/// sticky `AtomicBool` that no later `initialize` clears and no public API
+/// can reset, both methods being `pub(crate)`. Every subsequent request
+/// but `initialize` that carries no `_meta` is then refused -32602
+/// (`handler/server.rs:78-100`), so a client that probes and then opens a
+/// session is dead (#267). A probe rmcp refuses is worse: it answers and
+/// then ENDS the process with `ExpectedInitializeRequest`.
+///
+/// Answering here keeps discover off that path entirely. rmcp's first frame
+/// is then the first one that IS a commitment — `initialize` for a session,
+/// or a `_meta`-carrying request that sets the flag exactly as before. The
+/// per-request gate stays rmcp's and no other frame is intercepted — but a
+/// probe no longer moves rmcp past its pre-`initialize` loop, so a `ping`
+/// after one is answered `{}` there rather than refused -32601 by the
+/// per-request handler (`handler/server.rs:112-118`), which is where a
+/// probe used to leave it.
+///
+/// http needs none of this: there `serve_negotiated_request_directly`
+/// answers a discover per POST and sets no flag.
+pub struct DiscoverAnswering<T: Transport<RoleServer>> {
+    inner: T,
+    /// Cloned, not snapshotted: `get_info()` is read per discover, as
+    /// rmcp's default handler reads it.
+    server: BugWarden,
+    /// A discover reply whose write has not finished, parked across
+    /// `receive` calls because `receive` is one arm of rmcp's `select!`
+    /// (`service.rs:1395`) and is dropped whenever another arm wins. A
+    /// reply awaited on that stack dies with the frame that asked for it —
+    /// consumed, never answered, the client hung on that id — while the
+    /// inner transport survives the same cancellation by keeping its
+    /// partial line in `line_buf` (`transport/async_rw.rs:126-131`).
+    pending: Option<QueuedSend<T::Error>>,
+    /// Set once a probe's reply has reached the peer, served or refused.
+    /// See [`DiscoverAnswering::answered`].
+    probed: Arc<AtomicBool>,
+}
+
+impl<T: Transport<RoleServer>> DiscoverAnswering<T> {
+    /// Answer `server/discover` on `inner` from `server`.
+    pub fn new(inner: T, server: BugWarden) -> Self {
+        Self {
+            inner,
+            server,
+            pending: None,
+            probed: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Whether a probe has been answered, shared with whoever outlives the
+    /// transport.
+    ///
+    /// A probe answered here leaves rmcp still waiting for its first
+    /// committing frame, so a probe-only client's hangup surfaces as
+    /// `ServerInitializeError::ConnectionClosed` rather than as the clean
+    /// close it is. `main` reads this to tell the two apart (#267).
+    pub fn answered(&self) -> Arc<AtomicBool> {
+        self.probed.clone()
+    }
+
+    /// rmcp's own answer for one discover request, in rmcp's own order:
+    /// the pre-`initialize` metadata check (`service/server.rs:541-551`,
+    /// its text at `:486`), then the declared-revision check
+    /// (`handler/server.rs:64-72`), then that file's default result (`:347`).
+    ///
+    /// That order is the pre-`initialize` path's, which is the one this
+    /// replaces; rmcp's in-session handler runs the two the other way
+    /// round, so a `_meta` malformed BOTH ways — an unserved revision and
+    /// no `clientCapabilities` — now draws -32602 where a mid-session
+    /// probe drew -32022. Refused either way, and a `_meta` missing a
+    /// required key declares no lifecycle worth reading a version out of.
+    ///
+    /// Not stripped for a legacy peer: `strip_result_type_for_legacy_peer`
+    /// (`model.rs:4596`) has no `DiscoverResult` arm, so `resultType`
+    /// stays on the wire whatever revision the probe declares.
+    fn discover_reply(&self, request: &ClientRequest, id: RequestId) -> ServerJsonRpcMessage {
+        let meta = request.get_meta();
+        let missing = meta.missing_required_keys(&ProtocolVersion::V_2026_07_28);
+        if !missing.is_empty() {
+            return ServerJsonRpcMessage::error(
+                McpError::invalid_params(
+                    format!(
+                        "request _meta is missing or has malformed required fields: {}",
+                        missing.join(", ")
+                    ),
+                    None,
+                ),
+                Some(id),
+            );
+        }
+        if let Some(requested) = meta
+            .protocol_version()
+            .filter(|version| !SUPPORTED_PROTOCOL_VERSIONS.contains(version))
+        {
+            return ServerJsonRpcMessage::error(
+                McpError::unsupported_protocol_version(requested, SUPPORTED_PROTOCOL_VERSIONS),
+                Some(id),
+            );
+        }
+        ServerJsonRpcMessage::response(
+            ServerResult::DiscoverResult(DiscoverResult::from_server_info(
+                SUPPORTED_PROTOCOL_VERSIONS.to_vec(),
+                self.server.get_info(),
+            )),
+            id,
+        )
+    }
+}
+
+impl<R, W> DiscoverAnswering<AsyncRwTransport<RoleServer, R, W>>
+where
+    R: AsyncRead + Send + Unpin,
+    W: AsyncWrite + Send + Unpin + 'static,
+{
+    /// The same wrapper over a newline-framed pair, so `main` frames stdio
+    /// through rmcp rather than naming rmcp's transport itself.
+    pub fn framed(read: R, write: W, server: BugWarden) -> Self {
+        Self::new(AsyncRwTransport::new_server(read, write), server)
+    }
+}
+
+impl<T: Transport<RoleServer>> Transport<RoleServer> for DiscoverAnswering<T> {
+    type Error = T::Error;
+
+    fn send(
+        &mut self,
+        item: ServerJsonRpcMessage,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+        self.inner.send(item)
+    }
+
+    /// Loops instead of returning: an answered discover is consumed here
+    /// and the next frame awaited, so rmcp never learns a lifecycle from
+    /// one. A failed send closes the transport, like every other write
+    /// failure on this path.
+    ///
+    /// The reply is queued in `pending` and driven at the top of the loop,
+    /// never awaited on this stack: this future is cancelled whenever
+    /// another arm of rmcp's `select!` wins, which under any pipelining is
+    /// most of the time.
+    async fn receive(&mut self) -> Option<ClientJsonRpcMessage> {
+        loop {
+            if let Some(pending) = self.pending.as_mut() {
+                let sent = pending.await;
+                self.pending = None;
+                sent.ok()?;
+                self.probed.store(true, Ordering::Release);
+            }
+            match self.inner.receive().await? {
+                ClientJsonRpcMessage::Request(request)
+                    if matches!(request.request, ClientRequest::DiscoverRequest(_)) =>
+                {
+                    let reply = self.discover_reply(&request.request, request.id);
+                    self.pending = Some(Box::pin(self.inner.send(reply)));
+                }
+                other => return Some(other),
+            }
+        }
+    }
+
+    /// Drains `pending` first: rmcp closes the transport on its way out of
+    /// the serve loop, and the last `receive` may have been cancelled with
+    /// a probe's answer still queued.
+    async fn close(&mut self) -> Result<(), Self::Error> {
+        if let Some(pending) = self.pending.take() {
+            let _ = pending.await;
+        }
+        self.inner.close().await
     }
 }
 
@@ -350,5 +547,763 @@ mod tests {
             received.is_none(),
             "an over-cap frame must close the transport, not yield a message"
         );
+    }
+}
+
+/// [`DiscoverAnswering`]: what the wrapper answers, what it lets past, and
+/// that the lifecycle rmcp ends up on is the one the client's FIRST
+/// committing request chose (#267).
+#[cfg(test)]
+mod discover {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use bugwarden_core::guard::Guard;
+    use bugwarden_core::policy::Policy;
+    use rmcp::model::{
+        ClientJsonRpcMessage, ClientRequest, DiscoverResult, ProtocolVersion, ServerJsonRpcMessage,
+    };
+    use rmcp::transport::Transport as _;
+    use rmcp::{RoleServer, ServerHandler as _, ServiceExt as _};
+    use serde_json::{json, Value};
+    use tokio::io::{
+        AsyncBufReadExt as _, AsyncWriteExt as _, BufReader, DuplexStream, ReadHalf, WriteHalf,
+    };
+
+    use super::DiscoverAnswering;
+    use crate::pinned_cli::pinned;
+    use crate::server::{bugzilla_client, BugWarden, SUPPORTED_PROTOCOL_VERSIONS};
+
+    /// Bounded so a wrapper that swallows a frame fails rather than hanging
+    /// the suite until CI's own timeout kills it.
+    const REPLY_BUDGET: Duration = Duration::from_secs(10);
+
+    /// A revision this build serves, so a probe carrying it is answered.
+    const SERVED: &str = "2026-07-28";
+
+    /// A revision no build serves, standing in for the next one a client
+    /// adopts before bugwarden does — the reporter's case.
+    const UNSERVED: &str = "2027-01-01";
+
+    /// The narrow pipe [`Session::open_narrow`] serves over: wide enough
+    /// for a whole burst of requests, far too narrow for the answers.
+    const PIPE: usize = 8 * 1024;
+
+    fn test_server() -> BugWarden {
+        let cfg = Arc::new(pinned(&[
+            "bugwarden",
+            "--bugzilla-server",
+            "https://bugzilla.example.invalid",
+            "--transport",
+            "stdio",
+            "--api-key",
+            "test-key",
+        ]));
+        let guard = Arc::new(Guard {
+            policy: Policy::from_toml_str("").expect("the empty policy must parse"),
+        });
+        let bz = Arc::new(bugzilla_client(&cfg).expect("client must build"));
+        BugWarden::new(cfg, guard, bz).expect("server must build")
+    }
+
+    /// The `_meta` a 2026-07-28 client sends, with the two required keys.
+    fn meta(version: &str) -> Value {
+        json!({
+            "io.modelcontextprotocol/protocolVersion": version,
+            "io.modelcontextprotocol/clientCapabilities": {},
+        })
+    }
+
+    fn discover(id: u32, meta: Value) -> Value {
+        json!({ "jsonrpc": "2.0", "id": id, "method": "server/discover",
+                "params": { "_meta": meta } })
+    }
+
+    /// The one frame rmcp answers before `initialize`, and this file's
+    /// filler for pipelining probes against.
+    fn ping(id: u32) -> Value {
+        json!({ "jsonrpc": "2.0", "id": id, "method": "ping" })
+    }
+
+    /// The client end of a served stdio session: raw JSON lines in, raw
+    /// JSON lines out, exactly what a subprocess client writes.
+    struct Session {
+        write: WriteHalf<DuplexStream>,
+        lines: tokio::io::Lines<BufReader<ReadHalf<DuplexStream>>>,
+    }
+
+    impl Session {
+        /// Serve `test_server()` over a duplex pair, wrapped the way `main`
+        /// wraps stdio.
+        fn open() -> Self {
+            Self::serving(true, 256 * 1024)
+        }
+
+        /// The same server with rmcp answering the probe itself: the
+        /// oracle the wrapper is diffed against.
+        fn open_bare() -> Self {
+            Self::serving(false, 256 * 1024)
+        }
+
+        /// A pipe too small for the replies a burst produces, so the
+        /// writes really do park — which is what makes rmcp's `select!`
+        /// cancel a `receive` mid-send.
+        fn open_narrow() -> Self {
+            Self::serving(true, PIPE)
+        }
+
+        fn serving(wrapped: bool, capacity: usize) -> Self {
+            let (theirs, ours) = tokio::io::duplex(capacity);
+            let (read, write) = tokio::io::split(ours);
+            let server = test_server();
+            tokio::spawn(async move {
+                let service = if wrapped {
+                    let transport = DiscoverAnswering::framed(read, write, server.clone());
+                    server.serve(transport).await?
+                } else {
+                    server.serve((read, write)).await?
+                };
+                service.waiting().await?;
+                Ok::<(), anyhow::Error>(())
+            });
+            let (read, write) = tokio::io::split(theirs);
+            Session {
+                write,
+                lines: BufReader::new(read).lines(),
+            }
+        }
+
+        async fn send(&mut self, message: Value) {
+            self.write
+                .write_all(format!("{message}\n").as_bytes())
+                .await
+                .expect("the session must accept input");
+        }
+
+        /// Write every frame in one go, so replies are still being written
+        /// when the next frames land — the contention that makes rmcp's
+        /// `select!` cancel `receive`.
+        async fn burst(&mut self, frames: &[Value]) {
+            let mut buffer = String::new();
+            for frame in frames {
+                buffer.push_str(&format!("{frame}\n"));
+            }
+            self.write
+                .write_all(buffer.as_bytes())
+                .await
+                .expect("the session must accept input");
+        }
+
+        /// The next frame the server wrote, parsed.
+        async fn recv(&mut self) -> Value {
+            let line = tokio::time::timeout(REPLY_BUDGET, self.lines.next_line())
+                .await
+                .expect("the server must answer within the budget")
+                .expect("the session must be readable")
+                .expect("the server must not close before answering");
+            serde_json::from_str(&line).unwrap_or_else(|e| panic!("{line:?}: {e}"))
+        }
+
+        /// Send `message` and read its reply.
+        async fn call(&mut self, message: Value) -> Value {
+            self.send(message).await;
+            self.recv().await
+        }
+
+        /// Handshake at 2025-11-25 and announce it, the legacy lifecycle.
+        async fn initialize(&mut self, id: u32) -> Value {
+            let reply = self
+                .call(json!({
+                    "jsonrpc": "2.0", "id": id, "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": {},
+                        "clientInfo": { "name": "discover-test", "version": "0" },
+                    }
+                }))
+                .await;
+            self.send(json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }))
+                .await;
+            reply
+        }
+    }
+
+    /// The `tools` array of a served listing.
+    fn tools_of(reply: &Value) -> &Vec<Value> {
+        reply["result"]["tools"]
+            .as_array()
+            .unwrap_or_else(|| panic!("a served listing carries a tools array: {reply}"))
+    }
+
+    /// The JSON-RPC error code of a refusal.
+    fn error_code(reply: &Value) -> i64 {
+        reply["error"]["code"]
+            .as_i64()
+            .unwrap_or_else(|| panic!("a refusal carries an error code: {reply}"))
+    }
+
+    /// rmcp's per-request metadata refusal, spelled out rather than read
+    /// off the code under test.
+    const MISSING_META: &str = "request _meta is missing or has malformed required fields: ";
+
+    #[tokio::test]
+    async fn the_reporter_chain_reaches_the_tool_list() {
+        // Issue #267 exactly: a Go SDK client probes with a revision this
+        // build does not serve, is told so, falls back to the legacy
+        // handshake — and used to find every later request refused -32602,
+        // because rmcp had already committed the session to the
+        // handshake-free lifecycle on the probe alone.
+        let mut session = Session::open();
+        let probe = session.call(discover(1, meta(UNSERVED))).await;
+        assert_eq!(error_code(&probe), -32022, "{probe}");
+        let init = session.initialize(2).await;
+        assert_eq!(init["result"]["protocolVersion"], "2025-11-25", "{init}");
+        let listed = session
+            .call(json!({ "jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": {} }))
+            .await;
+        assert!(!tools_of(&listed).is_empty(), "{listed}");
+    }
+
+    #[tokio::test]
+    async fn a_served_probe_then_a_session_reaches_the_tool_list() {
+        // The other half of the same defect, and the commoner one: the
+        // probe SUCCEEDS and the client opens a session anyway. Nothing
+        // about the answer differs; the lifecycle must still be the
+        // session's.
+        let mut session = Session::open();
+        let probe = session.call(discover(1, meta(SERVED))).await;
+        assert!(probe["result"]["supportedVersions"].is_array(), "{probe}");
+        session.initialize(2).await;
+        let listed = session
+            .call(json!({ "jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": {} }))
+            .await;
+        assert!(!tools_of(&listed).is_empty(), "{listed}");
+    }
+
+    #[tokio::test]
+    async fn a_probe_with_no_meta_is_refused_and_the_session_survives() {
+        // On main this frame was answered and then ENDED the process
+        // (`ExpectedInitializeRequest`), so the client's `initialize`
+        // reached a closed pipe. The refusal is unchanged; what changes is
+        // that the session outlives it.
+        let mut session = Session::open();
+        let probe = session
+            .call(
+                json!({ "jsonrpc": "2.0", "id": 1, "method": "server/discover",
+                          "params": {} }),
+            )
+            .await;
+        assert_eq!(error_code(&probe), -32602, "{probe}");
+        assert_eq!(
+            probe["error"]["message"],
+            json!(format!(
+                "{MISSING_META}io.modelcontextprotocol/protocolVersion, \
+                 io.modelcontextprotocol/clientCapabilities"
+            )),
+            "{probe}"
+        );
+        let init = session.initialize(2).await;
+        assert_eq!(init["result"]["protocolVersion"], "2025-11-25", "{init}");
+        let listed = session
+            .call(json!({ "jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": {} }))
+            .await;
+        assert!(!tools_of(&listed).is_empty(), "{listed}");
+    }
+
+    #[tokio::test]
+    async fn a_probe_mid_session_is_answered_and_changes_nothing() {
+        // A probe is not only an opener: a client may re-probe a live
+        // session. The wrapper intercepts that one too, so the answer must
+        // still be the full result and the session must keep serving
+        // `_meta`-free requests afterwards.
+        let mut session = Session::open();
+        session.initialize(1).await;
+        let probe = session.call(discover(2, meta(SERVED))).await;
+        assert_eq!(probe["result"]["resultType"], "complete", "{probe}");
+        let listed = session
+            .call(json!({ "jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": {} }))
+            .await;
+        assert!(!tools_of(&listed).is_empty(), "{listed}");
+    }
+
+    #[tokio::test]
+    async fn a_pipelined_probe_is_answered_under_write_contention() {
+        // The one thing this wrapper does that the inner transport does
+        // not: hold a reply. rmcp polls `receive` as one arm of a
+        // `select!` (rmcp 3.1.4 `service.rs:1395`) and drops the future
+        // whenever another arm wins, so a reply awaited on `receive`'s own
+        // stack dies with the frame that asked for it — consumed, never
+        // answered, the client hung on that id while every other reply
+        // arrives. Every other row here is lock-step, where nothing else
+        // is ever ready and the drop never happens. A session first:
+        // before `initialize` rmcp awaits `receive` outside its `select!`
+        // (`service/server.rs:511`), so a probe-only chain never shows
+        // this either. The whole burst fits `PIPE`, so only the SERVER's
+        // writes park.
+        const FRAMES: u32 = 40;
+        let mut session = Session::open_narrow();
+        session.initialize(1).await;
+        let frames: Vec<Value> = (2..=FRAMES + 1)
+            .map(|id| {
+                if id % 2 == 0 {
+                    discover(id, meta(SERVED))
+                } else {
+                    ping(id)
+                }
+            })
+            .collect();
+        session.burst(&frames).await;
+        let mut answered = std::collections::HashSet::new();
+        for _ in 0..FRAMES {
+            let reply = session.recv().await;
+            answered.insert(
+                reply["id"]
+                    .as_u64()
+                    .unwrap_or_else(|| panic!("every reply names its request: {reply}")),
+            );
+        }
+        let unanswered: Vec<u64> = (2..=u64::from(FRAMES) + 1)
+            .filter(|id| !answered.contains(id))
+            .collect();
+        assert!(unanswered.is_empty(), "unanswered ids: {unanswered:?}");
+    }
+
+    #[tokio::test]
+    async fn the_per_request_lifecycle_is_still_rmcps_to_choose() {
+        // The invariant the fix must not weaken. A probe commits nothing,
+        // so the FIRST `_meta`-carrying request is what puts rmcp on the
+        // handshake-free lifecycle — and rmcp's gate then refuses a
+        // request that drops the `_meta`, exactly as before. A wrapper
+        // that had answered or relaxed anything past discover would serve
+        // the second listing.
+        let mut session = Session::open();
+        let probe = session.call(discover(1, meta(SERVED))).await;
+        assert!(probe["result"]["supportedVersions"].is_array(), "{probe}");
+        let declared = session
+            .call(json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list",
+                          "params": { "_meta": meta(SERVED) } }))
+            .await;
+        assert!(!tools_of(&declared).is_empty(), "{declared}");
+        let bare = session
+            .call(json!({ "jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": {} }))
+            .await;
+        assert_eq!(error_code(&bare), -32602, "{bare}");
+        assert!(
+            bare["error"]["message"]
+                .as_str()
+                .is_some_and(|message| message.starts_with(MISSING_META)),
+            "{bare}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_ping_before_initialize_is_still_answered_by_rmcp() {
+        // The one other frame rmcp accepts before `initialize`. The
+        // wrapper must pass it through, not eat it, and the probe that
+        // follows must still be answered here.
+        let mut session = Session::open();
+        let pong = session.call(ping(1)).await;
+        assert_eq!(pong["result"], json!({}), "{pong}");
+        let probe = session.call(discover(2, meta(SERVED))).await;
+        assert_eq!(probe["result"]["resultType"], "complete", "{probe}");
+        let init = session.initialize(3).await;
+        assert_eq!(init["result"]["protocolVersion"], "2025-11-25", "{init}");
+    }
+
+    #[tokio::test]
+    async fn a_malformed_meta_names_only_the_key_that_is_wrong() {
+        // `missing_required_keys` counts a key present but undecodable as
+        // missing, and the refusal names it. A number where the revision
+        // belongs must not be read as a revision, nor drag the well-formed
+        // capabilities key into the message.
+        let mut session = Session::open();
+        let probe = session
+            .call(discover(
+                1,
+                json!({
+                    "io.modelcontextprotocol/protocolVersion": 7,
+                    "io.modelcontextprotocol/clientCapabilities": {},
+                }),
+            ))
+            .await;
+        assert_eq!(error_code(&probe), -32602, "{probe}");
+        assert_eq!(
+            probe["error"]["message"],
+            json!(format!(
+                "{MISSING_META}io.modelcontextprotocol/protocolVersion"
+            )),
+            "{probe}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_in_session_probe_wrong_two_ways_is_refused_on_the_metadata() {
+        // The one shape whose refusal CODE this fix changes, pinned as a
+        // decision. rmcp's in-session handler checks the declared revision
+        // before the required keys (-32022); its pre-`initialize` path —
+        // the one the wrapper replaces, and the one a probe normally takes
+        // — checks the keys first (-32602). A `_meta` missing a required
+        // key declares no lifecycle worth reading a revision out of, so
+        // the pre-`initialize` order is the one kept on both.
+        let mut session = Session::open();
+        session.initialize(1).await;
+        let probe = session
+            .call(discover(
+                2,
+                json!({ "io.modelcontextprotocol/protocolVersion": UNSERVED }),
+            ))
+            .await;
+        assert_eq!(error_code(&probe), -32602, "{probe}");
+        assert_eq!(
+            probe["error"]["message"],
+            json!(format!(
+                "{MISSING_META}io.modelcontextprotocol/clientCapabilities"
+            )),
+            "{probe}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_answer_is_the_sdk_default_discover_result() {
+        // The parity oracle: the wrapper replaces rmcp's default
+        // `ServerHandler::discover`, so what reaches the wire must be that
+        // default's result, built from this server's own `get_info()` —
+        // serverInfo, instructions, capabilities and the SEP-2549 cache
+        // hints included. Compared whole: a field this wrapper forgot, or
+        // one it added, is exactly how the identity surface drifts.
+        let mut session = Session::open();
+        let probe = session.call(discover(1, meta(SERVED))).await;
+        let expected = serde_json::to_value(DiscoverResult::from_server_info(
+            SUPPORTED_PROTOCOL_VERSIONS.to_vec(),
+            test_server().get_info(),
+        ))
+        .expect("the SDK result must serialize");
+        assert_eq!(probe["result"], expected, "{probe}");
+        assert_eq!(
+            probe["result"]["_meta"]["io.modelcontextprotocol/serverInfo"],
+            json!({ "name": "bugwarden", "version": env!("CARGO_PKG_VERSION") }),
+            "the probe must name this build, and nothing else: {probe}"
+        );
+        // Present whatever revision the probe declares:
+        // `strip_result_type_for_legacy_peer` (rmcp 3.1.4 model.rs) has no
+        // `DiscoverResult` arm, so rmcp never stripped it here either.
+        assert_eq!(probe["result"]["resultType"], "complete", "{probe}");
+    }
+
+    /// The `_meta` shape whose refusal CODE the wrapper moves, named once
+    /// so the differential and its exception cannot drift apart.
+    const UNSERVED_WITHOUT_CAPABILITIES: &str = "an unserved revision, no capabilities";
+
+    /// Every `_meta` shape the differential drives: what a probe carries,
+    /// well formed and not.
+    fn probe_shapes() -> Vec<(&'static str, Value)> {
+        vec![
+            ("both keys, a served revision", meta(SERVED)),
+            ("both keys, a legacy revision", meta("2025-11-25")),
+            ("both keys, the oldest served revision", meta("2024-11-05")),
+            ("both keys, an unserved revision", meta(UNSERVED)),
+            (
+                "the Go SDK shape, clientInfo included",
+                json!({
+                    "io.modelcontextprotocol/protocolVersion": SERVED,
+                    "io.modelcontextprotocol/clientCapabilities": {},
+                    "io.modelcontextprotocol/clientInfo": { "name": "agy", "version": "1.7.0" },
+                }),
+            ),
+            ("an empty _meta", json!({})),
+            (
+                "a served revision, no capabilities",
+                json!({ "io.modelcontextprotocol/protocolVersion": SERVED }),
+            ),
+            (
+                "capabilities, no revision",
+                json!({ "io.modelcontextprotocol/clientCapabilities": {} }),
+            ),
+            (
+                UNSERVED_WITHOUT_CAPABILITIES,
+                json!({ "io.modelcontextprotocol/protocolVersion": UNSERVED }),
+            ),
+            (
+                "a revision that is not a string",
+                json!({
+                    "io.modelcontextprotocol/protocolVersion": 7,
+                    "io.modelcontextprotocol/clientCapabilities": {},
+                }),
+            ),
+            (
+                "capabilities that are not an object",
+                json!({
+                    "io.modelcontextprotocol/protocolVersion": SERVED,
+                    "io.modelcontextprotocol/clientCapabilities": "yes",
+                }),
+            ),
+        ]
+    }
+
+    /// One probe on a session opened for it alone: rmcp ends a bare
+    /// session on the shapes it refuses pre-`initialize`, so no two rows
+    /// may share one.
+    async fn probe_reply(mut session: Session, in_session: bool, meta: Value) -> Value {
+        let id = if in_session {
+            session.initialize(1).await;
+            2
+        } else {
+            1
+        };
+        session.call(discover(id, meta)).await
+    }
+
+    #[tokio::test]
+    async fn the_wrapper_answers_what_rmcp_answered() {
+        // The oracle `the_answer_is_the_sdk_default_discover_result`
+        // cannot be: that one compares the wrapper against the constructor
+        // the wrapper itself calls, so it sees nothing rmcp does BETWEEN
+        // handler and wire (`handler/server.rs:246-259`, the legacy-peer
+        // strip). This serves the same server bare and diffs its
+        // replies over every probe shape, on both paths a probe can take —
+        // so an rmcp bump that changes its default `discover`, or starts
+        // stripping a `DiscoverResult`, fails here.
+        for (name, meta) in probe_shapes() {
+            for in_session in [false, true] {
+                let bare = probe_reply(Session::open_bare(), in_session, meta.clone()).await;
+                let wrapped = probe_reply(Session::open(), in_session, meta.clone()).await;
+                if in_session && name == UNSERVED_WITHOUT_CAPABILITIES {
+                    // The only row that moves, pinned in both directions:
+                    // rmcp's in-session handler checks the declared
+                    // revision before the required keys, the
+                    // pre-`initialize` path the wrapper replaces checks
+                    // the keys first.
+                    assert_eq!(error_code(&bare), -32022, "{name}: {bare}");
+                    assert_eq!(error_code(&wrapped), -32602, "{name}: {wrapped}");
+                    continue;
+                }
+                assert_eq!(bare, wrapped, "{name}, in a session: {in_session}");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn a_legacy_declaration_is_answered_unstripped() {
+        // The other side of that no-op: a pre-2026 revision is a served
+        // one, so the probe is answered — and the answer is byte-identical
+        // to the 2026-07-28 one, `resultType` included.
+        let mut session = Session::open();
+        let legacy = session.call(discover(1, meta("2025-11-25"))).await;
+        let modern = session.call(discover(2, meta(SERVED))).await;
+        assert_eq!(legacy["result"], modern["result"], "{legacy}");
+        assert_eq!(legacy["result"]["resultType"], "complete", "{legacy}");
+    }
+
+    #[tokio::test]
+    async fn the_refusal_lists_exactly_the_revisions_this_build_serves() {
+        // What the Go SDK's retry loop reads to pick its second attempt.
+        // A list narrower than the served set makes a client give up on a
+        // revision that works; a wider one sends it back with a revision
+        // that does not.
+        let mut session = Session::open();
+        let probe = session.call(discover(1, meta(UNSERVED))).await;
+        assert_eq!(error_code(&probe), -32022, "{probe}");
+        assert_eq!(probe["error"]["data"]["requested"], UNSERVED, "{probe}");
+        assert_eq!(
+            probe["error"]["data"]["supported"],
+            serde_json::to_value(SUPPORTED_PROTOCOL_VERSIONS).expect("versions serialize"),
+            "{probe}"
+        );
+    }
+
+    /// A [`Transport`] over queued frames, so the wrapper's own dispatch is
+    /// testable without a service behind it.
+    ///
+    /// [`Transport`]: rmcp::transport::Transport
+    struct Queued {
+        inbound: std::collections::VecDeque<ClientJsonRpcMessage>,
+        sent: Arc<std::sync::Mutex<Vec<ServerJsonRpcMessage>>>,
+        /// Fails every send, standing in for a peer that closed its end.
+        broken: bool,
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("send refused")]
+    struct SendRefused;
+
+    impl rmcp::transport::Transport<RoleServer> for Queued {
+        type Error = SendRefused;
+
+        fn send(
+            &mut self,
+            item: ServerJsonRpcMessage,
+        ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send + 'static {
+            let broken = self.broken;
+            let sent = self.sent.clone();
+            async move {
+                sent.lock().expect("sent lock poisoned").push(item);
+                if broken {
+                    Err(SendRefused)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+
+        async fn receive(&mut self) -> Option<ClientJsonRpcMessage> {
+            self.inbound.pop_front()
+        }
+
+        async fn close(&mut self) -> Result<(), Self::Error> {
+            self.inbound.clear();
+            Ok(())
+        }
+    }
+
+    /// Parse `frames` as inbound client messages and wrap them.
+    fn queued(frames: &[Value], broken: bool) -> DiscoverAnswering<Queued> {
+        let sent = Arc::new(std::sync::Mutex::new(Vec::new()));
+        DiscoverAnswering::new(
+            Queued {
+                inbound: frames
+                    .iter()
+                    .map(|frame| {
+                        serde_json::from_value(frame.clone())
+                            .unwrap_or_else(|e| panic!("{frame}: {e}"))
+                    })
+                    .collect(),
+                sent,
+                broken,
+            },
+            test_server(),
+        )
+    }
+
+    /// What the inner transport was asked to write.
+    fn written(wrapper: &DiscoverAnswering<Queued>) -> Vec<Value> {
+        wrapper
+            .inner
+            .sent
+            .lock()
+            .expect("sent lock poisoned")
+            .iter()
+            .map(|message| serde_json::to_value(message).expect("a reply serializes"))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn every_frame_but_a_discover_request_reaches_rmcp() {
+        // The pass-through half, at the one place it can be observed
+        // directly: a notification, a response, an error and an ordinary
+        // request all come back out of `receive`, and none of them makes
+        // the wrapper write anything.
+        let passed = [
+            json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
+            json!({ "jsonrpc": "2.0", "id": 1, "result": {} }),
+            json!({ "jsonrpc": "2.0", "id": 2, "error": { "code": -1, "message": "no" } }),
+            json!({ "jsonrpc": "2.0", "id": 3, "method": "ping" }),
+            json!({ "jsonrpc": "2.0", "id": 4, "method": "tools/list", "params": {} }),
+        ];
+        let mut wrapper = queued(&passed, false);
+        for frame in &passed {
+            let received = wrapper
+                .receive()
+                .await
+                .unwrap_or_else(|| panic!("{frame} must reach rmcp"));
+            assert_eq!(
+                serde_json::to_value(&received).expect("a frame serializes"),
+                *frame
+            );
+        }
+        assert!(wrapper.receive().await.is_none(), "the queue is drained");
+        assert!(written(&wrapper).is_empty(), "{:?}", written(&wrapper));
+    }
+
+    #[tokio::test]
+    async fn a_discover_is_answered_and_the_next_frame_is_returned() {
+        // The interception half: the probe never leaves `receive`, its
+        // answer is written to the inner transport, and the frame after it
+        // is what rmcp gets — so rmcp learns the lifecycle from THAT one.
+        let ping = json!({ "jsonrpc": "2.0", "id": 2, "method": "ping" });
+        let mut wrapper = queued(&[discover(1, meta(SERVED)), ping.clone()], false);
+        let received = wrapper.receive().await.expect("the ping must come through");
+        assert_eq!(
+            serde_json::to_value(&received).expect("a frame serializes"),
+            ping
+        );
+        let written = written(&wrapper);
+        assert_eq!(written.len(), 1, "{written:?}");
+        assert_eq!(written[0]["id"], json!(1), "{written:?}");
+        assert_eq!(
+            written[0]["result"]["resultType"], "complete",
+            "{written:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_reply_that_cannot_be_written_closes_the_transport() {
+        // A wrapper that ignored the send error would loop on to the next
+        // frame and hand rmcp a session whose peer is already gone, with
+        // the probe silently unanswered. `None` is rmcp's own reading of a
+        // dead transport.
+        let mut wrapper = queued(
+            &[
+                discover(1, meta(SERVED)),
+                json!({ "jsonrpc": "2.0", "id": 2, "method": "ping" }),
+            ],
+            true,
+        );
+        assert!(
+            wrapper.receive().await.is_none(),
+            "a failed reply must close the transport, not skip to the next frame"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_and_close_are_the_inner_transport_s() {
+        // The two delegating methods: `send` must reach the inner
+        // transport (and carry its error back), `close` must reach it too.
+        let mut wrapper = queued(
+            &[json!({ "jsonrpc": "2.0", "id": 1, "method": "ping" })],
+            false,
+        );
+        let pong = ServerJsonRpcMessage::response(
+            rmcp::model::ServerResult::EmptyResult(rmcp::model::EmptyObject {}),
+            rmcp::model::RequestId::Number(1),
+        );
+        wrapper.send(pong).await.expect("the inner send must run");
+        assert_eq!(written(&wrapper).len(), 1);
+        wrapper.close().await.expect("the inner close must run");
+        assert!(
+            wrapper.receive().await.is_none(),
+            "close must reach the inner transport"
+        );
+    }
+
+    #[test]
+    fn a_discover_frame_is_recognised_by_its_method() {
+        // The guard the interception arm turns on, spelled out: rmcp's
+        // deserializer routes `server/discover` to `DiscoverRequest` and
+        // everything else elsewhere, so `matches!` on that variant is a
+        // method test. If a bump renamed the method, this fails here
+        // rather than by every probe silently reaching rmcp again.
+        let frame: ClientJsonRpcMessage =
+            serde_json::from_value(discover(1, meta(SERVED))).expect("the probe must parse");
+        let ClientJsonRpcMessage::Request(request) = frame else {
+            panic!("a probe is a request");
+        };
+        assert!(matches!(request.request, ClientRequest::DiscoverRequest(_)));
+        assert_eq!(request.request.method(), "server/discover");
+    }
+
+    #[test]
+    fn the_wrapper_reads_the_list_the_handler_advertises() {
+        // The wrapper answers from the constant while rmcp's default
+        // handler answers from `supported_protocol_versions()`. They are
+        // the same list today; if they ever diverge the probe and the
+        // handshake would tell a client two different things.
+        assert_eq!(
+            test_server().supported_protocol_versions().as_ref(),
+            SUPPORTED_PROTOCOL_VERSIONS
+        );
+        assert!(SUPPORTED_PROTOCOL_VERSIONS.contains(&ProtocolVersion::V_2026_07_28));
+        assert!(!SUPPORTED_PROTOCOL_VERSIONS
+            .iter()
+            .any(|version| version.as_str() == UNSERVED));
     }
 }

--- a/crates/bugwarden/tests/binary_discover_lifecycle.rs
+++ b/crates/bugwarden/tests/binary_discover_lifecycle.rs
@@ -1,0 +1,390 @@
+//! What a `server/discover` probe does to the SHIPPED BINARY's stdio
+//! session (issue #267).
+//!
+//! Only a process proves this. rmcp reads the stdio lifecycle off the first
+//! frame in `serve_server_with_ct_inner` — code the in-process rows drive
+//! too, but the failure the reporter hit was a *process* one: the probe
+//! stuck a flag on the session's peer, or ended the process outright, and
+//! everything after it was refused -32602 by a binary that looked healthy.
+//! So both chains are driven end to end over real pipes, including the exit
+//! code, which no in-process test observes.
+//!
+//! Coverage contract (each of these must fail a test here):
+//! - the wrapper dropped from `main`, leaving rmcp to answer the probe;
+//! - a probe answered but still committing the lifecycle;
+//! - a probe rmcp refuses ending the process instead of the request.
+
+use std::collections::HashSet;
+use std::process::{ExitStatus, Stdio};
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::process::{Child, ChildStdin};
+
+#[path = "common/scrub_env.rs"]
+mod scrub_env;
+
+/// Bounded so a binary that never answers fails this test rather than
+/// hanging the suite until CI's own timeout kills it.
+const REPLY_BUDGET: Duration = Duration::from_secs(20);
+
+/// A revision no build serves. Stands in for the next one a client adopts
+/// before bugwarden does — the reporter's chain, and the one the Go SDK's
+/// retry loop reads the served list back from.
+const UNSERVED: &str = "2027-01-01";
+
+/// Each binary runs the walker itself, so a single-binary
+/// `cargo test --test binary_discover_lifecycle` still proves what its
+/// scrub claims.
+#[test]
+fn the_scrub_list_covers_every_environment_fallback() {
+    scrub_env::assert_the_scrub_list_covers_every_environment_fallback(
+        scrub_env::AMBIENT_VARS,
+        scrub_env::HTTP_TOKEN_VARS,
+    );
+}
+
+/// A spawned `bugwarden --transport stdio`, driven over its real pipes.
+///
+/// Bugzilla is deliberately unreachable: every frame here is answered
+/// before any upstream call, so the whole exchange happens without a mock.
+struct Server {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: tokio::io::Lines<BufReader<tokio::process::ChildStdout>>,
+}
+
+impl Server {
+    fn spawn() -> Self {
+        Self::spawn_with(Stdio::null())
+    }
+
+    /// The same child with its log kept, for a test that pins what `main`
+    /// said on the way out as well as what it exited with.
+    fn spawn_logged() -> Self {
+        Self::spawn_with(Stdio::piped())
+    }
+
+    fn spawn_with(stderr: Stdio) -> Self {
+        let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_bugwarden"));
+        cmd.args(["--transport", "stdio"])
+            .args(["--bugzilla-server", "https://bugzilla.example.invalid"])
+            .args(["--api-key", "test-key"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(stderr)
+            .kill_on_drop(true);
+        // Scrubbed and NOT set back: an ambient value would change exactly
+        // what is under test.
+        for var in scrub_env::AMBIENT_VARS {
+            cmd.env_remove(var);
+        }
+        let mut child = cmd.spawn().expect("the built binary must start");
+        let stdin = child.stdin.take().expect("stdin is piped");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout is piped")).lines();
+        Server {
+            child,
+            stdin,
+            stdout,
+        }
+    }
+
+    async fn send(&mut self, message: Value) {
+        self.stdin
+            .write_all(format!("{message}\n").as_bytes())
+            .await
+            .expect("the child must accept input");
+    }
+
+    /// The next frame the child wrote to stdout, parsed.
+    async fn recv(&mut self) -> Value {
+        let line = tokio::time::timeout(REPLY_BUDGET, self.stdout.next_line())
+            .await
+            .expect("the child must answer within the budget")
+            .expect("the child's stdout must be readable")
+            .expect("the child must not close stdout before answering");
+        serde_json::from_str(&line).unwrap_or_else(|e| panic!("{line:?}: {e}"))
+    }
+
+    async fn call(&mut self, message: Value) -> Value {
+        self.send(message).await;
+        self.recv().await
+    }
+
+    /// Write every frame in one go, so the child is still writing replies
+    /// when the next frames land — the contention that makes rmcp's
+    /// `select!` cancel a `receive` mid-send.
+    async fn burst(&mut self, frames: &[Value]) {
+        let mut buffer = String::new();
+        for frame in frames {
+            buffer.push_str(&format!("{frame}\n"));
+        }
+        self.stdin
+            .write_all(buffer.as_bytes())
+            .await
+            .expect("the child must accept input");
+    }
+
+    /// Close stdin and wait, yielding the exit status and the child's log
+    /// (empty unless it was spawned with [`Server::spawn_logged`]).
+    async fn finish(self) -> (ExitStatus, String) {
+        drop(self.stdin);
+        let output = tokio::time::timeout(REPLY_BUDGET, self.child.wait_with_output())
+            .await
+            .expect("the child must exit when stdin closes")
+            .expect("the child must be waitable");
+        (
+            output.status,
+            String::from_utf8_lossy(&output.stderr).into_owned(),
+        )
+    }
+
+    /// Close stdin and wait: a clean peer hangup must end the process 0.
+    /// A probe that ended the serve loop early exits 1 here.
+    async fn close(self) {
+        let (status, _) = self.finish().await;
+        assert!(
+            status.success(),
+            "a probe must refuse the request, never the process: {status}"
+        );
+    }
+}
+
+/// The Go SDK v1.7.0 discover frame (`mcp/client.go`): the two required
+/// `_meta` keys plus the client's own identity, which is what makes this
+/// the shape a real client sends rather than a minimal one.
+fn go_sdk_discover(id: u32, version: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0", "id": id, "method": "server/discover",
+        "params": { "_meta": {
+            "io.modelcontextprotocol/protocolVersion": version,
+            "io.modelcontextprotocol/clientCapabilities": {},
+            "io.modelcontextprotocol/clientInfo": { "name": "agy", "version": "1.7.0" },
+        }}
+    })
+}
+
+/// The legacy handshake the Go SDK falls back to when its probe loop gives
+/// up, at the revision it names.
+fn legacy_initialize(id: u32) -> Value {
+    json!({
+        "jsonrpc": "2.0", "id": id, "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": { "name": "agy", "version": "1.7.0" },
+        }
+    })
+}
+
+/// A `tools/list` with no `_meta`, which is every legacy client's listing.
+fn bare_list(id: u32) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "method": "tools/list", "params": {} })
+}
+
+#[tokio::test]
+async fn a_refused_probe_leaves_the_legacy_handshake_intact() {
+    // The reported chain, byte for byte. The probe is refused -32022 with
+    // the served list — that part always worked — and the session the
+    // client then opens must serve its `_meta`-free listing.
+    let mut server = Server::spawn();
+    let probe = server.call(go_sdk_discover(1, UNSERVED)).await;
+    assert_eq!(probe["error"]["code"], json!(-32022), "{probe}");
+    assert_eq!(probe["error"]["data"]["requested"], UNSERVED, "{probe}");
+    assert!(
+        probe["error"]["data"]["supported"]
+            .as_array()
+            .is_some_and(|served| served.contains(&json!("2026-07-28"))),
+        "the refusal must hand back the served list the client retries from: {probe}"
+    );
+
+    let init = server.call(legacy_initialize(2)).await;
+    assert_eq!(init["result"]["protocolVersion"], "2025-11-25", "{init}");
+    server
+        .send(json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }))
+        .await;
+
+    let listed = server.call(bare_list(3)).await;
+    assert!(
+        listed["result"]["tools"]
+            .as_array()
+            .is_some_and(|tools| !tools.is_empty()),
+        "a probed-then-handshook session must be served its tools: {listed}"
+    );
+    server.close().await;
+}
+
+#[tokio::test]
+async fn a_served_probe_leaves_the_legacy_handshake_intact() {
+    // The same chain with a probe this build DOES serve — the commoner
+    // shape, and the one that fails without a client ever seeing an error
+    // before the listing.
+    let mut server = Server::spawn();
+    let probe = server.call(go_sdk_discover(1, "2026-07-28")).await;
+    assert_eq!(
+        probe["result"]["_meta"]["io.modelcontextprotocol/serverInfo"],
+        json!({ "name": "bugwarden", "version": env!("CARGO_PKG_VERSION") }),
+        "the probe must name this build: {probe}"
+    );
+
+    server.call(legacy_initialize(2)).await;
+    server
+        .send(json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }))
+        .await;
+    let listed = server.call(bare_list(3)).await;
+    assert!(
+        listed["result"]["tools"]
+            .as_array()
+            .is_some_and(|tools| !tools.is_empty()),
+        "a served probe must not commit the session either: {listed}"
+    );
+    server.close().await;
+}
+
+#[tokio::test]
+async fn a_probe_with_no_meta_refuses_the_request_not_the_process() {
+    // On main this frame was answered and then ended the process with
+    // `ExpectedInitializeRequest` (exit 1), so the client's `initialize`
+    // read EOF. The refusal text is rmcp's own and unchanged; what the fix
+    // changes is that the session survives it — and that the process still
+    // exits 0 when the peer hangs up for real.
+    let mut server = Server::spawn();
+    let probe = server
+        .call(
+            json!({ "jsonrpc": "2.0", "id": 1, "method": "server/discover",
+                      "params": {} }),
+        )
+        .await;
+    assert_eq!(probe["error"]["code"], json!(-32602), "{probe}");
+    assert_eq!(
+        probe["error"]["message"],
+        json!(
+            "request _meta is missing or has malformed required fields: \
+             io.modelcontextprotocol/protocolVersion, \
+             io.modelcontextprotocol/clientCapabilities"
+        ),
+        "{probe}"
+    );
+
+    let init = server.call(legacy_initialize(2)).await;
+    assert_eq!(init["result"]["protocolVersion"], "2025-11-25", "{init}");
+    server
+        .send(json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }))
+        .await;
+    let listed = server.call(bare_list(3)).await;
+    assert!(
+        listed["result"]["tools"]
+            .as_array()
+            .is_some_and(|tools| !tools.is_empty()),
+        "a malformed probe must not end the session: {listed}"
+    );
+    server.close().await;
+}
+
+#[tokio::test]
+async fn a_probe_still_commits_nothing_that_a_declaring_request_does_not() {
+    // The guard the fix must not weaken, at binary level: rmcp's
+    // per-request lifecycle is still chosen by the first `_meta`-carrying
+    // request, and rmcp's gate still refuses one that drops the `_meta`
+    // afterwards. A wrapper that had relaxed anything past discover serves
+    // the second listing instead.
+    let mut server = Server::spawn();
+    server.call(go_sdk_discover(1, "2026-07-28")).await;
+    let declared = server
+        .call(json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/list",
+            "params": { "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientCapabilities": {},
+            }}
+        }))
+        .await;
+    assert!(
+        declared["result"]["tools"]
+            .as_array()
+            .is_some_and(|tools| !tools.is_empty()),
+        "{declared}"
+    );
+    let bare = server.call(bare_list(3)).await;
+    assert_eq!(
+        bare["error"]["code"],
+        json!(-32602),
+        "the handshake-free lifecycle must still demand per-request _meta: {bare}"
+    );
+    server.close().await;
+}
+
+#[tokio::test]
+async fn a_probe_only_client_hangs_up_cleanly() {
+    // The simplest client there is — probe, read, close — and the one the
+    // wrapper puts on rmcp's least travelled path: the probe never
+    // reaches rmcp, so rmcp is still inside `expect_next_message`'s wait
+    // for a first COMMITTING frame when stdin ends, and calls that
+    // `ConnectionClosed` rather than a clean close
+    // (`service/server.rs:432, 511`). `main` reads it as the hangup it is
+    // — exit 0, as before #267 and as for every other peer that just
+    // leaves — whether the probe was served or refused.
+    for probe in [
+        go_sdk_discover(1, "2026-07-28"),
+        go_sdk_discover(1, UNSERVED),
+        json!({ "jsonrpc": "2.0", "id": 1, "method": "server/discover", "params": {} }),
+    ] {
+        let mut server = Server::spawn_logged();
+        server.call(probe.clone()).await;
+        let (status, log) = server.finish().await;
+        assert!(
+            status.success(),
+            "a probe-only client hung up: {probe}: {status}"
+        );
+        assert!(
+            log.contains("peer hung up after a server/discover probe"),
+            "the hangup must be logged as one: {probe}: {log}"
+        );
+        assert!(
+            !log.contains("serving error"),
+            "a hangup is not a serving failure: {probe}: {log}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_pipelined_probe_is_answered_over_real_pipes() {
+    // A probe behind other traffic, which no lock-step row here reaches:
+    // rmcp polls `receive` as one arm of a `select!` (rmcp 3.1.4
+    // `service.rs:1395`) and drops that future whenever another arm wins,
+    // so a reply the wrapper awaited on `receive`'s own stack would be
+    // dropped with it — the frame consumed, the id never answered, the
+    // client hung on it while every other reply arrives. The listings are
+    // the filler because their replies are far larger than a pipe.
+    const FRAMES: u32 = 40;
+    let mut server = Server::spawn();
+    server.call(legacy_initialize(1)).await;
+    server
+        .send(json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }))
+        .await;
+    let frames: Vec<Value> = (2..=FRAMES + 1)
+        .map(|id| {
+            if id % 2 == 0 {
+                go_sdk_discover(id, "2026-07-28")
+            } else {
+                bare_list(id)
+            }
+        })
+        .collect();
+    server.burst(&frames).await;
+    let mut answered = HashSet::new();
+    for _ in 0..FRAMES {
+        let reply = server.recv().await;
+        answered.insert(
+            reply["id"]
+                .as_u64()
+                .unwrap_or_else(|| panic!("every reply names its request: {reply}")),
+        );
+    }
+    let unanswered: Vec<u64> = (2..=u64::from(FRAMES) + 1)
+        .filter(|id| !answered.contains(id))
+        .collect();
+    assert!(unanswered.is_empty(), "unanswered ids: {unanswered:?}");
+    server.close().await;
+}

--- a/crates/bugwarden/tests/binary_shutdown.rs
+++ b/crates/bugwarden/tests/binary_shutdown.rs
@@ -260,6 +260,33 @@ async fn initialize_and_drain(server: &mut Server) -> tokio::task::JoinHandle<()
     tokio::spawn(async move { while stdout.next_line().await.ok().flatten().is_some() {} })
 }
 
+/// Answer a `server/discover` probe over the child's pipes, then keep
+/// draining its stdout, as [`initialize_and_drain`] does. The probe is
+/// answered by the transport wrapper and commits no lifecycle (#267), so
+/// rmcp is still waiting for a first committing frame afterwards.
+async fn probe_and_drain(server: &mut Server) -> tokio::task::JoinHandle<()> {
+    let stdin = server.stdin.as_mut().expect("stdin is piped");
+    let stdout = server.child.stdout.take().expect("stdout is piped");
+    let mut stdout = BufReader::new(stdout).lines();
+    stdin
+        .write_all(
+            br#"{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}
+"#,
+        )
+        .await
+        .expect("the child must accept the probe");
+    let reply = tokio::time::timeout(EXIT_TIMEOUT, stdout.next_line())
+        .await
+        .expect("the probe must not hang")
+        .expect("stdout must be readable")
+        .expect("the server must answer the probe");
+    assert!(
+        reply.contains("supportedVersions"),
+        "the probe must be answered before the test acts: {reply}"
+    );
+    tokio::spawn(async move { while stdout.next_line().await.ok().flatten().is_some() {} })
+}
+
 /// Write one over-cap frame, delimiter-free, and ignore the write result:
 /// the child refuses partway through and closes the pipe, so the tail of
 /// this write is expected to fail with `BrokenPipe`. Bounded so a build
@@ -370,6 +397,21 @@ async fn stdio_an_over_cap_frame_before_the_handshake_exits_one() {
     write_an_over_cap_frame(&mut server).await;
     server
         .assert_over_cap_exit("stdio pre-handshake over-cap")
+        .await;
+}
+
+#[tokio::test]
+async fn stdio_a_probe_then_an_over_cap_frame_still_exits_one() {
+    // The one exit `main` forgives since #267 is a hangup after a probe,
+    // and only that: an over-cap frame closes the transport exactly the
+    // same way (`receive() -> None`, then rmcp's `ConnectionClosed`), so
+    // a probed session must not turn the refused frame into exit 0.
+    let mut server = spawn_stdio();
+    server.wait_for_stderr(STDIO_READY).await;
+    let _drain = probe_and_drain(&mut server).await;
+    write_an_over_cap_frame(&mut server).await;
+    server
+        .assert_over_cap_exit("stdio probed pre-handshake over-cap")
         .await;
 }
 

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -765,6 +765,75 @@ async fn discover_names_this_build_and_reaches_nothing_else() {
 }
 
 #[tokio::test]
+async fn an_http_probe_never_commits_the_session_lifecycle() {
+    // The transport half of issue #267, pinned on the side that needs no
+    // fix. Over streamable http a discover POST is negotiated on its own
+    // (`serve_negotiated_request_directly` — a POST carrying
+    // `mcp-session-id` goes to its session instead), so a probe — refused
+    // or served — sets no `require_request_metadata` flag on any peer, and
+    // the session a client opens next is an ordinary legacy one. Over stdio
+    // rmcp reads the lifecycle off the first frame instead, which is why
+    // that transport wraps discover (`stdio::DiscoverAnswering`); this
+    // fails if an rmcp bump ever gives http the same behaviour.
+    let mock = MockServer::start().await;
+    let file = key_file("srv-key\n");
+    let cli = http_cli(&mock, Some(file.path()));
+    let addr = serve_http(cli, "", &mock, None).await;
+
+    // A revision this build does not serve, so the probe takes the
+    // refusing arm — the reporter's chain, and the arm that was worst over
+    // stdio, where the flag outlived even the refusal.
+    let refused = mcp_post(addr, None)
+        // rmcp's transport refuses a `_meta` revision the header does not
+        // repeat, and a 2026-07-28+ POST that does not name its method in a
+        // header (both -32020) — so the handler is only reachable with all
+        // three agreeing. That gate is http's alone; stdio has no headers.
+        .header("MCP-Protocol-Version", "2027-01-01")
+        .header("Mcp-Method", "server/discover")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "server/discover",
+            "params": { "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2027-01-01",
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }}
+        }))
+        .send()
+        .await
+        .expect("the probe must reach the server");
+    let body = refused.text().await.expect("a body");
+    let payload: Value = body
+        .lines()
+        .find_map(|line| line.strip_prefix("data: "))
+        .and_then(|data| serde_json::from_str(data).ok())
+        .unwrap_or_else(|| serde_json::from_str(&body).unwrap_or_else(|e| panic!("{body}: {e}")));
+    assert_eq!(payload["error"]["code"], json!(-32022), "{body}");
+
+    // The session the client opens afterwards must serve a `_meta`-free
+    // listing: over stdio this is exactly where the refusal used to appear.
+    let session = raw_initialize(addr, "probing-client").await;
+    let response = mcp_post(addr, Some(&session))
+        .header("MCP-Protocol-Version", "2025-11-25")
+        .json(&json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {} }))
+        .send()
+        .await
+        .expect("the listing request must reach the server");
+    let body = response.text().await.expect("a body");
+    assert!(
+        body.contains("\"bug_info\""),
+        // A named tool, not the `"tools"` key: that key is present even for
+        // an empty listing.
+        "a probed session must still be served its listing: {body}"
+    );
+    assert!(
+        !body.contains("request _meta is missing"),
+        "the probe must not have put this session on the handshake-free \
+         lifecycle: {body}"
+    );
+}
+
+#[tokio::test]
 async fn a_legacy_session_listing_carries_no_cache_hints() {
     // The regression guard for every client alive today, at the only place
     // it is the real thing: the in-process rows serialize what the handler

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1958,12 +1958,15 @@ wired, `server.rs` and `main.rs` are the reference.
   the SDK default of every revision it knows. What that override bounds is
   precisely which **declared** revisions `initialize`, per-request `_meta` and
   `server/discover` may agree to; it does not decide which request *lifecycle*
-  the transport routes to (see the `_meta`-shape trap below). `2026-07-28` is
-  SERVED as of issue #34 stage 2: its handshake-free requests carry the calling
-  client in their own `_meta`, which `client_of` reads, so a record on that path
-  names the caller or names nobody. Adoption ADDED it — `2024-11-05` through
-  `2025-11-25` keep their handshakes and their sessions — so the two lifecycles
-  are served side by side and `DEFAULT_PROTOCOL_VERSION` stays `2025-11-25`.
+  the transport routes to (see the `_meta`-shape trap below). Over stdio since
+  #267 the probe is answered by `DiscoverAnswering`, which reads the constant
+  itself — `the_wrapper_reads_the_list_the_handler_advertises` pins the two
+  equal. `2026-07-28` is SERVED as of issue #34 stage 2: its handshake-free
+  requests carry the calling client in their own `_meta`, which `client_of`
+  reads, so a record on that path names the caller or names nobody. Adoption
+  ADDED it — `2024-11-05` through `2025-11-25` keep their handshakes and their
+  sessions — so the two lifecycles are served side by side and
+  `DEFAULT_PROTOCOL_VERSION` stays `2025-11-25`.
   One consequence worth stating because nothing enforces it: rmcp's
   `KNOWN_VERSIONS` now equals this list, so there is no known-but-unserved
   revision left to test the fallback with, and the negotiation tests use a
@@ -2061,23 +2064,30 @@ wired, `server.rs` and `main.rs` are the reference.
   accessor.** It falls back to `peer_info().client_info` unless
   `peer.request_metadata_required()`, which rmcp 3.1.4 sets on exactly one path
   (`service/server.rs`, the stdio first-message-is-not-`initialize` case) and
-  never over streamable http. So on the http handshake-free path that
-  convenience accessor IS the placeholder, silently. `client_of` therefore
-  reads `ctx.meta.client_info()` directly on the per-request arm and
-  `peer.peer_info()` only on the handshake arm — never the accessor, never the
-  peer on the per-request arm. `ctx.meta.client_info()` decodes
-  all-or-nothing, so a half-declared identity records as nothing at all. Both
-  recorded fields are capped at `PARAM_VALUE_MAX_CHARS`, the audited-parameter
-  cap: per-request sourcing repeats a client-controlled string into every
-  record where the handshake wrote it once per session. Grep misleads here:
+  never over streamable http. Since #267 that stdio path no longer sees a
+  `server/discover`: the transport answers it (`stdio::DiscoverAnswering`,
+  next bullet), so the flag flips only for a first request that itself carries
+  both `_meta` keys — at ANY revision, the pre-2026 shape `lifecycle_of` then
+  refuses included, since `missing_required_keys` (`model/meta.rs:518-530`)
+  never compares the revision declared against the one it validates for. So on
+  the http handshake-free path that convenience accessor IS the placeholder,
+  silently.
+  `client_of` therefore reads `ctx.meta.client_info()` directly on the
+  per-request arm and `peer.peer_info()` only on the handshake arm — never the
+  accessor, never the peer on the per-request arm. `ctx.meta.client_info()`
+  decodes all-or-nothing, so a half-declared identity records as nothing at
+  all. Both recorded fields are capped at `PARAM_VALUE_MAX_CHARS`, the
+  audited-parameter cap: per-request sourcing repeats a client-controlled
+  string into every record where the handshake wrote it once per session.
+  Grep misleads here:
   `message_has_per_request_protocol_version` tests presence alone, and inside
   the stateless arm that presence does pick a route — but nothing it decides
   gets a request INTO that arm; everywhere else it only feeds header
-  validation. `server/discover` is never answered from a session: only
-  `serve_negotiated_request_directly` serves it, and it refuses every shape
-  but a `_meta` carrying both keys at a revision this build serves. It answers
-  `get_info` only and reaches no tool, guard or router. General rule: **no
-  `_meta` key and no `Mcp-*` header may carry a security decision** — like
+  validation. Over http `server/discover` is never answered from a session:
+  only `serve_negotiated_request_directly` serves it, and it refuses every
+  shape but a `_meta` carrying both keys at a revision this build serves. It
+  answers `get_info` only and reaches no tool, guard or router. General rule:
+  **no `_meta` key and no `Mcp-*` header may carry a security decision** — like
   `KNOWN_VERSIONS`, they are the SDK's vocabulary, not this build's contract.
   Two more things to re-check on an rmcp bump, both load-bearing for the
   handshake arm: that a POST naming `2026-07-28` in the `MCP-Protocol-Version`
@@ -2087,7 +2097,73 @@ wired, `server.rs` and `main.rs` are the reference.
   never handshook — and that `request_metadata_required()` is still set on no
   http path. The first has a test
   (`a_header_only_2026_declaration_is_refused_by_the_transport`); the second
-  does not, and is why `client_of` never uses the convenience accessor.
+  has one for the discover POST only
+  (`an_http_probe_never_commits_the_session_lifecycle`, #267) and none for the
+  served per-request POST, which is why `client_of` never uses the convenience
+  accessor.
+- **rmcp trap — over stdio, `server/discover` CHOOSES the lifecycle before it is
+  answered.** `serve_server_with_ct_inner` (rmcp 3.1.4
+  `service/server.rs:510-577`) reads the session's lifecycle off the first
+  non-`ping` frame: anything that is not `initialize` is taken as a commitment
+  to the handshake-free one, and `Peer::require_request_metadata()` (`:562`) is
+  called BEFORE the handler answers. That flag is a sticky `AtomicBool` — no
+  later `initialize` clears it (a later `initialize` succeeds and stores peer
+  info, `handler/server.rs:323`, leaving it set), and both it and its reader are
+  `pub(crate)`, so nothing in this build can reset it.
+  `handler/server.rs:78-100` then refuses every subsequent request but
+  `initialize` that carries no `_meta` with -32602. A probe is exactly such a
+  frame, so a client that discovers and then opens an ordinary session found
+  every call refused (#267): the reporter's Antigravity/Go SDK 1.7 chain
+  (`mcp/client.go`: probe, retry on -32022 with a served revision, then legacy
+  `initialize`) broke on ANY probe, served or refused. Worse, a probe rmcp
+  itself refuses — no `_meta` at all — ended the PROCESS with
+  `ExpectedInitializeRequest` after answering, logging the whole frame on the
+  way out (#261). Upstream `main` still does all of this as of 2026-09-04
+  (`server.rs:616`); rmcp 3.2 is unvetted. **Decision:** a probe is a probe
+  and must not pick a lifecycle, so over stdio it is answered by the transport
+  ([`DiscoverAnswering`](../crates/bugwarden/src/stdio.rs), wrapped in `main`)
+  and never reaches rmcp's picker. rmcp's first frame is then the first one that
+  IS a commitment — `initialize` for a session, or a `_meta`-carrying request
+  that sets the flag exactly as before. Every other frame passes through
+  untouched, `ping` before `initialize` and the over-cap `None` from
+  `BoundedLines` included — though a probe no longer moves rmcp past its
+  pre-`initialize` loop, so a `ping` after one is answered `{}` there instead of
+  refused -32601 by the per-request handler (`handler/server.rs:112-118`), where
+  a probe used to leave it. The answer is QUEUED on the wrapper and driven by
+  the next `receive`, never awaited inside one: rmcp polls `receive` as one arm
+  of a `select!` (`service.rs:1395`) and drops that future whenever another arm
+  wins, so an inline await loses the reply — and the probe with it — to any
+  pipelined client (`a_pipelined_probe_is_answered_under_write_contention` and
+  its binary twin; the inner transport survives the same cancellation only
+  because it keeps its partial line in `line_buf`). **Deliberately unchanged:**
+  the answer is rmcp's own default `discover` result, byte for byte —
+  `the_wrapper_answers_what_rmcp_answered` serves the same server bare and diffs
+  its replies over eleven `_meta` shapes on both paths, so an rmcp bump that
+  changes its default `discover`, or anything it does between handler and wire
+  (`handler/server.rs:246-259`), fails there. `resultType` is NOT stripped for a
+  legacy declaration because `strip_result_type_for_legacy_peer`
+  (`model.rs:4596`) has no `DiscoverResult` arm; no audit record, no guard, no
+  router, as before; and rmcp keeps sole ownership of the per-request gate, so a
+  `_meta`-free request on a handshake-free session is still refused. One refusal
+  CODE moves: a MID-SESSION probe whose `_meta` is wrong two ways (an unserved
+  revision AND a missing required key) now draws rmcp's -32602 instead of its
+  -32022, because the wrapper keeps the pre-`initialize` order — keys first — on
+  both paths; a `_meta` missing a required key declares no lifecycle worth
+  reading a revision out of. And a probe rmcp refuses now refuses the REQUEST
+  only: the session survives it. What every probe does move is where a hangup
+  lands — rmcp is still waiting for its first committing frame, so a probe-only
+  client's EOF returns `ServerInitializeError::ConnectionClosed` from `serve`
+  where it used to return a live session. `main` reads that as the peer hangup
+  it is and exits 0, as before #267, but only where
+  `DiscoverAnswering::answered` says a probe was answered AND the frame cap is
+  untripped: an over-cap frame closes the transport the same way and stays a
+  failure exit (`stdio_a_probe_then_an_over_cap_frame_still_exits_one`). Every
+  other `ConnectionClosed` still exits 1, and
+  `a_probe_only_client_hangs_up_cleanly` pins the code and the log line. HTTP
+  needs none of this and gets none: `serve_negotiated_request_directly` answers
+  a discover per POST and sets no flag, which
+  `an_http_probe_never_commits_the_session_lifecycle` pins so an rmcp bump that
+  changed it fails loudly.
 - **rmcp trap — `mcp-session-id` is a validated header on only one of the two
   routes.** In rmcp 3.1.4 the session branch of `handle_post`
   (`transport/streamable_http_server/tower.rs`) checks the header against
@@ -2140,8 +2216,9 @@ wired, `server.rs` and `main.rs` are the reference.
   about peers because in rmcp 3.1.4 `DiscoverResult` (`model.rs`) declares
   `ttl_ms: u64` and `cache_scope: CacheScope` as non-`Option` fields with no
   `skip_serializing_if`, hard-coded to `0`/`Private` by both constructors,
-  and this build keeps rmcp's default `server/discover` — so a legacy peer
-  naming 2025-11-25 gets the pair from *that* surface today, whatever
+  and this build serves rmcp's default `server/discover` result on both
+  transports (over stdio from the transport wrapper, #267 above) — so a legacy
+  peer naming 2025-11-25 gets the pair from *that* surface today, whatever
   `tools/list` does. Since stage 2 the served branch is reachable end to end —
   a 2026-07-28 request, or a session that negotiated it — and is tested over
   real streamable HTTP as well as in-process. The in-process rows are still the


### PR DESCRIPTION
Closes #267.

rmcp 3.1.4 reads a stdio session's lifecycle off the first non-`ping` frame: anything but `initialize` — a `server/discover` probe included — calls the sticky, `pub(crate)` `Peer::require_request_metadata()` before the handler answers, and nothing clears it. So a client that probes and then opens an ordinary session (the Go SDK v1.7.0 loop Antigravity uses, after a `-32022` or on a revision below 2026-07-28) gets `-32602` on every `_meta`-free call; a probe rmcp refuses outright ended the process. Reproduced on `main`, not only on 0.5.0; upstream `main` and the `rmcp-v3.2.0` tag still do the same.

Fix: a stdio transport wrapper (`stdio::DiscoverAnswering`) answers `server/discover` itself — rmcp's own default result, byte for byte, in rmcp's own refusal order — and passes every other frame through, so rmcp's first frame is the first one that is a commitment. The reply is queued on the wrapper rather than awaited inside `receive`, which rmcp polls as one `select!` arm and cancels freely. `main` treats a probe-only client's hangup as the clean close it is (exit 0, as before) unless the frame cap tripped. HTTP is untouched and now pinned.

Tests: 17 in-process (`stdio::discover`, including a differential that serves the same server bare and diffs eleven `_meta` shapes, and a pipelined-probe contention case), 5 binary-level stdio (`binary_discover_lifecycle.rs`: the reporter's frames, no-`_meta` probe, probe-then-EOF, probe-then-over-cap), 1 HTTP pin. cargo-mutants over the new code: 0 survivors (the five `main.rs` misses are pre-existing startup code, #269).

Adversarially reviewed before opening (protocol/rmcp internals, invariants/audit, test adequacy with reverts and mutants, prose): 2 must (the `receive` cancel-safety, which the first cut got wrong; the probe-only exit code), 4 should, 9 nits — all folded and re-verified.