### PR TITLE
test(main): pin main.rs's three startup sites

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -20,8 +20,9 @@ concurrency:
 
 jobs:
   mutants:
-    # cargo-mutants over the guard policy engine, weekly and NON-GATING. It
-    # does not replace the hand-run discipline (#203), it catches lapses in it.
+    # cargo-mutants over the guard policy engine and the binary's startup
+    # wiring (the scope below), weekly and NON-GATING. It does not replace the
+    # hand-run discipline (#203), it catches lapses in it.
     #
     # NEVER a required status check; do not add it to branch protection. A run
     # is hours and its timeouts need a human who knows what the suite is meant
@@ -44,10 +45,13 @@ jobs:
     # the timeout floor holds.
     runs-on: ubuntu-latest
     # Measured at 30-46s of incremental build plus 6-23s of tests per mutant on
-    # a 32-core box; call it ~3 min on a 4-core runner, so a 31-mutant shard is
-    # ~95 min plus setup. Doubled for margin -- a shard that outruns this has
-    # itself become the finding. Unsharded, guard.rs would flirt with GitHub's
-    # 360-minute ceiling.
+    # a 32-core box -- main.rs's nine averaged 43s there, inside that band, so
+    # the startup scope costs no more per mutant than the guard one. Call it
+    # ~3 min on a 4-core runner, so a 34-mutant shard is ~102 min plus setup.
+    # Doubled for margin -- a shard that outruns this has itself become the
+    # finding. Unsharded the scope below does not fit at all: 134 x 3 min is
+    # 402, past GitHub's 360-minute ceiling, so the shards are load-bearing
+    # rather than a convenience.
     timeout-minutes: 240
     strategy:
       # A survivor in one shard must not cancel the rest: the run's value is
@@ -60,10 +64,16 @@ jobs:
     env:
       # Scope lives here, not in .cargo/mutants.toml, because it is a CI budget
       # decision and not a property of the tree: a hand-run must stay free to
-      # point anywhere. The workspace holds ~1130 mutants and server.rs alone
-      # 377; guard.rs is 125 and is where the DESIGN.md invariants live. Grow
-      # this by adding shards, not by dropping the filter.
-      MUTANTS_SCOPE: crates/bugwarden-core/src/guard.rs
+      # point anywhere. The workspace holds ~1180 mutants and server.rs alone
+      # 400; guard.rs is 125 and is where the DESIGN.md invariants live, and
+      # main.rs is 9 -- the startup wiring (the I9 --read-only tightening, the
+      # audit sink selection) that only a spawned process executes, so no
+      # in-process suite reaches it. Its five survivors came out of a hand run
+      # (#269); this job saw none of them, because until now its scope was
+      # guard.rs alone. 134 together, so ~34 a shard. Space-separated, one
+      # --file each below. Grow this by adding shards, not by dropping the
+      # filter.
+      MUTANTS_SCOPE: crates/bugwarden-core/src/guard.rs crates/bugwarden/src/main.rs
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -107,10 +117,18 @@ jobs:
           MUTANTS_SHARDS: ${{ strategy.job-total }}
         run: |
           set -euo pipefail
+          # One --file per path in MUTANTS_SCOPE: cargo-mutants takes the flag
+          # repeatedly and unions the files, and the shard split then runs over
+          # the combined list.
+          read -r -a scope <<< "${MUTANTS_SCOPE}"
+          files=()
+          for path in "${scope[@]}"; do
+            files+=(--file "${path}")
+          done
           rc=0
           cargo mutants --no-shuffle \
             --shard "${MUTANTS_SHARD}/${MUTANTS_SHARDS}" \
-            --file "${MUTANTS_SCOPE}" || rc=$?
+            "${files[@]}" || rc=$?
           count() {
             if [ -f "mutants.out/$1.txt" ]; then wc -l < "mutants.out/$1.txt"; else echo 0; fi
           }

