### PR TITLE
fix(server): cap and escape fields at the sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ Command-line arguments take precedence over environment variables.
 | — | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | — | Logs-specific endpoint. Overrides `OTEL_EXPORTER_OTLP_ENDPOINT` per the OTLP spec, and is used **as given** — write the whole URL including `/v1/logs`. Set alone it still turns export on |
 | — | `OTEL_EXPORTER_OTLP_LOGS_HEADERS` | — | Logs-specific headers; overrides `OTEL_EXPORTER_OTLP_HEADERS`. Same secrecy rules |
 | — | `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL` | — | Logs-specific protocol; overrides `OTEL_EXPORTER_OTLP_PROTOCOL`. Same single accepted value |
-| — | `RUST_LOG` | `info` | Tracing filter for the diagnostic log, which always goes to **stderr** — stdout belongs to the stdio transport. An unparsable value falls back to `info` |
+| — | `RUST_LOG` | `info` | Tracing filter for the diagnostic log, which always goes to **stderr** — stdout belongs to the stdio transport. An unparsable value falls back to `info`. Whatever the filter, every FIELD of every line — the MCP library's own included — is cut at 1024 characters and has ESC, BEL, BS, FF, DEL and U+0080–U+009F escaped, so no single client string can fill the terminal or open an escape sequence in it. Two limits worth knowing: the bound is per field per line and says nothing about how many lines a client can cause, and LF, CR and TAB are not in that set (issue #275) |
 
 An empty value counts as unset for `--api-key`, `--api-key-file`,
 `--allowed-hosts`, `BUGWARDEN_HTTP_TOKEN` and `BUGWARDEN_HTTP_READ_TOKEN`, so

--- a/crates/bugwarden/src/lib.rs
+++ b/crates/bugwarden/src/lib.rs
@@ -15,6 +15,7 @@ pub mod http_session;
 pub mod otel;
 pub mod server;
 pub mod stdio;
+pub mod tracing_fields;
 
 #[cfg(test)]
 mod testlog;

--- a/crates/bugwarden/src/main.rs
+++ b/crates/bugwarden/src/main.rs
@@ -17,6 +17,7 @@ use bugwarden::http_auth::{self, HttpEnv};
 use bugwarden::http_session::AuditedSessionManager;
 use bugwarden::otel::{self, OtelEnv, Pipeline};
 use bugwarden::stdio::DiscoverAnswering;
+use bugwarden::tracing_fields::CappedFields;
 use bugwarden::{config, server};
 use bugwarden_core::{guard::Guard, policy::Policy};
 use clap::Parser;
@@ -44,10 +45,16 @@ async fn main() -> anyhow::Result<()> {
     // Tracing always goes to stderr: stdout belongs to the stdio transport.
     // The OTLP layer, when export is on, sits beside the stderr one under
     // the same filter, so both carry the same events.
+    //
+    // `fmt_fields` is the bound on what a client can put there (#260,
+    // #266): every field of every line, ours and rmcp's alike, is cut at
+    // 1024 chars and has ESC, BEL, BS, FF, DEL and the C1 range escaped,
+    // whatever this filter says.
     let registry = tracing_subscriber::registry()
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
         .with(
             tracing_subscriber::fmt::layer()
+                .fmt_fields(CappedFields)
                 .with_writer(std::io::stderr)
                 .with_ansi(false),
         );

--- a/crates/bugwarden/src/otel.rs
+++ b/crates/bugwarden/src/otel.rs
@@ -66,6 +66,7 @@ use tracing_subscriber::layer::Context as LayerContext;
 use tracing_subscriber::Layer;
 
 use crate::audit::{AuditEvent, AuditEventKind, AuditExport, ExportRefused};
+use crate::tracing_fields::CappedWriter;
 
 /// Collector base URL; `LOGS_PATH` is appended to it. Unset or empty —
 /// with [`LOGS_ENDPOINT_VAR`] unset or empty too — turns the whole feature
@@ -1216,8 +1217,17 @@ pub struct DiagnosticsLayer {
     slot: Arc<OnceLock<Arc<Pipeline>>>,
 }
 
-/// Collects an event's fields into the body text, message first, the way
-/// the stderr formatter renders them.
+/// Collects an event's fields into the body text, message first, close to
+/// the way the stderr formatter renders them — close, because a `&str`
+/// field is written here unquoted, where `DefaultVisitor` would
+/// `Debug`-quote it. That predates #260 and is not what it changed.
+///
+/// Every value goes through a [`CappedWriter`], for the reason the stderr
+/// layer's own formatter does (#260, #266): the collector is the same
+/// operator's stream, reached by the same rmcp lines, and a bound the
+/// terminal has that the collector lacks is not a bound. So a body field
+/// is at most [`crate::tracing_fields::PARAM_VALUE_MAX_CHARS`] characters
+/// and carries no raw ESC, BEL, BS, FF, DEL or C1 byte.
 ///
 /// It also picks the `log.target` field out rather than rendering it. The
 /// `log` crate's records reach a `tracing` subscriber through
@@ -1227,7 +1237,9 @@ pub struct DiagnosticsLayer {
 /// to read it, or every `reqwest` and `hyper` line sails past a check that
 /// only ever sees `"log"`. Its `log.module_path`/`log.file`/`log.line`
 /// siblings are dropped for the same reason the stderr formatter drops
-/// them: they are bridge bookkeeping, not what the event said.
+/// them: they are bridge bookkeeping, not what the event said. The target
+/// is neither capped nor escaped: it is the emitting module's own static
+/// name, and it rides an attribute rather than the body.
 struct BodyVisitor {
     message: String,
     fields: String,
@@ -1244,6 +1256,20 @@ fn is_log_bridge_field(name: &str) -> bool {
     )
 }
 
+impl BodyVisitor {
+    /// Open a field's slot: the separator and `name=` go in raw — a field
+    /// name is static text of ours or of a dependency's — and the value
+    /// that follows is written through the budget.
+    fn open_field(&mut self, name: &str) -> CappedWriter<'_, String> {
+        if !self.fields.is_empty() {
+            self.fields.push(' ');
+        }
+        self.fields.push_str(name);
+        self.fields.push('=');
+        CappedWriter::new(&mut self.fields)
+    }
+}
+
 impl tracing::field::Visit for BodyVisitor {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn fmt::Debug) {
         use std::fmt::Write as _;
@@ -1255,14 +1281,9 @@ impl tracing::field::Visit for BodyVisitor {
             return;
         }
         if field.name() == "message" {
-            let _ = write!(self.message, "{value:?}");
+            let _ = write!(CappedWriter::new(&mut self.message), "{value:?}");
         } else {
-            let _ = write!(
-                self.fields,
-                "{}{}={value:?}",
-                if self.fields.is_empty() { "" } else { " " },
-                field.name()
-            );
+            let _ = write!(self.open_field(field.name()), "{value:?}");
         }
     }
 
@@ -1276,14 +1297,9 @@ impl tracing::field::Visit for BodyVisitor {
             return;
         }
         if field.name() == "message" {
-            self.message.push_str(value);
+            let _ = CappedWriter::new(&mut self.message).write_str(value);
         } else {
-            let _ = write!(
-                self.fields,
-                "{}{}={value}",
-                if self.fields.is_empty() { "" } else { " " },
-                field.name()
-            );
+            let _ = self.open_field(field.name()).write_str(value);
         }
     }
 }

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -35,6 +35,7 @@ use crate::audit::{self, AuditCell, AuditState, FailMode, TransportKind, Verdict
 use crate::config::{Cli, KeyCustody, Transport};
 use crate::http_auth::{self, Scope};
 use crate::stdio::BoundedLines;
+use crate::tracing_fields::PARAM_VALUE_MAX_CHARS;
 
 /// The MCP revisions this build actually implements, newest last.
 ///
@@ -329,10 +330,11 @@ const PARAM_ALLOWLIST: &[&str] = &[
     "version",
 ];
 
-/// Cap on recorded string values AND on object key names; see
-/// [`PARAM_ALLOWLIST`]. Also on every tracing field that formats a client
-/// string ([`Capped`], #240).
-const PARAM_VALUE_MAX_CHARS: usize = 1024;
+// The cap on recorded string values AND on object key names (see
+// `PARAM_ALLOWLIST`) is `PARAM_VALUE_MAX_CHARS`, imported above. It moved
+// to `tracing_fields` in #260, where the same constant bounds every field
+// of every tracing line at the sink: one number rather than two that have
+// to agree.
 
 /// Reserved key under which one recorded object holds its over-cap and
 /// reserved-name keys; see [`recorded_object`].
@@ -389,6 +391,15 @@ fn capped(value: &str) -> String {
 /// SILENTLY, no marker, exactly as the record's own cut does. [`capped`]
 /// delegates here, so there is one cut to remember (#191); the unit
 /// tests pin both at the boundary.
+///
+/// [`crate::tracing_fields`] now cuts every field of every line at the
+/// same bound, this one included, which MASKS these wrappers on stderr:
+/// `%Capped(&p.query)` and `%p.query` render the same bytes once the sink
+/// cuts at the same constant, so `binary_tracing_caps` measures the sink
+/// and no longer this. They stay anyway. [`capped`] delegates here and IS
+/// the record's cut, which `audit_wiremock` measures; `bug_ids` needs a
+/// count-plus-head SHAPE no sink can synthesise from a rendered value;
+/// and a second bound in front of the first costs a wrapper.
 struct Capped<'a>(&'a str);
 
 impl<'a> Capped<'a> {

--- a/crates/bugwarden/src/tracing_fields.rs
+++ b/crates/bugwarden/src/tracing_fields.rs
@@ -1,0 +1,584 @@
+//! The diagnostic stream's bound, applied at the SINK: every field of
+//! every tracing line is cut at [`PARAM_VALUE_MAX_CHARS`] characters and
+//! rewritten wherever it carries one of the control bytes
+//! tracing-subscriber escapes in `message` (#260, #266). That set is ESC,
+//! BEL, BS, FF, DEL and the C1 range, and no more: LF, CR and TAB pass
+//! through, which is #275's subject rather than this module's.
+//!
+//! bugwarden caps the client strings it logs at the CALL SITE
+//! (`server::Capped`), which bounds its own lines and nothing else. rmcp
+//! writes to the same stderr and into the same OTLP diagnostics stream,
+//! and bounds nothing: `service.rs:1342` logs the whole `initialize`
+//! parameters (`?peer_info`), `:1597` every client notification whole,
+//! `:1585` a JSON-RPC request id raw on every error reply (`%id`), and
+//! `service/server.rs:477` the declared protocol version raw. Raise the
+//! level and `service.rs:1535` adds the whole of every request at debug
+//! and `:1438` the whole of every loop event at trace. A cap that lives
+//! at a call site reaches none of them, and a
+//! level filter that hides them is undone by the next `RUST_LOG` an
+//! operator sets — so the bound goes where every line passes instead:
+//! the field formatter `main` gives the stderr layer, and the visitor
+//! `otel` builds the exported body with.
+//!
+//! Escaping is the other half (#266). tracing-subscriber 0.3's
+//! `DefaultVisitor` sanitizes `message` and `record_error` only, and a
+//! `%`-formatted value is a tracing-core `DisplayValue` recorded through
+//! `record_debug`, whose `Debug` hands straight to its `Display` — so it
+//! reaches the terminal verbatim, and a `query` of ESC `[2J` clears the
+//! operator's screen while ESC `]0;` … BEL retitles it. [`CappedWriter`]
+//! escapes the bytes `EscapeGuard` does, for every field.
+//!
+//! Parity with `DefaultFields` is a requirement, not a courtesy: a value
+//! under the cap carrying no control bytes must render byte for byte as
+//! it does today, because the operator's own greps and this workspace's
+//! `binary_tracing_caps` needles read those lines. The unit tests below
+//! render the same events through both and compare.
+
+use std::fmt;
+use std::fmt::Write as _;
+
+use tracing::field::{Field, Visit};
+use tracing_subscriber::field::RecordFields;
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::FormatFields;
+
+/// The one bound every client-chosen string in this process answers to:
+/// 1024 characters.
+///
+/// It is the audit record's cap — on an allowlisted parameter value, on a
+/// recorded object key, on the tool name and on the JSON-RPC request id,
+/// where `server.rs` reads it — and, since #260, the per-field cap of
+/// every diagnostic line as well. One constant because a bound the record
+/// enforces and the log undoes is not a bound, and because a second
+/// number would have to be remembered next to this one.
+pub const PARAM_VALUE_MAX_CHARS: usize = 1024;
+
+/// A [`fmt::Write`] that bounds and sanitizes one field's value.
+///
+/// It passes characters through until [`PARAM_VALUE_MAX_CHARS`] of them
+/// have been written and then swallows the rest, silently and with no
+/// marker — the same cut `server::Capped` and the audit record make, so a
+/// field written through `%Capped(..)` and the same text written raw stop
+/// at the same character. The budget counts the characters handed TO the
+/// adapter, across however many `write_str` calls a `fmt::Arguments`
+/// arrives in, so a value assembled in pieces is cut at the total. It
+/// allocates nothing.
+///
+/// The budget covers the RENDERED value, decoration included: the adapter
+/// sees a stream of characters and cannot know which of them the client
+/// wrote. So a `Debug`-shaped field spends part of its budget on its own
+/// `Some("` and loses the closing `")` to the cut, and an `?Capped` field
+/// carries that much less of the client's text than the `%Capped` one
+/// beside it. For the same reason an OPERATOR's own value — a config
+/// path, say — is cut like anyone else's; 1018 characters is legible for
+/// any real path, and a bound with an exception for trusted values is a
+/// bound with a hole. A strict tightening either way, and the price of a
+/// cut that does not depend on the site knowing it exists.
+///
+/// Control bytes are escaped on the way through, in the rendering
+/// tracing-subscriber 0.3's own `EscapeGuard` uses for `message`: ESC,
+/// BEL, BS, FF and DEL become `\x1b`-style text and the C1 range
+/// `\u{80}`–`\u{9f}` becomes `\u{..}`. `EscapeGuard` is private to
+/// tracing-subscriber, so this is a copy of its byte set rather than a
+/// reuse, and a unit test below pins the rendering byte-equal to what
+/// `DefaultFields` produces for the same bytes in `message`. The escaping
+/// is UNCONDITIONAL — it does not consult
+/// `Writer::sanitizes_ansi_escapes`, whose `false` setting exists so that
+/// TRUSTED sequences in logged values pass through unchanged, which is
+/// exactly the channel a client must never inherit.
+pub struct CappedWriter<'a, W: fmt::Write> {
+    inner: &'a mut W,
+    remaining: usize,
+}
+
+impl<'a, W: fmt::Write> CappedWriter<'a, W> {
+    /// A budget of [`PARAM_VALUE_MAX_CHARS`] characters into `inner`.
+    pub fn new(inner: &'a mut W) -> Self {
+        Self {
+            inner,
+            remaining: PARAM_VALUE_MAX_CHARS,
+        }
+    }
+}
+
+impl<W: fmt::Write> fmt::Write for CappedWriter<'_, W> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for ch in s.chars() {
+            if self.remaining == 0 {
+                return Ok(());
+            }
+            self.remaining -= 1;
+            match ch {
+                // The C0 bytes a terminal reads as the start of, or part
+                // of, a control sequence.
+                '\x1b' => self.inner.write_str("\\x1b")?,
+                '\x07' => self.inner.write_str("\\x07")?,
+                '\x08' => self.inner.write_str("\\x08")?,
+                '\x0c' => self.inner.write_str("\\x0c")?,
+                '\x7f' => self.inner.write_str("\\x7f")?,
+                // C1: the 8-bit forms of the same sequences.
+                '\u{80}'..='\u{9f}' => write!(self.inner, "\\u{{{:x}}}", ch as u32)?,
+                _ => self.inner.write_char(ch)?,
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The stderr layer's field formatter: `DefaultFields`' rendering with
+/// every value written through a [`CappedWriter`].
+///
+/// Installed by `main` with `fmt::layer().fmt_fields(..)`, so it formats
+/// the fields of every event and of every span, whatever the target,
+/// level or `RUST_LOG` — which is the whole point, since the lines this
+/// exists for are rmcp's rather than ours.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CappedFields;
+
+impl<'writer> FormatFields<'writer> for CappedFields {
+    fn format_fields<R: RecordFields>(&self, writer: Writer<'writer>, fields: R) -> fmt::Result {
+        let mut visitor = CappedVisitor {
+            writer,
+            is_empty: true,
+            result: Ok(()),
+        };
+        fields.record(&mut visitor);
+        visitor.result
+    }
+}
+
+/// [`CappedFields`]' visitor, a transcription of tracing-subscriber
+/// 0.3's `DefaultVisitor` whose one intended change is that the value
+/// goes through a [`CappedWriter`] and the field NAME does not — a name
+/// is static text of ours or of a dependency's, never the client's.
+///
+/// Transcribed rather than wrapped because `DefaultVisitor` writes
+/// straight to its own `Writer` and exposes no seam. That transcription
+/// carries one limit: `Writer`'s `italic()`/`dimmed()` are private to
+/// tracing-subscriber, so names and separators are written unstyled.
+/// bugwarden installs this layer with `with_ansi(false)`, where
+/// `DefaultVisitor` writes them unstyled too, so the two agree byte for
+/// byte in the only configuration this binary builds.
+struct CappedVisitor<'a> {
+    writer: Writer<'a>,
+    is_empty: bool,
+    result: fmt::Result,
+}
+
+impl CappedVisitor<'_> {
+    /// The single space that separates two fields.
+    fn maybe_pad(&mut self) {
+        if self.is_empty {
+            self.is_empty = false;
+        } else {
+            self.result = self.writer.write_char(' ');
+        }
+    }
+
+    /// One field's value, bounded and sanitized.
+    fn write_value(&mut self, value: &dyn fmt::Debug) -> fmt::Result {
+        write!(CappedWriter::new(&mut self.writer), "{value:?}")
+    }
+}
+
+impl Visit for CappedVisitor<'_> {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if self.result.is_err() {
+            return;
+        }
+        // `message` prints bare and every other string prints quoted, so
+        // the two reach `record_debug` as different kinds of value.
+        if field.name() == "message" {
+            self.record_debug(field, &format_args!("{value}"));
+        } else {
+            self.record_debug(field, &value);
+        }
+    }
+
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        // The error's own text, then its chain under a `<name>.sources`
+        // pseudo-field — `DefaultVisitor`'s shape, and the raw field name
+        // in the label as it uses it, `r#` prefix and all.
+        match value.source() {
+            Some(source) => self.record_debug(
+                field,
+                &format_args!("{value} {}.sources={}", field.name(), ErrorSources(source)),
+            ),
+            None => self.record_debug(field, &format_args!("{value}")),
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if self.result.is_err() {
+            return;
+        }
+        let name = field.name();
+        // `tracing-log`'s bridge hangs a `log` record's real target,
+        // module path, file and line on the event as `log.*` fields, and
+        // `DefaultVisitor` drops them behind the same feature that
+        // installs the bridge — so where they exist, the skip does too.
+        // `otel::BodyVisitor` still reads `log.target`, because the
+        // export has to know the target the metadata no longer carries.
+        if name.starts_with("log.") {
+            return;
+        }
+        self.maybe_pad();
+        self.result = match name {
+            "message" => self.write_value(value),
+            // A raw identifier's field name keeps its `r#` in the
+            // metadata and loses it on the line.
+            name => {
+                let key = name.strip_prefix("r#").unwrap_or(name);
+                self.writer
+                    .write_str(key)
+                    .and_then(|()| self.writer.write_char('='))
+                    .and_then(|()| self.write_value(value))
+            }
+        };
+    }
+}
+
+/// An error's SOURCE chain as `DefaultVisitor` renders one: `[its
+/// source, that source's own source, …]`, each entry a `Display` text
+/// unquoted. The error itself is printed before the list, not in it.
+struct ErrorSources<'a>(&'a (dyn std::error::Error + 'static));
+
+impl fmt::Display for ErrorSources<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut list = f.debug_list();
+        let mut current = Some(self.0);
+        while let Some(error) = current {
+            list.entry(&Unquoted(error));
+            current = error.source();
+        }
+        list.finish()
+    }
+}
+
+/// One entry of an [`ErrorSources`] list: `Debug` that prints `Display`,
+/// so `debug_list` does not quote what is already prose.
+struct Unquoted<'a>(&'a (dyn std::error::Error + 'static));
+
+impl fmt::Debug for Unquoted<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.0, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use tracing_subscriber::fmt::format::DefaultFields;
+    use tracing_subscriber::layer::{Context, SubscriberExt as _};
+    use tracing_subscriber::Layer;
+
+    use super::*;
+
+    /// ESC, the byte a terminal reads as the start of a control sequence.
+    const ESC: char = '\x1b';
+
+    /// One event's fields rendered by both formatters.
+    #[derive(Clone, Debug, Default)]
+    struct Rendered {
+        default: String,
+        capped: String,
+    }
+
+    /// A layer that renders every event through `DefaultFields` and
+    /// through [`CappedFields`], into one `Writer` configuration.
+    ///
+    /// The differential runs inside one `on_event` on purpose: both
+    /// formatters see the SAME `ValueSet`, so a difference cannot come
+    /// from the two runs having recorded different values, and no
+    /// timestamp or level prefix has to be normalized away.
+    ///
+    /// `Writer::new` builds the configuration this binary installs — no
+    /// ANSI, sanitization on — so the comparison is the one that matters
+    /// rather than a convenient one.
+    struct Differential(Arc<Mutex<Vec<Rendered>>>);
+
+    impl<S: tracing::Subscriber> Layer<S> for Differential {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            let mut rendered = Rendered::default();
+            DefaultFields::new()
+                .format_fields(Writer::new(&mut rendered.default), event)
+                .expect("a String never fails to be written");
+            CappedFields
+                .format_fields(Writer::new(&mut rendered.capped), event)
+                .expect("a String never fails to be written");
+            self.0.lock().expect("the render lock").push(rendered);
+        }
+    }
+
+    /// Render everything `emit` logs through both formatters.
+    ///
+    /// `with_default` and not a global subscriber: these tests share a
+    /// process with `testlog`, which installs one of its own.
+    fn render(emit: impl FnOnce()) -> Vec<Rendered> {
+        let out: Arc<Mutex<Vec<Rendered>>> = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(Differential(out.clone()));
+        tracing::subscriber::with_default(subscriber, emit);
+        let rendered = out.lock().expect("the render lock").clone();
+        assert!(!rendered.is_empty(), "the differential saw no events");
+        rendered
+    }
+
+    /// The one event `emit` logs, rendered through both formatters.
+    fn render_one(emit: impl FnOnce()) -> Rendered {
+        let mut rendered = render(emit);
+        assert_eq!(rendered.len(), 1, "exactly one event: {rendered:?}");
+        rendered.remove(0)
+    }
+
+    /// The adapter's budget is the whole point: over-cap text stops at
+    /// exactly the cap, on a character boundary, and short text is
+    /// untouched.
+    #[test]
+    fn the_budget_cuts_at_exactly_the_cap_on_a_char_boundary() {
+        for chars in [0, 1, PARAM_VALUE_MAX_CHARS - 1, PARAM_VALUE_MAX_CHARS] {
+            let mut out = String::new();
+            // Multi-byte: an ASCII probe cannot tell a char budget from a
+            // byte one.
+            write!(CappedWriter::new(&mut out), "{}", "é".repeat(chars))
+                .expect("a String never fails to be written");
+            assert_eq!(out, "é".repeat(chars), "under the cap nothing moves");
+        }
+        let mut out = String::new();
+        write!(
+            CappedWriter::new(&mut out),
+            "{}",
+            "é".repeat(PARAM_VALUE_MAX_CHARS * 4)
+        )
+        .expect("a String never fails to be written");
+        assert_eq!(
+            out,
+            "é".repeat(PARAM_VALUE_MAX_CHARS),
+            "over the cap the cut is exact and lands between characters"
+        );
+    }
+
+    /// A `fmt::Arguments` reaches the adapter in as many `write_str`
+    /// calls as it has pieces, and the budget is the total across them.
+    #[test]
+    fn a_value_written_in_pieces_is_cut_at_the_char_total() {
+        let piece = "é".repeat(PARAM_VALUE_MAX_CHARS / 2);
+        let mut out = String::new();
+        write!(CappedWriter::new(&mut out), "{piece}{piece}{piece}{piece}")
+            .expect("a String never fails to be written");
+        assert_eq!(out, "é".repeat(PARAM_VALUE_MAX_CHARS));
+
+        // And the writes past the budget are swallowed rather than
+        // failing, so the fields after this one still render.
+        let mut writer = CappedWriter::new(&mut out);
+        writer
+            .write_str(&"z".repeat(PARAM_VALUE_MAX_CHARS * 2))
+            .expect("an exhausted budget swallows, it does not error");
+        writer
+            .write_str("z")
+            .expect("an exhausted budget swallows, it does not error");
+        assert_eq!(
+            out.chars().filter(|c| *c == 'z').count(),
+            PARAM_VALUE_MAX_CHARS,
+            "a second value gets its own budget and no more"
+        );
+    }
+
+    /// Every control byte `EscapeGuard` rewrites, rendered exactly as
+    /// tracing-subscriber renders it in `message` — the property that
+    /// makes this a copy of that byte set rather than an approximation.
+    #[test]
+    fn the_escaping_matches_what_default_fields_does_to_a_message() {
+        let probe: String = ['\x1b', '\x07', '\x08', '\x0c', '\x7f']
+            .into_iter()
+            .chain(('\u{80}'..='\u{9f}').chain(['a', 'é', '\n', '\t', '"', '\\']))
+            .collect();
+        // `DefaultFields` escapes `message` and `record_error` and
+        // nothing else, so `message` is where the two renderings can be
+        // compared directly.
+        let rendered = render_one(|| tracing::info!("{probe}"));
+        assert_eq!(rendered.capped, rendered.default);
+        assert!(
+            rendered.capped.contains("\\x1b") && rendered.capped.contains("\\u{9b}"),
+            "and it really escaped something: {:?}",
+            rendered.capped
+        );
+
+        // The same bytes in a `%` field, which `DefaultFields` leaves
+        // raw: ours is the escaped rendering of the message, prefixed by
+        // the field's name.
+        let escaped = rendered.capped.clone();
+        let field = render_one(|| tracing::info!(probe = %probe));
+        assert_eq!(field.capped, format!("probe={escaped}"));
+        assert!(
+            field.default.contains(ESC),
+            "the raw ESC this exists to stop must still be in what \
+             `DefaultFields` writes: {:?}",
+            field.default
+        );
+    }
+
+    /// Parity: a value under the cap with no control bytes renders byte
+    /// for byte as it does today, for every shape a field arrives in.
+    #[test]
+    fn every_field_shape_renders_exactly_as_default_fields_renders_it() {
+        #[derive(Debug)]
+        struct Inner;
+
+        impl std::fmt::Display for Inner {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("the inner cause")
+            }
+        }
+
+        impl std::error::Error for Inner {}
+
+        #[derive(Debug)]
+        struct Outer(Inner);
+
+        impl std::fmt::Display for Outer {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("the outer failure")
+            }
+        }
+
+        impl std::error::Error for Outer {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        let text = "a plain value";
+        let owned = String::from("owned text");
+        let lone: &(dyn std::error::Error + 'static) = &Inner;
+        let chained: &(dyn std::error::Error + 'static) = &Outer(Inner);
+        let rendered = render(|| {
+            tracing::info!("a message alone");
+            tracing::info!(display = %text, "message and fields");
+            tracing::info!(debug = ?text, quoted = text, owned = owned.as_str());
+            tracing::info!(count = 7u64, signed = -7i64, ratio = 0.5, flag = true);
+            tracing::info!(r#type = "raw identifier", nested = ?vec![1, 2, 3]);
+            // A field whose NAME really carries the `r#`: the raw
+            // identifier above does not — the macro stringifies it to
+            // `type` — and only a literal name reaches the visitor with
+            // the prefix `DefaultVisitor` strips.
+            tracing::info!("r#type" = "a literal raw name");
+            tracing::error!(error = lone, "an error without a source");
+            tracing::error!(error = chained, "an error with a source");
+            // The bridge's own fields, which neither formatter renders.
+            tracing::info!(
+                log.target = "reqwest::connect",
+                log.module_path = "reqwest",
+                log.file = "connect.rs",
+                log.line = 1,
+                "a bridged record"
+            );
+        });
+        for one in &rendered {
+            assert_eq!(one.capped, one.default, "rendering must not drift");
+        }
+        // Named shapes the loop above would pass over silently if the
+        // events stopped carrying them.
+        let all = rendered
+            .iter()
+            .map(|one| one.capped.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        for needle in [
+            "display=a plain value",
+            "debug=\"a plain value\"",
+            "quoted=\"a plain value\"",
+            "count=7 signed=-7 ratio=0.5 flag=true",
+            "type=\"raw identifier\"",
+            "type=\"a literal raw name\"",
+            "nested=[1, 2, 3]",
+            "error=the outer failure error.sources=[the inner cause]",
+        ] {
+            assert!(all.contains(needle), "{needle:?} missing from:\n{all}");
+        }
+    }
+
+    /// The bridge's `log.*` fields are dropped, and dropping them does
+    /// not eat the separator of the fields that stay.
+    #[test]
+    fn the_log_bridge_fields_never_reach_the_line() {
+        let rendered = render_one(|| {
+            tracing::info!(
+                log.target = "hyper_util::client::legacy::pool",
+                kept = "yes",
+                log.line = 12,
+                also_kept = "yes",
+                "bridged"
+            );
+        });
+        assert_eq!(rendered.capped, "bridged kept=\"yes\" also_kept=\"yes\"");
+        assert_eq!(rendered.capped, rendered.default);
+    }
+
+    /// `message` is a field like any other here. That is what bounds
+    /// the #261 `serving error: {:?}` line, whose whole payload is the
+    /// message; rmcp's `?notification` payload rides a field instead and
+    /// is bounded by the same budget one field over.
+    #[test]
+    fn the_message_is_capped_too() {
+        let long = "é".repeat(PARAM_VALUE_MAX_CHARS * 4);
+        let rendered = render_one(|| tracing::info!("{long}"));
+        assert_eq!(rendered.capped, "é".repeat(PARAM_VALUE_MAX_CHARS));
+        assert!(
+            rendered.default.chars().count() > PARAM_VALUE_MAX_CHARS,
+            "and `DefaultFields` is what it is being capped against: {}",
+            rendered.default.chars().count()
+        );
+    }
+
+    /// The budget charges the characters handed IN, not the ones written
+    /// OUT.
+    ///
+    /// The two orders agree on ordinary text and differ by a factor of
+    /// four or six on escapable input, and it is the in-order one that
+    /// the rustdoc above and DESIGN.md's "at most six bytes per budgeted
+    /// character" rest on. Nothing on the stderr path tells them apart,
+    /// because a real line's escapable characters are a handful among
+    /// thousands.
+    #[test]
+    fn the_budget_charges_the_characters_handed_in_not_the_ones_written_out() {
+        let mut out = String::new();
+        write!(
+            CappedWriter::new(&mut out),
+            "{}",
+            ESC.to_string().repeat(PARAM_VALUE_MAX_CHARS + 1)
+        )
+        .expect("a String never fails to be written");
+        assert_eq!(
+            out,
+            "\\x1b".repeat(PARAM_VALUE_MAX_CHARS),
+            "1024 escapes in, four characters out apiece"
+        );
+
+        // And through the visitor, on both the `%` path and `message`:
+        // the leading ESC costs one character of the field's budget, so
+        // 1023 of the client's own characters follow it.
+        let long = format!("{ESC}{}", "é".repeat(PARAM_VALUE_MAX_CHARS * 4));
+        let expected = format!("\\x1b{}", "é".repeat(PARAM_VALUE_MAX_CHARS - 1));
+        assert_eq!(
+            render_one(|| tracing::info!(probe = %long)).capped,
+            format!("probe={expected}")
+        );
+        assert_eq!(render_one(|| tracing::info!("{long}")).capped, expected);
+    }
+
+    /// Each field gets its own budget, and the cut leaves the fields
+    /// after it intact — a shared budget would silently drop them.
+    #[test]
+    fn every_field_is_capped_on_its_own_budget() {
+        let long = "é".repeat(PARAM_VALUE_MAX_CHARS * 2);
+        let rendered = render_one(|| tracing::info!(first = %long, second = %long, "m"));
+        assert_eq!(
+            rendered.capped,
+            format!(
+                "m first={cap} second={cap}",
+                cap = "é".repeat(PARAM_VALUE_MAX_CHARS)
+            )
+        );
+    }
+}

--- a/crates/bugwarden/tests/binary_tracing_caps.rs
+++ b/crates/bugwarden/tests/binary_tracing_caps.rs
@@ -1,5 +1,5 @@
 //! What the SHIPPED BINARY's tracing lines carry of a client's own strings
-//! and id arrays (issues #240, #258).
+//! and id arrays (issues #240, #258, #260, #266).
 //!
 //! The audit record caps every client string at 1024 chars before it
 //! reaches the JSONL file or the OTLP audit stream; the `info!` line the
@@ -10,14 +10,43 @@
 //! back) and reaches the stderr writer; `testlog` runs at TRACE under its
 //! own writer and proves neither.
 //!
+//! The second half is not ours to spell at all: rmcp's own lines print
+//! the handshake, the notifications and the request ids of a client this
+//! process never gave a `Capped` to. Those are bounded at the SINK, by
+//! the field formatter `main` installs (#260), and sanitized there too
+//! (#266) — and only a process can show it, because the formatter is
+//! part of the subscriber `main` builds and of nothing else.
+//!
 //! Coverage contract (each of these mutations must fail a test here):
-//! - any `Capped` field formatted from its parameter instead of the
-//!   wrapper — one [`Site`] row per field, the handshake `warn!` that is
-//!   not a tool parameter included;
-//! - a wrapper cutting at cap-1, cap+1, or on a byte boundary, which is
-//!   why every probe is multi-byte;
+//! - the stderr layer built without `fmt_fields`, or with a formatter
+//!   that caps only the fields and not `message`, or only the values
+//!   bugwarden itself formats — the [`Site`] rows whose field is
+//!   `Debug`-shaped are the sharp ones there, because the sink's budget
+//!   covers the RENDERED value: without it a `resolution=Some("` row
+//!   measures 1024 client characters where [`decoration`] expects 1018;
+//! - a cut at cap-1, cap+1, or on a byte boundary, which is why every
+//!   probe is multi-byte;
 //! - `bug_info` or `update_bug_dependencies` logging an id array whole, or
-//!   a head without the count that says how long the array really was.
+//!   a head without the count that says how long the array really was;
+//! - ESC or BEL reaching stderr unescaped. BS, FF, DEL and the C1 range
+//!   are in the same match arm but are not probed here; the module's own
+//!   `the_escaping_matches_what_default_fields_does_to_a_message` walks
+//!   the whole byte set, and a process is the wrong instrument for that.
+//!
+//! What this file NO LONGER proves, since #260, is anything about the
+//! call SITES. `%Capped(&p.query)` and `%p.query` render identically once
+//! the sink cuts at the same constant, so removing a wrapper leaves every
+//! row here green — measured. The wrappers stay all the same: `capped()`
+//! shares their cut and IS the audit record's, `bug_ids` needs a
+//! count-plus-head shape no sink can synthesise (and the row below still
+//! observes that one), and a second bound costs nothing. The record is
+//! measured by `audit_wiremock`, not here.
+//!
+//! Untestable at any level and so not claimed: making the escaping
+//! conditional on `Writer::sanitizes_ansi_escapes`. That flag is `true`
+//! in every configuration this workspace builds — its default, and
+//! `with_ansi_sanitization` is called nowhere — so such a mutant changes
+//! no byte anywhere.
 
 use std::path::Path;
 use std::path::PathBuf;
@@ -46,6 +75,16 @@ const CAP: usize = 1024;
 /// A revision the server serves, so the handshake is unremarkable
 /// everywhere except the row testing an unsupported one.
 const SUPPORTED_VERSION: &str = "2025-11-25";
+
+/// The character every over-cap probe is made of. Multi-byte on purpose:
+/// an ASCII probe cannot tell a character cap from a byte one, and a byte
+/// cut is one of the two ways a cap drifts.
+const PROBE: char = 'é';
+
+/// The byte a terminal reads as the start of a control sequence, and the
+/// one it rings the bell for (#266).
+const ESC: char = '\u{1b}';
+const BEL: char = '\u{7}';
 
 /// Each binary runs the walker itself, so a single-binary
 /// `cargo test --test binary_tracing_caps` still proves what its scrub claims.
@@ -127,6 +166,166 @@ async fn tool_call_log_line(tool: &str, arguments: serde_json::Value, needle: &s
     log_line(SUPPORTED_VERSION, None, Some((tool, arguments)), needle).await
 }
 
+/// Drive `messages` through the real executable over stdio and return
+/// EVERYTHING it wrote to stderr, first line to EOF.
+///
+/// [`log_line`] answers "what did that one line say". The sink's cap is
+/// not a line's property but the stream's, and it covers lines this
+/// workspace does not spell — rmcp's — so these rows have to see all of
+/// them. `needle` is a barrier rather than the subject: stdin stays open
+/// until the line carrying it has been logged, because EOF ends the serve
+/// loop and a spawned handler's line can lose that race; the drain past
+/// it is what makes "no line over the cap" evidence.
+///
+/// `rust_log` is `Some` only where a row is proving that the cap does not
+/// depend on the filter; every other row runs at the level `main` falls
+/// back to, with the variable scrubbed like everywhere else here.
+///
+/// The writes go in a task of their own because these rows send hundreds
+/// of kilobytes: filling the child's stdin pipe while nobody is draining
+/// its stderr deadlocks the pair, and the defect under test is precisely
+/// a child that answers a large frame with a larger log line.
+async fn stderr_through(messages: &[String], rust_log: Option<&str>, needle: &str) -> String {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_bugwarden"));
+    cmd.args(["--transport", "stdio"])
+        .args(["--bugzilla-server", "https://bugzilla.example.invalid"])
+        .args(["--api-key", "test-key"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    for var in scrub_env::AMBIENT_VARS {
+        cmd.env_remove(var);
+    }
+    if let Some(filter) = rust_log {
+        cmd.env("RUST_LOG", filter);
+    }
+    let mut child = cmd.spawn().expect("the built binary must start");
+    let mut stderr = startup_line::stderr_lines(&mut child);
+    let mut stdin = child.stdin.take().expect("stdin is piped");
+    let payload: Vec<u8> = messages
+        .iter()
+        .flat_map(|line| format!("{line}\n").into_bytes())
+        .collect();
+    // Holds stdin open until the barrier is reached: EOF ends the serve
+    // loop, and a handler's line can lose that race.
+    let (release, released) = tokio::sync::oneshot::channel::<()>();
+    let writes = tokio::spawn(async move {
+        stdin
+            .write_all(&payload)
+            .await
+            .expect("the child must accept input");
+        let _ = released.await;
+    });
+    let mut log = String::new();
+    startup_line::wait_for_line(&mut stderr, &mut log, needle, LOG_TIMEOUT).await;
+    let _ = release.send(());
+    writes.await.expect("the writer task must not panic");
+    tokio::time::timeout(LOG_TIMEOUT, async {
+        while startup_line::next_logged_line(&mut stderr, &mut log)
+            .await
+            .is_some()
+        {}
+    })
+    .await
+    .unwrap_or_else(|_| panic!("the child's stderr must reach EOF: {}", excerpt(&log)));
+    log
+}
+
+/// The `initialize` request, with `name` as the client's declared name.
+///
+/// A LINE rather than a `Value`, because one row sends a line that is not
+/// JSON at all and every message goes down the same pipe.
+fn initialize(name: &str) -> String {
+    json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": SUPPORTED_VERSION,
+            "capabilities": {},
+            "clientInfo": { "name": name, "version": "0" }
+        }
+    })
+    .to_string()
+}
+
+/// The notification that ends the handshake.
+fn initialized() -> String {
+    json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }).to_string()
+}
+
+/// A `tools/call` under `id`, so a row can choose an id the client wrote.
+fn tools_call(id: serde_json::Value, tool: &str, arguments: serde_json::Value) -> String {
+    json!({
+        "jsonrpc": "2.0", "id": id, "method": "tools/call",
+        "params": { "name": tool, "arguments": arguments }
+    })
+    .to_string()
+}
+
+/// As much of a log as a panic message should carry: a failing row here
+/// can be holding a hundred kilobytes of one client string.
+fn excerpt(log: &str) -> String {
+    log.chars().take(2_000).collect()
+}
+
+/// The first line of `log` carrying `needle`.
+fn find_line<'a>(log: &'a str, needle: &str) -> &'a str {
+    log.lines()
+        .find(|line| line.contains(needle))
+        .unwrap_or_else(|| panic!("stderr must carry a {needle:?} line: {}", excerpt(log)))
+}
+
+/// The lines the subscriber wrote, told apart by the RFC 3339 UTC
+/// timestamp it puts first — 27 characters ending in `Z`.
+///
+/// The child's own `Error:` exit line is `anyhow`'s Debug of the failure
+/// `main` returned rather than a tracing event, carries no such prefix,
+/// and is #261's subject rather than this file's.
+fn tracing_lines(log: &str) -> impl Iterator<Item = &str> {
+    log.lines().filter(|line| line.chars().nth(26) == Some('Z'))
+}
+
+/// `line` with the `TIMESTAMP LEVEL [span: ]<target>: ` prefix removed,
+/// so what an assertion bounds is the message and the fields alone.
+///
+/// Split off the line rather than assumed: the prefix's width is the
+/// event formatter's business and no part of what #260 decided.
+fn after_target<'a>(line: &'a str, target: &str) -> &'a str {
+    line.split_once(&format!("{target}: "))
+        .unwrap_or_else(|| panic!("the line must be {target}'s: {}", excerpt(line)))
+        .1
+}
+
+/// The longest run of `probe` in `text`: the client's own characters,
+/// which is what the cap is a cap on.
+fn longest_run(text: &str, probe: char) -> usize {
+    let mut longest = 0;
+    let mut run = 0;
+    for ch in text.chars() {
+        run = if ch == probe { run + 1 } else { 0 };
+        longest = longest.max(run);
+    }
+    longest
+}
+
+/// No raw ESC and no raw BEL anywhere on stderr, and both present in
+/// their escaped spellings so the absence is evidence rather than an
+/// empty haystack.
+fn assert_control_bytes_escaped(log: &str) {
+    for (byte, name, escaped) in [(ESC, "ESC", "\\x1b"), (BEL, "BEL", "\\x07")] {
+        assert!(
+            !log.contains(byte),
+            "a raw {name} reached stderr: {}",
+            excerpt(log)
+        );
+        assert!(
+            log.contains(escaped),
+            "and its escaped form must be there, or this proves nothing: {}",
+            excerpt(log)
+        );
+    }
+}
+
 /// The value the tracing line gives `field`; `ends_with` is `None` when the
 /// field is the last one on its line.
 fn logged_field<'a>(line: &'a str, field: &str, ends_with: Option<&str>) -> &'a str {