--- a/crates/bugwarden/tests/binary_startup_policy.rs
+++ b/crates/bugwarden/tests/binary_startup_policy.rs
@@ -1,0 +1,440 @@
+//! What `main`'s startup wiring does, driven through the SHIPPED BINARY
+//! (issue #269).
+//!
+//! Three sites in `main.rs` run in a spawned process and nowhere else: the
+//! I9 tightening `policy.global.read_only |= cli.read_only`, the arm that
+//! loads the operator's `--audit-config` document for a file-bearing sink
+//! selection, and the "auditing is OFF" warning. Every in-process suite
+//! hands `BugWarden::new` a `Policy` it built itself and attaches its
+//! audit state afterwards through `with_audit`, so none of them executes
+//! a line of this — which is why a mutation run left all three bare.
+//!
+//! Coverage contract (each of these mutations must fail a test here):
+//! - `|=` at the tightening site becoming `^=`, which makes `--read-only`
+//!   CLEAR a policy that already said `read_only = true`;
+//! - the same `|=` becoming `&=`, which makes `--read-only` never tighten
+//!   a policy that said `false` — and makes a policy that said `true`
+//!   depend on the flag to mean anything at all;
+//! - the `FileOnly | Both` arm deleted, which silently substitutes
+//!   `AuditConfig::fileless()` for the operator's document and writes no
+//!   audit file at all;
+//! - the warning condition's `==` becoming `!=` or its `&&` becoming
+//!   `||`, either of which fires the warning in the wrong deployments.
+//!
+//! Bugzilla is deliberately unreachable everywhere here: the default
+//! policy consults no identity, so the preflight makes no request, and
+//! every frame these tests send is answered before any upstream call.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use bugwarden::server::WRITE_TOOLS;
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+
+#[path = "common/scrub_env.rs"]
+mod scrub_env;
+
+#[path = "common/startup_line.rs"]
+mod startup_line;
+
+/// Bounded so a binary that never answers fails this test rather than
+/// hanging the suite until CI's own timeout kills it. The same budget
+/// `binary_user_agent` and `binary_discover_lifecycle` give a child.
+const REPLY_BUDGET: Duration = Duration::from_secs(20);
+
+/// The needle both transports' readiness lines start with — the http one
+/// continues with the bound address, the stdio one with `stdio`. Every
+/// line this file reads stderr for is logged BEFORE it, so matching it is
+/// proof that the startup sequence ran past the site under test.
+const STARTUP_READY: &str = "Starting Bugzilla MCP server on ";
+
+/// Enough of the warning at `main.rs:192` to identify it and no more: the
+/// rest of the text names the two ways to configure a sink and would tie
+/// this file to that wording.
+const NO_AUDIT_WARNING: &str = "auditing is OFF";
+
+/// Each binary runs the walker itself, so a single-binary
+/// `cargo test --test binary_startup_policy` still proves what its scrub
+/// claims.
+#[test]
+fn the_scrub_list_covers_every_environment_fallback() {
+    scrub_env::assert_the_scrub_list_covers_every_environment_fallback(
+        scrub_env::AMBIENT_VARS,
+        scrub_env::HTTP_TOKEN_VARS,
+    );
+}
+
+/// The shipped binary, spawned with every environment fallback scrubbed
+/// and NOT set back: an ambient value would change exactly what is under
+/// test. `RUST_LOG` goes with them, so the stderr assertions read the
+/// lines at the level `main` falls back to.
+fn command(args: &[&str]) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_bugwarden"));
+    cmd.args(args).kill_on_drop(true);
+    for var in scrub_env::AMBIENT_VARS {
+        cmd.env_remove(var);
+    }
+    cmd
+}
+
+/// A spawned `bugwarden --transport stdio`, driven over its real pipes.
+struct Server {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: tokio::io::Lines<BufReader<tokio::process::ChildStdout>>,
+}
+
+impl Server {
+    /// `args` are appended to the stdio transport, the unreachable
+    /// Bugzilla server and the startup key every case here shares.
+    fn spawn(args: &[&str]) -> Self {
+        let mut cmd = command(&[
+            "--transport",
+            "stdio",
+            "--bugzilla-server",
+            "https://bugzilla.example.invalid",
+            "--api-key",
+            "test-key",
+        ]);
+        cmd.args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        let mut child = cmd.spawn().expect("the built binary must start");
+        let stdin = child.stdin.take().expect("stdin is piped");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout is piped")).lines();
+        Server {
+            child,
+            stdin,
+            stdout,
+        }
+    }
+
+    async fn send(&mut self, message: Value) {
+        self.stdin
+            .write_all(format!("{message}\n").as_bytes())
+            .await
+            .expect("the child must accept input");
+    }
+
+    /// The next frame the child wrote to stdout, parsed.
+    async fn call(&mut self, message: Value) -> Value {
+        self.send(message).await;
+        let line = tokio::time::timeout(REPLY_BUDGET, self.stdout.next_line())
+            .await
+            .expect("the child must answer within the budget")
+            .expect("the child's stdout must be readable")
+            .expect("the child must not close stdout before answering");
+        serde_json::from_str(&line).unwrap_or_else(|e| panic!("{line:?}: {e}"))
+    }
+
+    /// Complete the MCP handshake, so the session may be served.
+    async fn handshake(&mut self) {
+        let init = self
+            .call(json!({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": { "name": "binary-startup-policy-test", "version": "0" }
+                }
+            }))
+            .await;
+        assert_eq!(init["result"]["protocolVersion"], "2025-11-25", "{init}");
+        self.send(json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }))
+            .await;
+    }
+
+    /// Close stdin and wait for a clean exit, so a child is never left
+    /// behind holding the tempdir a test is about to drop.
+    async fn close(mut self) {
+        drop(self.stdin);
+        let status = tokio::time::timeout(REPLY_BUDGET, self.child.wait())
+            .await
+            .expect("the child must exit when stdin closes")
+            .expect("the child must be waitable");
+        assert_eq!(
+            status.code(),
+            Some(0),
+            "a peer hangup must end the process cleanly: {status}"
+        );
+    }
+}
+
+/// A guard policy that says `read_only = <read_only>` and nothing else,
+/// written where a spawned child can read it.
+///
+/// `dir` is the caller's own `tempfile::tempdir()`, never a shared path:
+/// libtest runs these cases on parallel threads, and a fixed name would
+/// have two of them truncating and rewriting one file while a third child
+/// reads it.
+fn policy_file(dir: &Path, read_only: bool) -> PathBuf {
+    let path = dir.join(format!("policy-read-only-{read_only}.toml"));
+    std::fs::write(&path, format!("[global]\nread_only = {read_only}\n"))
+        .expect("the policy file must be writable");
+    path
+}
+
+/// The tool names a spawned binary lists under `policy`, with
+/// `--read-only` passed or not.
+async fn listed_tools(policy: &Path, read_only_flag: bool) -> BTreeSet<String> {
+    let policy = policy.to_str().expect("utf-8 path");
+    let mut args = vec!["--policy", policy];
+    if read_only_flag {
+        args.push("--read-only");
+    }
+    let mut server = Server::spawn(&args);
+    server.handshake().await;
+    let listed = server
+        .call(json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {} }))
+        .await;
+    let tools: BTreeSet<String> = listed["result"]["tools"]
+        .as_array()
+        .unwrap_or_else(|| panic!("a served listing carries an array of tools: {listed}"))
+        .iter()
+        .map(|tool| {
+            tool["name"]
+                .as_str()
+                .unwrap_or_else(|| panic!("every listed tool is named: {listed}"))
+                .to_owned()
+        })
+        .collect();
+    server.close().await;
+    tools
+}
+
+/// A restricted listing is exactly the `loosened` one minus
+/// [`WRITE_TOOLS`] — asserted in both directions, so neither an empty
+/// listing nor one that lost a read tool can pass for a delisting.
+///
+/// `loosened` is a deployment that restricts nothing, and its only job is
+/// to prove the write-tool names exist to be removed; it is not a
+/// one-variable control for every caller (see the `^=` test).
+fn assert_delisted(restricted: &BTreeSet<String>, loosened: &BTreeSet<String>, what: &str) {
+    for name in WRITE_TOOLS {
+        assert!(
+            loosened.contains(*name),
+            "{what}: {name} must be listed by a deployment that restricts \
+             nothing, or its absence under one proves nothing: {loosened:?}"
+        );
+        assert!(
+            !restricted.contains(*name),
+            "{what}: {name} must be removed from the listing (I13): {restricted:?}"
+        );
+    }
+    let expected: BTreeSet<String> = loosened
+        .iter()
+        .filter(|name| !WRITE_TOOLS.contains(&name.as_str()))
+        .cloned()
+        .collect();
+    assert!(
+        !expected.is_empty(),
+        "{what}: the read tools must survive the restriction, \
+         or the assertion below passes on an empty listing"
+    );
+    assert_eq!(
+        *restricted, expected,
+        "{what}: read-only removes the write tools and nothing else"
+    );
+}
+
+#[tokio::test]
+async fn the_flag_over_a_read_only_policy_keeps_the_write_tools_delisted() {
+    // `^=` at the tightening site: `true ^ true` is false, so the flag an
+    // operator passes for belt and braces would RE-ENABLE every write tool
+    // the policy file had already forbidden — the one direction I9 rules
+    // out.
+    //
+    // The policy is checked restrictive on its own first, because the kill
+    // rests on it: were `Policy::load` to ignore `read_only = true`, the
+    // mutated `false ^ true` would still restrict and the mutant would
+    // live. Nothing else pins that at binary level.
+    //
+    // This pair has no one-variable control. (true, no flag) is itself
+    // restricted, so the listing that still carries the write tools has to
+    // come from a deployment that restricts nothing — it proves the names
+    // exist to be removed and no more. The flag is varied alone in the
+    // `&=` test below.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let restrictive = policy_file(dir.path(), true);
+    let policy_alone = listed_tools(&restrictive, false).await;
+    let with_the_flag = listed_tools(&restrictive, true).await;
+    let loosened = listed_tools(&policy_file(dir.path(), false), false).await;
+    assert_delisted(&policy_alone, &loosened, "policy true, no flag");
+    assert_delisted(&with_the_flag, &loosened, "policy true + --read-only");
+}
+
+#[tokio::test]
+async fn the_flag_tightens_a_policy_that_says_read_only_false() {
+    // `&=` at the same site: `false & true` is false, so the flag would
+    // never tighten anything a policy had not already tightened. One
+    // policy file, spawned twice — the flag is the only thing that varies,
+    // which is what makes this pair differential.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let policy = policy_file(dir.path(), false);
+    let restricted = listed_tools(&policy, true).await;
+    let loosened = listed_tools(&policy, false).await;
+    assert_delisted(&restricted, &loosened, "policy false + --read-only");
+}
+
+#[tokio::test]
+async fn a_file_bearing_selection_writes_the_operator_s_audit_file() {
+    // `--audit-config` with no OTLP endpoint is `SinkSelection::FileOnly`,
+    // the selection whose arm the mutation deletes; without it the match
+    // falls to `AuditConfig::fileless()`, whose `path` is `None`, and the
+    // sink writes nowhere. `path` is the setting this test observes — the
+    // file appearing where the operator's document put it, and holding the
+    // records of the session that ran, is what the arm buys.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let audit_path = dir.path().join("startup-policy-audit.jsonl");
+    let config_path = dir.path().join("audit.toml");
+    std::fs::write(
+        &config_path,
+        format!("path = {:?}\n", audit_path.to_str().expect("utf-8 path")),
+    )
+    .expect("write the audit config");
+
+    let mut server = Server::spawn(&["--audit-config", config_path.to_str().expect("utf-8 path")]);
+    server.handshake().await;
+    // Served from the server's own state, so the whole exchange happens
+    // without a Bugzilla request; the record is written before the reply.
+    let info = server
+        .call(json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": { "name": "mcp_server_info", "arguments": {} }
+        }))
+        .await;
+    assert_eq!(info["result"]["isError"], json!(false), "{info}");
+    server.close().await;
+
+    let written = std::fs::read_to_string(&audit_path).unwrap_or_else(|e| {
+        panic!(
+            "the operator's audit file must exist at {}: {e}",
+            audit_path.display()
+        )
+    });
+    let records: Vec<Value> = written
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap_or_else(|e| panic!("{line:?}: {e}")))
+        .collect();
+    assert!(
+        records.iter().any(|r| r["event"] == "initialize"),
+        "the session's handshake must be recorded: {written}"
+    );
+    let served = records
+        .iter()
+        .filter(|r| r["event"] == "tool_call" && r["request"]["tool"] == "mcp_server_info")
+        .count();
+    assert_eq!(
+        served, 1,
+        "the served call must reach the operator's file exactly once (I15): {written}"
+    );
+}
+
+/// Everything the shipped binary logged on its way to [`STARTUP_READY`].
+///
+/// The warning under test is emitted while the audit sinks are wired,
+/// which both transports do before they announce readiness, so a log that
+/// reaches the readiness line and does not carry the warning is proof the
+/// warning did not fire.
+async fn startup_log(args: &[&str]) -> String {
+    let mut cmd = command(args);
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("the built binary must start");
+    // Not the barrier: `main` logs the readiness line before `serve` reads
+    // a byte, so this reader gets its line either way. Held so the child is
+    // still running when `kill()` reaps it — on EOF a stdio child leaves
+    // through `ConnectionClosed("initialize request")` and exit 1, which
+    // is a noisier teardown than this test has any reason to produce.
+    let _stdin = child.stdin.take().expect("stdin is piped");
+    let mut lines = startup_line::stderr_lines(&mut child);
+    let mut log = String::new();
+    startup_line::wait_for_line(&mut lines, &mut log, STARTUP_READY, REPLY_BUDGET).await;
+    let _ = child.kill().await;
+    log
+}
+
+/// An audit configuration document naming a file under `dir`.
+fn audit_config_in(dir: &Path) -> PathBuf {
+    let path = dir.join("audit.toml");
+    std::fs::write(
+        &path,
+        format!(
+            "path = {:?}\n",
+            dir.join("audit.jsonl").to_str().expect("utf-8 path")
+        ),
+    )
+    .expect("write the audit config");
+    path
+}
+
+#[tokio::test]
+async fn http_without_a_sink_warns_that_auditing_is_off() {
+    // `==` → `!=` at the warning condition silences exactly this case:
+    // the only deployment that serves remote clients with no audit trail.
+    let log = startup_log(&[
+        "--bugzilla-server",
+        "https://bugzilla.example.invalid",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--insecure-no-auth",
+    ])
+    .await;
+    assert!(
+        log.contains(NO_AUDIT_WARNING),
+        "an unaudited http start must say so: {log}"
+    );
+}
+
+#[tokio::test]
+async fn http_with_an_audit_file_does_not_warn() {
+    // `&&` → `||` fires the warning here, on a deployment that HAS the
+    // file the warning tells the operator to configure.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = audit_config_in(dir.path());
+    let log = startup_log(&[
+        "--bugzilla-server",
+        "https://bugzilla.example.invalid",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "0",
+        "--insecure-no-auth",
+        "--audit-config",
+        config.to_str().expect("utf-8 path"),
+    ])
+    .await;
+    assert!(
+        !log.contains(NO_AUDIT_WARNING),
+        "an audited http start must not warn: {log}"
+    );
+}
+
+#[tokio::test]
+async fn stdio_without_a_sink_does_not_warn() {
+    // The other half of `&&` → `||`, and the reason the condition names
+    // the transport at all: an unaudited stdio session is the ordinary
+    // desktop deployment, whose operator owns the process.
+    let log = startup_log(&[
+        "--transport",
+        "stdio",
+        "--bugzilla-server",
+        "https://bugzilla.example.invalid",
+        "--api-key",
+        "test-key",
+    ])
+    .await;
+    assert!(
+        !log.contains(NO_AUDIT_WARNING),
+        "a local stdio session is not the deployment this warns about: {log}"
+    );
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3337,6 +3337,36 @@ wired, `server.rs` and `main.rs` are the reference.
   post-handshake case exits `0`, which is what rmcp's silent close makes of
   it. The needle is bugwarden's line, not rmcp's `Error reading from
   stream`, so an SDK reword cannot pass for the bound.
+- Startup-wiring tests (crates/bugwarden/tests/binary_startup_policy.rs,
+  the SHIPPED BINARY): the three `main.rs` sites only a process executes,
+  which is why a hand mutation run found all three bare (#269). The I9
+  tightening `policy.global.read_only |= cli.read_only` is driven from
+  both sides. A `read_only = true` policy delists the write tools on its
+  own AND still does with `--read-only` on top, `^=` there RE-ENABLING
+  exactly the writes that policy forbade; the first of those two is not
+  decoration, since it is the only thing at binary level pinning that
+  `Policy::load` honours the field, and were the field ignored the
+  mutant's `false ^ true` would restrict and survive. That pair has no
+  one-variable control — (true, no flag) is already restricted, so the
+  listing that still carries the write tools has to come from a
+  deployment restricting nothing, and it proves only that the names exist
+  to be removed. `read_only = false` plus the flag delists them too
+  (`&=` never tightens), and there one policy file spawned twice makes
+  the flag the only thing that varies. Every restricted listing is
+  asserted EQUAL to the loosened one minus `WRITE_TOOLS`, so an empty
+  listing, or one that lost a read tool, fails as well.
+  `--audit-config` with no OTLP endpoint is the `FileOnly` arm: the
+  operator's file appears where the document's `path` put it and holds
+  the `initialize` record and EXACTLY ONE record for the served
+  `mcp_server_info` call (I15 through the shipped binary), where deleting
+  the arm substitutes `AuditConfig::fileless()` and writes nowhere.
+  `path` is the setting this test observes, not the only one a healthy
+  sink would show. The "auditing is OFF" warning is read off stderr in
+  all three deployments — http with no sink warns, http with the file
+  does not, stdio with no sink does not — which is what makes both its
+  `==` and its `&&` load-bearing. Each log is read only as far as the
+  startup line, which `main` logs after the warning on both transports,
+  so a log without it is proof and not a race.
 - Unit tests (#[cfg(test)] in crates/bugwarden/src/stdio.rs) at a 16-byte
   cap, for what the binary test cannot reach: a frame of exactly the cap is
   accepted both whole and split across chunks (`<=`, and the split half is


### PR DESCRIPTION
Closes #269.

## What

Tests only, plus the mutants workflow's scope. No production code changes; `main.rs` is byte-identical to `main`.

A cargo-mutants run over `main.rs` had left five survivors in startup code only a spawned process executes: the I9 `--read-only` tightening (`|=` → `^=` would make the flag CLEAR a policy that already says `read_only = true`; `|=` → `&=` would discard a `read_only = true` policy unless the operator also passed the flag), the arm that loads the operator's `--audit-config` document (deleted, the file is silently ignored and nothing is written), and the "auditing is OFF" warning condition.

`binary_startup_policy.rs` drives the shipped binary for all three: a `read_only = true` policy delists the write tools on its own and with the flag on top, a `read_only = false` policy plus the flag delists them, every restricted listing asserted equal to the loosened one minus `WRITE_TOOLS`; `--audit-config` writes the operator's file holding the `initialize` record and exactly one `mcp_server_info` record; the warning read off stderr in all three deployments, up to the startup line `main` logs after it. Each of the five mutants was hand-applied and is caught by the targeted test in under a second. A full run over `main.rs`: 9 mutants, 8 caught, 1 unviable, 0 missed.

The second commit adds `main.rs` to the scheduled mutants job's scope (134 mutants over the existing four shards, 34/34/33/33, inside the unchanged budget) and refreshes the stale counts in its comments. The issue's "36 mutants" figure was the earlier stdio.rs + main.rs run; `main.rs` alone holds 9.

## Review before opening

Three parallel refutation-lens reviews over the uncommitted diff (security MERGE-SAFE, correctness MERGE-SAFE, docs NOT MERGE-SAFE on one prose claim), then one fold pass:

- **Must-fix (docs, also correctness):** the sentence "each pair differs in one thing" was true of the `&=` control and copied onto the `^=` one, whose two spawns differ in both the field and the flag. Rewritten as fact, and the missing binary-level assertion added: a `read_only = true` policy restricts WITHOUT the flag. Nothing pinned that before, and the `^=` kill silently depended on it. That assertion also catches `&=` for the worse defect above.
- **Should-fix:** the workflow's first comment still said "over the guard policy engine"; the stdin-holding rationale was false (the readiness line is logged before `serve` reads a byte); two tests truncated-and-rewrote the same fixed-name policy file on parallel threads, benign only because an empty document is the default policy. All corrected; every test now uses its own `tempfile` dir.
- **Nits:** 134 × 3 min exceeds the 360-minute ceiling rather than "flirting" with it; "hid from every other run" reworded; the rotation overclaim dropped; `with_audit` named instead of `new`; the audit-record check tightened from `any` to exactly one (I15 through the shipped binary).
- Verified sound by the lenses: every number in the workflow comments recomputed from `cargo mutants --list`; the shell split expands to two `--file` flags and unions to 134; child cleanup and port handling; scrub coverage; I12 on the audit path with the test's own frames; README's four `--read-only` claims agree with the tests.

Out of scope, tracked: a reviewer copy's seeded target dir keeps the other checkout's `CARGO_BIN_EXE` path (process note, in memory).