@@ -153,8 +352,7 @@ fn logged_ids(line: &str, field: &str) -> Vec<u64> {
 }
 
 /// One tracing field that formats a client string, and the call that puts
-/// it on stderr. `field` and `ends_with` bracket the value: a `%Capped`
-/// field prints bare, an `?Option<Capped>` one prints `Some("…")`.
+/// it on stderr.
 struct Site {
     /// `None` for the handshake `warn!`, whose probe is the declared
     /// protocol version rather than a tool argument.
@@ -163,8 +361,29 @@ struct Site {
     /// A policy the guard refuses, for the line only a refusal reaches.
     policy: Option<&'static str>,
     needle: &'static str,
+    /// The field as it reaches the line, up to where the client's own
+    /// text begins: `query=` for a `%Capped` field, `resolution=Some("`
+    /// for an `?Option<Capped>` one. Everything it carries past the `=`
+    /// is [`decoration`].
     field: &'static str,
-    ends_with: Option<&'static str>,
+}
+
+/// The characters a field's own rendering spends out of the sink's
+/// per-field budget before the client's text starts: none for a bare
+/// `%Capped` field, one for a `Debug`-quoted one, six for `Some("`.
+///
+/// Since #260 the budget covers the RENDERED value (the sink sees a
+/// stream of characters and cannot know which of them the client wrote),
+/// so a decorated field carries exactly that much less of the probe —
+/// and loses its closing delimiter to the cut, which is why no row
+/// brackets its value on one.
+fn decoration(field: &str) -> usize {
+    field
+        .split_once('=')
+        .unwrap_or_else(|| panic!("a field needle carries its `=`: {field}"))
+        .1
+        .chars()
+        .count()
 }
 
 /// Denies every product, so `create_bug` reaches its refusal line. No other
@@ -183,7 +402,6 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "tool: bugs_quicksearch",
             field: "query=",
-            ends_with: Some(" status="),
         },
         Site {
             tool: Some("bugs_quicksearch"),
@@ -191,7 +409,6 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "tool: bugs_quicksearch",
             field: "status=",
-            ends_with: Some(" include_fields="),
         },
         Site {
             tool: Some("bugs_quicksearch"),
@@ -199,7 +416,6 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "tool: bugs_quicksearch",
             field: "include_fields=",
-            ends_with: Some(" limit="),
         },
         Site {
             tool: Some("bugs_quicksearch"),
@@ -207,9 +423,9 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "tool: bugs_quicksearch",
             // Debug-formatted, so it stays quoted like the bare `&str`
-            // field it replaced.
+            // field it replaced — and the opening quote is one character
+            // of the sink's budget.
             field: "group_by=\"",
-            ends_with: Some("\""),
         },
         Site {
             tool: Some("create_bug"),
@@ -220,7 +436,6 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "tool: create_bug",
             field: "product=",
-            ends_with: Some(" component="),
         },
         Site {
             tool: Some("create_bug"),
@@ -231,7 +446,6 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "tool: create_bug",
             field: "component=",
-            ends_with: Some(" custom_field_count="),
         },
         Site {
             tool: Some("create_bug"),
@@ -242,7 +456,6 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: Some(DENY_ALL),
             needle: "guard denied bug creation",
             field: "product=",
-            ends_with: None,
         },
         Site {
             tool: Some("add_attachment"),
@@ -253,7 +466,6 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "tool: add_attachment",
             field: "file_name=",
-            ends_with: Some(" is_private="),
         },
         Site {
             tool: Some("update_bug_status"),
@@ -261,7 +473,6 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "tool: update_bug_status",
             field: "status=",
-            ends_with: Some(" resolution="),
         },
         Site {
             tool: Some("update_bug_status"),
@@ -269,7 +480,6 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "tool: update_bug_status",
             field: "resolution=Some(\"",
-            ends_with: Some("\")"),
         },
         Site {
             tool: Some("assign_bug"),
@@ -277,7 +487,6 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "tool: assign_bug",
             field: "assignee=",
-            ends_with: None,
         },
         Site {
             tool: Some("update_bug_fields"),
@@ -285,7 +494,6 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "tool: update_bug_fields",
             field: "priority=Some(\"",
-            ends_with: Some("\")"),
         },
         Site {
             tool: Some("update_bug_fields"),
@@ -293,7 +501,6 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "tool: update_bug_fields",
             field: "severity=Some(\"",
-            ends_with: Some("\")"),
         },
         Site {
             tool: Some("update_bug_fields"),
@@ -301,7 +508,6 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "tool: update_bug_fields",
             field: "resolution=Some(\"",
-            ends_with: Some("\")"),
         },
         Site {
             tool: Some("add_cc_to_bug"),
@@ -309,7 +515,6 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "tool: add_cc_to_bug",
             field: "cc_email=",
-            ends_with: None,
         },
         Site {
             // rmcp logs the same message text with the version raw (#260),
@@ -319,7 +524,17 @@ fn sites(probe: &str) -> Vec<Site> {
             policy: None,
             needle: "bugwarden::server: client requested unsupported",
             field: "client_requested=",
-            ends_with: Some(" server_fallback="),
+        },
+        Site {
+            // And rmcp's own copy of it, one line later: the fourth row
+            // of #260's table, and a field no `Capped` of ours can
+            // reach — 100 179 characters on this branch's parent for a
+            // 100 000-character `protocolVersion`.
+            tool: None,
+            arguments: json!({}),
+            policy: None,
+            needle: "rmcp::service::server: client requested unsupported",
+            field: "client_requested=",
         },
     ]
 }
@@ -333,9 +548,7 @@ fn policy_file(toml: &str) -> PathBuf {
 
 #[tokio::test]
 async fn every_tracing_field_that_formats_a_client_string_is_cut_to_the_cap() {
-    // Multi-byte: an ASCII probe cannot tell a char cap from a byte one,
-    // and a byte cut is one of the two ways the shared wrapper can drift.
-    let probe = "é".repeat(CAP * 4);
+    let probe = PROBE.to_string().repeat(CAP * 4);
     for site in sites(&probe) {
         let policy = site.policy.map(policy_file);
         let version = if site.tool.is_some() {
@@ -345,22 +558,254 @@ async fn every_tracing_field_that_formats_a_client_string_is_cut_to_the_cap() {
         };
         let call = site.tool.map(|tool| (tool, site.arguments));
         let line = log_line(version, policy.as_deref(), call, site.needle).await;
-        let value = logged_field(&line, site.field, site.ends_with);
+        let value = line
+            .split_once(site.field)
+            .unwrap_or_else(|| panic!("the line must carry {}: {line}", site.field))
+            .1;
         // EXACTLY the cap, not "at most": an off-by-one cut is a second
         // rule that has to be remembered next to the audit record's, which
-        // is the thing #191 and this share a definition to prevent.
+        // is the thing #191 and this share a definition to prevent. The
+        // run stops where the sink's budget ran out, so counting it also
+        // proves the field ended there rather than running on.
+        let run = value.chars().take_while(|c| *c == PROBE).count();
         assert_eq!(
-            value.chars().count(),
+            run + decoration(site.field),
             CAP,
-            "{} on {:?} must reach stderr as exactly {CAP} chars: {line}",
+            "{} on {:?} must reach stderr as exactly {CAP} rendered chars, \
+             {} of them its own decoration: {line}",
             site.field,
-            site.needle
-        );
-        assert!(
-            value.chars().all(|c| c == 'é'),
-            "and as a prefix of what the client actually sent: {line}"
+            site.needle,
+            decoration(site.field)
         );
     }
+}
+
+/// rmcp's own lines print the client's handshake and its notifications
+/// whole (#260). Measured there and again on this branch's parent, with
+/// an ASCII probe: a 50 000-character `clientInfo.name` made
+/// `Service initialized as server` 50 438 characters, and a
+/// 100 000-character `notifications/progress` message made
+/// `received notification` 100 335. Neither is a field this workspace
+/// spells, so no call-site cap can reach either.
+///
+/// Both are `info!`, so the DEFAULT filter is what this row runs at:
+/// dropping to `warn` would have hidden these two and left the two
+/// `warn!` lines of the same table untouched, which is the argument the
+/// sink won. The lines a raised filter adds are the next row's.
+#[tokio::test]
+async fn rmcps_handshake_and_notification_lines_are_cut_at_the_sink() {
+    let name = PROBE.to_string().repeat(50_000);
+    let message = PROBE.to_string().repeat(100_000);
+    let log = stderr_through(
+        &[
+            initialize(&name),
+            initialized(),
+            json!({
+                "jsonrpc": "2.0", "method": "notifications/progress",
+                "params": { "progressToken": "t", "progress": 1, "message": message }
+            })
+            .to_string(),
+        ],
+        None,
+        "notification=ProgressNotification",
+    )
+    .await;
+
+    // The overhead is stated rather than guessed: the prefix comes off
+    // the line, and what is left is rmcp's own static message plus its
+    // one field name plus that field's value.
+    for (needle, message_text, field) in [
+        (
+            "Service initialized as server",
+            "Service initialized as server",
+            " peer_info=",
+        ),
+        (
+            "notification=ProgressNotification",
+            "received notification",
+            " notification=",
+        ),
+    ] {
+        let line = find_line(&log, needle);
+        let body = after_target(line, "rmcp::service").chars().count();
+        assert!(
+            body <= message_text.chars().count() + field.chars().count() + CAP,
+            "{needle:?} must fit its message, its field name and one \
+             capped value: {body} chars in {}",
+            excerpt(line)
+        );
+        assert!(
+            longest_run(line, PROBE) >= CAP / 2,
+            "and must still carry the client's text, or it bounds \
+             nothing: {}",
+            excerpt(line)
+        );
+    }
+
+    for line in tracing_lines(&log) {
+        assert!(
+            longest_run(line, PROBE) <= CAP,
+            "no line may carry more than {CAP} of the client's own \
+             characters: {}",
+            excerpt(line)
+        );
+    }
+}
+
+/// rmcp answers every failed request with `warn!(%id, ..)`, so a
+/// client-chosen STRING request id reaches stderr through a field this
+/// workspace never spells — and, being `%`, without even `Debug`'s
+/// escaping. A 4096-character ASCII id measured 4259 characters on the
+/// unpatched tree, at the DEFAULT filter.
+#[tokio::test]
+async fn an_over_long_request_id_is_cut_at_the_sink() {
+    let id = PROBE.to_string().repeat(CAP * 4);
+    let log = stderr_through(
+        &[
+            initialize("binary-tracing-caps-test"),
+            initialized(),
+            tools_call(json!(id), "no_such_tool", json!({})),
+        ],
+        None,
+        "response error",
+    )
+    .await;
+    let line = find_line(&log, "response error");
+    let value = logged_field(line, "id=", Some(" error="));
+    assert_eq!(
+        value.chars().count(),
+        CAP,
+        "a string request id must reach stderr as exactly {CAP} chars: {}",
+        excerpt(line)
+    );
+    assert!(
+        value.chars().all(|c| c == PROBE),
+        "and as a prefix of what the client actually sent: {}",
+        excerpt(line)
+    );
+}
+
+/// Two rmcp lines that only a raised filter opens, both carrying client
+/// bytes this workspace never formats — which is where a level filter
+/// would have been the wrong fix and the sink is the right one.
+///
+/// `service.rs:1535` logs the whole request at debug, `params` and every
+/// argument included. `transport/async_rw.rs:336` logs the whole
+/// UNPARSABLE line at debug, once per malformed line — and it is the
+/// `message` field, so only a sink that budgets `message` bounds it.
+/// Measured on this branch's parent at `RUST_LOG=debug`: 100 330
+/// characters for a 100 000-character argument and 100 150 for a
+/// 100 000-character garbage line.
+///
+/// A malformed line does not end the session — rmcp skips it and serves
+/// the next message — so one child produces both.
+#[tokio::test]
+async fn a_raised_filter_opens_no_line_the_sink_does_not_cut() {
+    let probe = PROBE.to_string().repeat(100_000);
+    let log = stderr_through(
+        &[
+            initialize("binary-tracing-caps-test"),
+            initialized(),
+            // Not JSON, and not a prefix of any: rmcp echoes it whole.
+            probe.clone(),
+            tools_call(json!(2), "bugs_quicksearch", json!({ "query": probe })),
+        ],
+        Some("debug"),
+        "tool: bugs_quicksearch",
+    )
+    .await;
+
+    // The unparsable line is all `message`, so its whole body is one
+    // budgeted field and lands on the cap exactly.
+    let parse_failure = find_line(&log, "Failed to parse message");
+    assert_eq!(
+        after_target(parse_failure, "rmcp::transport::async_rw")
+            .chars()
+            .count(),
+        CAP,
+        "an unparsable line reaches stderr as one capped message: {}",
+        excerpt(parse_failure)
+    );
+
+    // The request line is a message plus two fields; the overhead is its
+    // own static text, and the id is the `2` this row sent.
+    const REQUEST: &str = "received request";
+    let request = find_line(&log, REQUEST);
+    let body = after_target(request, "rmcp::service").chars().count();
+    assert!(
+        body <= REQUEST.chars().count() + " id=2".len() + " request=".len() + CAP,
+        "a whole request at debug must fit its two field names and one \
+         capped value: {body} chars in {}",
+        excerpt(request)
+    );
+    assert!(
+        longest_run(request, PROBE) >= CAP / 2,
+        "and must still carry the client's text, or it bounds nothing: {}",
+        excerpt(request)
+    );
+
+    for line in tracing_lines(&log) {
+        assert!(
+            longest_run(line, PROBE) <= CAP,
+            "no line may carry more than {CAP} of the client's own \
+             characters, whatever the filter: {}",
+            excerpt(line)
+        );
+    }
+}
+
+/// A `%` field is written verbatim (#266): tracing-subscriber sanitizes
+/// `message` and `record_error` and nothing else, and most of the client
+/// strings this workspace logs are `%`, `query` among them. A `query` of
+/// ESC `[2J` clears the operator's terminal and BEL rings it; exactly one
+/// raw ESC and one raw BEL reached stderr on the unpatched tree.
+#[tokio::test]
+async fn a_tool_argument_never_reaches_stderr_as_a_raw_control_byte() {
+    let log = stderr_through(
+        &[
+            initialize("binary-tracing-caps-test"),
+            initialized(),
+            tools_call(
+                json!(2),
+                "bugs_quicksearch",
+                json!({ "query": format!("a{ESC}[2Jb{BEL}c") }),
+            ),
+        ],
+        None,
+        "tool: bugs_quicksearch",
+    )
+    .await;
+    assert_control_bytes_escaped(&log);
+    assert!(
+        log.contains("query=a\\x1b[2Jb\\x07c"),
+        "and the field must read as the escape, not as a hole: {}",
+        excerpt(&log)
+    );
+}
+
+/// The same for the fields no code of this workspace spells: rmcp's
+/// `warn!(%id, ..)` prints a client-chosen string request id raw, and its
+/// `?peer_info` prints the declared client name — the latter already
+/// escaped by `str`'s own `Debug`, pinned here so it stays that way.
+#[tokio::test]
+async fn rmcps_own_fields_never_reach_stderr_as_raw_control_bytes() {
+    let log = stderr_through(
+        &[
+            initialize(&format!("client{ESC}[2Jname")),
+            initialized(),
+            tools_call(json!(format!("id{ESC}[2J{BEL}")), "no_such_tool", json!({})),
+        ],
+        None,
+        "response error",
+    )
+    .await;
+    assert_control_bytes_escaped(&log);
+    let line = find_line(&log, "response error");
+    assert!(
+        line.contains("id=id\\x1b[2J\\x07"),
+        "rmcp's `%id` is the field with no `Debug` to fall back on: {}",
+        excerpt(line)
+    );
 }
 
 #[tokio::test]

--- a/crates/bugwarden/tests/otel_diagnostics.rs
+++ b/crates/bugwarden/tests/otel_diagnostics.rs
@@ -18,7 +18,14 @@
 //!   exporter its own source of records to export;
 //! - narrowing the skip back to this module's target, which lets the
 //!   exporter's `reqwest`/`hyper` events be exported and turns one flush
-//!   into an endless self-feeding one.
+//!   into an endless self-feeding one;
+//! - exporting a field's value without the sink's per-field budget or
+//!   without its escaping (#260, #266) — the collector is reached by the
+//!   same rmcp lines stderr is, and a bound only stderr has is not one;
+//! - swapping which of `message` and the other fields leads the body,
+//!   on either the `Debug` path or the `&str` one;
+//! - dropping the separator a second body field opens with, which a
+//!   one-field record cannot see.
 
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
@@ -31,6 +38,13 @@ use tracing_subscriber::EnvFilter;
 
 /// Bodies posted to the collector, newest last.
 type Posted = Arc<Mutex<Vec<Vec<u8>>>>;
+
+/// The sink's per-field cap, spelled out: a test that reads the constant
+/// it is testing agrees with any value.
+const CAP: usize = 1024;
+
+/// The byte a terminal reads as the start of a control sequence.
+const ESC: char = '\u{1b}';
 
 /// A collector that answers OTLP posts and LOGS NOTHING ITSELF.
 ///
@@ -219,6 +233,21 @@ async fn the_servers_diagnostics_reach_the_collector_but_the_exporters_own_do_no
     slot.set(pipeline.clone()).expect("the slot fills once");
 
     tracing::info!(answer = 42, "otel-diagnostics-probe");
+    // The body answers to the same per-field bound and the same escaping
+    // the stderr layer applies (#260, #266). Multi-byte after the ESC, so
+    // a byte budget cannot pass for a character one.
+    let over_cap = format!("{ESC}{}", "é".repeat(CAP * 4));
+    // Two fields, so the assertion below also pins that a cut field
+    // leaves the separator and the field after it intact.
+    tracing::info!(probe = %over_cap, next = "after", "otel-diagnostics-cap-probe");
+    // A `&str` value reaches the visitor through `record_str`, not
+    // `record_debug`, and only an explicit `message` field takes that
+    // path for the body's leading text — so this is the one shape that
+    // tells the two apart.
+    tracing::info!(
+        message = "otel-diagnostics-str-probe",
+        tag = "reached-as-a-str"
+    );
     // What the exporter says about itself never goes on the wire: this is
     // the shape of the drop warning, and exporting it would feed a failing
     // exporter its own failures.
@@ -276,6 +305,31 @@ async fn the_servers_diagnostics_reach_the_collector_but_the_exporters_own_do_no
         probe.1.iter().any(|(k, _)| k == "log.target"),
         "the emitting target must ride along: {:?}",
         probe.1
+    );
+
+    let by_str = records
+        .iter()
+        .find(|(body, _)| body.contains("otel-diagnostics-str-probe"))
+        .expect("the record_str diagnostic must be exported");
+    assert_eq!(
+        by_str.0, "otel-diagnostics-str-probe tag=reached-as-a-str",
+        "a `&str` message leads the body and a `&str` field follows it \
+         as `name=value`, the same way a `Debug` one does"
+    );
+
+    let capped = records
+        .iter()
+        .find(|(body, _)| body.starts_with("otel-diagnostics-cap-probe"))
+        .expect("the capped diagnostic must be exported");
+    assert_eq!(
+        capped.0,
+        format!(
+            "otel-diagnostics-cap-probe probe=\\x1b{} next=after",
+            "é".repeat(CAP - 1)
+        ),
+        "the body's field is cut at {CAP} characters as handed in, the \
+         ESC among them and escaped on the way out, and the field after \
+         it still opens with its own separator"
     );
 
     assert!(

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1226,8 +1226,54 @@ Decisions, all deliberate:
   the record enforces and the handler's own `info!` line undoes is not a
   bound.
 
+  Since #260 the bound no longer depends on the SITE. `tracing_fields`
+  puts it where every line passes: the stderr layer's field formatter
+  (`fmt::layer().fmt_fields(CappedFields)`) and `otel`'s diagnostics body
+  visitor write each field's value through one character budget, so every
+  field of every line is cut at `PARAM_VALUE_MAX_CHARS` — rmcp's own,
+  which print the whole handshake, every client notification and a raw
+  string request id, at whatever level and whatever `RUST_LOG` says. Each
+  value is also escaped there (#266): tracing-subscriber 0.3 sanitizes
+  `message` and `record_error` and nothing else, so a `%`-formatted
+  field reached the terminal verbatim, and most of the client strings
+  this codebase logs are `%` — a `query` of ESC `[2J` cleared the
+  operator's screen. (The `?`-formatted ones — `group_by`, `resolution`,
+  `priority`, `severity` — were already escaped by `str`'s own `Debug`,
+  as rmcp's `?peer_info` is; its `%id` is not.) The sink escapes ESC,
+  BEL, BS, FF, DEL and the C1 range, unconditionally, whatever the
+  writer's ANSI-sanitization setting says: that setting exists so that
+  TRUSTED sequences in a logged value pass through unchanged, and it is
+  not a channel a client may inherit. That set is `EscapeGuard`'s and no
+  larger, so LF, CR and TAB still pass — as they always did for
+  `message`, which `EscapeGuard` already covered — and a client field
+  carrying LF still forges a whole stderr line. That is #275, not this
+  bound's business: widening the set past what tracing-subscriber
+  escapes is a separate decision about a separate defect. The cap is
+  also per FIELD of a line and says nothing about how many LINES a
+  client can cause: rmcp logs every notification at `info`, so 300
+  `notifications/progress` still produce 301 lines, each bounded.
+
+  The call-site `Capped`s STAY, and the sink MASKS them on stderr: once
+  both cut at the same constant, `%Capped(&p.query)` and `%p.query` put
+  the same bytes on the line, so `binary_tracing_caps` now measures the
+  sink and nothing about the sites — measured, by removing a wrapper and
+  watching the suite stay green. They are kept for three reasons that
+  survive that. `capped()` shares their cut and is the AUDIT RECORD's,
+  which `audit_wiremock` measures and no sink touches. `bug_ids` needs a
+  count-plus-head shape, and a sink that sees only rendered characters
+  cannot synthesise one. And a bound in front of a bound costs a wrapper.
+  Where the two meet the sink's budget covers the rendered form,
+  decoration included, so an `?Option<Capped>` field spends six of its
+  1024 characters on `Some("` and loses the closing `")` to the cut: a
+  strict tightening, never a loosening, and the price of a cut that does
+  not depend on the site knowing it exists.
+
   The two lines a failed stdio handshake writes are bounded by a
-  different means, because a cap would not have reached them (#261).
+  different means, because the cut above is the wrong instrument for
+  them (#261): one of the two is no tracing event, so no sink reaches
+  it, and on the other a per-field cut would still leave 1024 characters
+  of the client's own frame in front of the operator, where the right
+  number is none.
   rmcp's `ServerInitializeError` carries the client's whole first frame
   in its `Debug` AND — through
   `ExpectedInitializeRequest`'s `#[error("…: {0:?}")]` — in its
@@ -1754,7 +1800,14 @@ names an endpoint.
   derives from the transport.
 - **What is exported.** One OTel log record per `AuditEvent` the sink
   persisted, plus the server's own `tracing` diagnostics; the two are told
-  apart by the `bugwarden.stream` attribute (`audit` / `diagnostics`). An
+  apart by the `bugwarden.stream` attribute (`audit` / `diagnostics`). A
+  DIAGNOSTICS record's body is the event's message followed by its
+  fields, built by `BodyVisitor`, and every value in it goes through the
+  same character budget and the same escaping the stderr formatter
+  applies (`tracing_fields`, #260/#266): the collector is the same
+  operator's stream, reached by the same uncapped rmcp lines, and a bound
+  only the terminal has is not a bound. That budget touches the
+  diagnostics body and nothing else. An
   audit record's body is the audit line VERBATIM — when a file is
   configured, the same bytes it holds, without the terminating newline and
   without the leading one a torn-line repair may have prefixed; a fileless
@@ -1822,12 +1875,17 @@ names an endpoint.
   peak (three copies of the batch's bytes); at the ceiling, ≈192 GiB and
   ≈256 GiB. Over stdio the same `max_request_body_bytes` bounds a frame
   (`BoundedLines`, #234), so the per-stream figures are identical. The
-  diagnostics queue is the same shape and not smaller. Since #240 the
-  server's OWN lines are bounded by their field count rather than by the
-  call (`error = %e` aside, #261), but rmcp's are not — its handshake and
-  notification lines print the client's frame whole (#260) — so the queue
-  stays unsized by record too. It DROPS what it cannot hold, where the audit queue refuses and
-  closes the fail-mode gate.
+  diagnostics queue is the same shape and not smaller, but since #260 it
+  is no longer unsized by record, and the figures above are the AUDIT
+  queue's alone. Every field of every diagnostic line is cut at 1024
+  characters at the sink — rmcp's handshake, notification, request and
+  parse-failure lines included — so a diagnostic record is at
+  most its callsite's field count × 1024 characters plus its field names,
+  `message` being one of those fields, and a character costs at most six
+  bytes once an escape expands it. A callsite's field count is fixed by
+  the code that logs, so count × cap is a real byte bound there. The diagnostics queue still DROPS what
+  it cannot hold, where the audit queue refuses and closes the fail-mode
+  gate.
 - **Decided-no: byte-bounding the queue (#235).** A byte budget (a
   `Semaphore` acquired per record in `accept`, released when the batch
   drops) would refuse audit records — and so close the gate for the whole
@@ -1842,9 +1900,12 @@ names an endpoint.
   records and the power-of-two drop line for the diagnostics. The
   numbers are large because a record is unbounded, and #220 decided
   against bounding one (a params-total cap) on the same terms —
-  the large records are the calls an operator most needs. This reopens
-  if a record-size cap ever lands: count × cap is then a real byte bound,
-  and the availability trade above stops being the whole argument.
+  the large records are the calls an operator most needs. This bullet is
+  about the AUDIT queue and the AUDIT record; the diagnostics record got
+  its own size cap in #260 and reopens nothing here. It reopens if a cap
+  on the audit record ever lands: count × cap is then a real byte bound
+  for this queue too, and the availability trade above stops being the
+  whole argument. Until then the decision stands as written.
 - **The drop line carries a count and a reason and nothing else.** The
   reason is a closed vocabulary (`queue_full`, `network`, `http_status`,
   `shutdown`) for the same purpose `GapReason` is one: a free-text reason


### PR DESCRIPTION
Closes #260. Closes #266. Closes #261 (its `error = %e` half; the main.rs half landed in #274).

## What was wrong

#240 capped the client strings bugwarden's own lines carry, at the call site. rmcp's lines on the same stderr and the same OTLP diagnostics stream were never capped: the `initialize` params whole, every client notification whole, a string request id raw on every error reply, and at debug every request whole. Measured on the unpatched tree: a 50 000-char `clientInfo.name` gave a 50 438-char line, a 100 000-char progress message a 100 335-char one, a 4096-char request id a 4259-char one, and the pre-`initialize` serving-error line 100 411 chars. A level filter would hide two of the four and be undone by the next `RUST_LOG` an operator sets.

And a `%`-formatted field is written verbatim: tracing-subscriber sanitizes `message` and `record_error` alone, so a `query` of `ESC [2J` cleared the operator's terminal and `BEL` rang it (#266).

## What changes

- A new library module, `tracing_fields`, holds `CappedWriter`, a no-allocation `fmt::Write` adapter that passes through 1024 characters and then swallows, escaping ESC, BEL, BS, FF, DEL and the C1 range in the same rendering tracing-subscriber's `EscapeGuard` uses, unconditionally. `CappedFields` is a `FormatFields` transcription of the default visitor with every value written through that budget; the stderr layer uses it, and `otel::BodyVisitor` uses the same writer for the exported diagnostics body. Audit-record bodies are untouched.
- `PARAM_VALUE_MAX_CHARS` moved into the module, so the record's cap and the sink's cap are one constant.
- The call-site `Capped` wrappers stay: the sink can only truncate a rendered value, so it cannot produce `bug_ids`' count-plus-head shape, and the site is what each `binary_tracing_caps` row measures. Where the two meet the budget covers the rendered form, so a `?Option<Capped>` field spends six characters on `Some("` and loses the closing `")`: a strict tightening, and the one thing this changes about the lines #240 pinned.
- Measured after: 1 126, 1 121, 1 187 and 1 069 chars for the four lines above; zero raw ESC or BEL on stderr.
- The diagnostics queue follows: a record is now its callsite's field count times the cap, so DESIGN.md's "stays unsized by record too" is false for that queue and the #235 figures are the audit queue's alone.

## Tests

Eight module unit tests: the cut at exactly the cap on a char boundary, a value written in pieces, the escape rendering byte-equal to what the default formatter does to `message`, every field shape rendering exactly as the default formatter renders it, `log.*` bridge fields skipped, `message` capped, the budget charging the characters handed in rather than the ones written out, and each field on its own budget. Each is pinned by a hand-applied mutant. Four new `binary_tracing_caps.rs` rows over the shipped binary, each shown to fail with the sink unwired: rmcp's handshake and notification lines, the over-long request id, rmcp's own control-byte fields, and a raised filter (`RUST_LOG=debug`) opening no line the sink does not cut, with a 100 000-char unparsable line and a `tools/call` after the handshake; plus a control-byte `query` row and the reworked cap row. `otel_diagnostics.rs` pins the exported body cut and escaped with a two-field probe. cargo-mutants over the diff: 32 mutants, 25 caught, 7 unviable, 0 missed.

## Review before opening

Three parallel refutation-lens reviews over the uncommitted diff, then one fold pass:

- **Security / invariants — MERGE-SAFE.** Field names are `&'static str` by construction, so no client-authored name can reach the sink; the escape set and rendering are byte-equal to `EscapeGuard`'s over 0x00–0xFF; the per-char budget persists across `write_str` pieces; error sources, `record_bytes` and span fields all go through the same budget; the longest line under `RUST_LOG=trace` with every probe is 1333 chars; the OTLP audit body is byte-for-byte untouched; `log.target` is captured before any budget so the exporter's skip list is intact. One should-fix: the test file claimed each row pins its call-site `Capped`, but the sink now masks the site (removing a wrapper leaves the suite green), so the contract now says the rows pin the sink and the wrappers are defence in depth.
- **Correctness / edge cases — NOT MERGE-SAFE on merge order, otherwise sound.** Whole-line parity with the default formatter verified through a real `fmt::layer()` for about forty event shapes, spans and `log` bridge records included; every escape byte via `message` and via `%` fields; cap boundaries with 4-byte chars and pieced `format_args!`; 14 hand mutants killed. Two under-pinned spots closed: the budget's counting order (chars handed to the adapter, not rendered chars) now has a module test with escapable input over the cap, and the OTLP body's inter-field separator has a two-field probe.
- **Docs / prose — NOT MERGE-SAFE on merge order.** The row pinning the pre-`initialize` serving-error line assumed the frame was in the message; #261 landed first and made that message fixed text, so the row was retargeted to what rmcp still prints whole at debug: a `tools/call` after the handshake (`received request`) and a 100 000-char unparsable line (`async_rw.rs:336`). Prose corrected where it overclaimed: "control bytes" named as the exact set (CR and LF pass, tracked as #275); "no client string can flood" scoped to per-field-per-line, since the line count is unbounded; the debug row's rationale; the coverage contract's untestable clause about the writer's sanitization flag.
- Every rmcp citation, the six-bytes-per-char worst case, the 1018-char figure, the `tracing-log` bridge, the `r#` stripping and the field-count arithmetic were verified against the vendored sources by the docs lens.

Out of scope, tracked: #275 (LF/CR forge a stderr line, pre-existing), #272 (three ERROR lines for one over-cap refusal).
