### PR TITLE
test(harness): bound every awaited request

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -19,9 +19,29 @@ test_workspace = true
 # `cargo test --workspace` (~20s unmutated) at max(20s, 5x baseline) = 20s.
 # That alone reported a dozen guard.rs mutants as timeouts; most resolve at
 # 20-23s. The floor must also clear this suite's failure paths, which hold
-# deliberate multi-second barriers (an 8s bounded wait in otel_wiremock, 20s
+# deliberate multi-second barriers (a 30s deadline on every request a test
+# awaits from the server, an 8s bounded wait in otel_wiremock, 20s
 # child-process budgets in binary_user_agent and http_auth_wiremock) so a
 # broken build fails instead of hanging -- an additive cost no multiple of a
-# 20s happy path expresses. A floor and not --timeout, so the 5x multiplier
-# still scales past it on a slow runner or once upstream fixes the baseline.
+# 20s happy path expresses.
+#
+# The 30s deadline is the largest, and it is paid PER TEST, not once: a
+# mutant that leaves requests unanswered costs a binary
+# ceil(failing tests / test threads) x 30s, since libtest defaults its
+# thread count to the core count. Measured under a hand-applied
+# CatchUnwind mutant that answers nothing, on a 32-core box and then at
+# --test-threads=4 to stand in for a small runner: the lib binary's 22
+# failures take 31s and 158s, audit_wiremock's 36 take 60s and 271s,
+# tools_wiremock's 82 take 91s and 632s. Four threads is thus already the
+# edge -- the floor holds for a mutant the lib binary catches, and cargo
+# reaches that binary first, but one that hangs ONLY a wiremock harness
+# outruns the floor and reports TIMEOUT with its verdict unknown. That
+# residual is #254's and is left standing on purpose: a shorter deadline
+# converts hangs sooner but flakes sooner too, on the smaller runners
+# ci.yml's rust-macos job and this workflow use, and the lever for the
+# residual is this floor or a --test-threads pinned in mutants.yml rather
+# than the constant the tests share.
+#
+# A floor and not --timeout, so the 5x multiplier still scales past it on a
+# slow runner or once upstream fixes the baseline.
 minimum_test_timeout = 300

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,22 @@ are never a justification for undoing them.
   `crates/bugwarden-core/tests/` and, for server- and transport-level
   behavior, `crates/bugwarden/tests/`. The guard test list in DESIGN.md
   ("Testing") is the minimum bar, not a ceiling.
+- Nothing a test awaits for an answer from the server may be awaited
+  without a deadline: rmcp sets none, and `reqwest::Client::new()` sets
+  none, so an unanswered request parks the binary and everything cargo
+  queues behind it instead of failing one test. Three site classes, each
+  with its own form. A request through an rmcp client — the `initialize`
+  handshake and any later one included — goes through `bounded`. So does
+  a direct `ServerHandler::call_tool` or `list_tools` await in
+  `server.rs`'s tests, with no client or transport in between:
+  `call_tool` reaches the same `dispatch`, and that is where the mutants
+  which used to hang the suite lived. A hand-built POST to `/mcp` takes
+  its client from `raw_client()` instead, because `send()` resolves at the
+  response headers and only reqwest's own total timeout also covers the
+  body. `bounded` and `CALL_DEADLINE` live in
+  `crates/bugwarden/tests/common/deadline.rs`, `raw_client()` beside them
+  in `common/raw_client.rs`, and `server.rs`'s test module keeps its own
+  equal copy of the constant.
 - A dependency change must update `Cargo.lock`, preserve the MSRV, and pass
   `cargo deny check`. Prefer the smallest compatible version change; do not
   run a broad `cargo update` as part of an unrelated change.

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -6717,11 +6717,50 @@ mod tests {
                 let _ = running.waiting().await;
             }
         });
-        ().serve(client_io)
+        bounded("the MCP handshake", ().serve(client_io))
             .await
             .expect("MCP handshake must succeed")
     }
 
+    /// Bound on every request these tests await — over the duplex
+    /// transport and in process alike.
+    ///
+    /// rmcp 3.1.4 sends with `PeerRequestOptions::default()`, whose
+    /// `timeout` is `None` (`service.rs`), and its `initialize` handshake
+    /// reads the response off the transport with no deadline either. A
+    /// request the server never answers therefore waits forever: it hangs
+    /// its test, this whole binary, and every binary cargo queues behind
+    /// it. That failure is the one this module hunts (#253, #254), so it
+    /// must fail ONE test rather than decide how long the run takes. A
+    /// direct `ServerHandler::call_tool` await is bounded for the same
+    /// reason: it reaches the same dispatch, and the mutants that hung the
+    /// suite were inside it. So is a hand-sent second `initialize` — over
+    /// a live session that is an ordinary request, answered or not.
+    ///
+    /// 30s is far above anything legitimate here — no test delays a mock
+    /// and every upstream is loopback or absent — and it is the number
+    /// `tests/common/deadline.rs` gives the integration harnesses. Two
+    /// definitions of it exist, not one: a `#[cfg(test)]` module in the
+    /// library cannot reach `tests/`, so nothing but this sentence keeps
+    /// them equal. Move one and move the other; the reasoning for the
+    /// value itself lives in that file.
+    const CALL_DEADLINE: std::time::Duration = std::time::Duration::from_secs(30);
+
+    /// Await `fut` under [`CALL_DEADLINE`], panicking if it does not
+    /// resolve. `what` names the request, because the panic is all a
+    /// reader of a CI log gets.
+    async fn bounded<T>(what: &str, fut: impl std::future::Future<Output = T>) -> T {
+        tokio::time::timeout(CALL_DEADLINE, fut)
+            .await
+            .unwrap_or_else(|_| panic!("{what} was not answered within {CALL_DEADLINE:?}"))
+    }
+
+    /// Call `tool` over the session, under [`CALL_DEADLINE`].
+    ///
+    /// The bound carries weight wherever this follows a call that panicked:
+    /// "the session survives" is a claim that a reply ARRIVES, so an
+    /// unbounded await would turn a missing one into a hang rather than
+    /// the failure it is.
     async fn call(
         client: &RunningService<RoleClient, ()>,
         tool: &str,
@@ -6730,10 +6769,12 @@ mod tests {
         let Value::Object(args) = args else {
             panic!("tool arguments must be a JSON object");
         };
-        client
-            .call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(args))
-            .await
-            .expect("tool call must not be a protocol error")
+        bounded(
+            &format!("the {tool} call"),
+            client.call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(args)),
+        )
+        .await
+        .expect("tool call must not be a protocol error")
     }
 
     fn text_of(result: &CallToolResult) -> String {
@@ -6989,8 +7030,7 @@ mod tests {
         let mut meta = rmcp::model::RequestMetaObject::new();
         meta.set_traceparent(traceparent);
         params.meta = Some(meta);
-        client
-            .call_tool(params)
+        bounded(&format!("the traced {tool} call"), client.call_tool(params))
             .await
             .expect("tool call must not be a protocol error")
     }
@@ -7032,35 +7072,38 @@ mod tests {
             }
         });
         let client: RunningService<RoleClient, ()> =
-            ().serve(client_io)
+            bounded("the MCP handshake", ().serve(client_io))
                 .await
                 .expect("MCP handshake must succeed");
 
         assert!(
-            client
-                .list_all_tools()
+            bounded("tools/list", client.list_all_tools())
                 .await
                 .expect("tools/list must succeed")
                 .is_empty(),
             "a request with no scope must be offered nothing"
         );
-        let refused = client
-            .call_tool(
+        let refused = bounded(
+            "the scope-refused bug_info call",
+            client.call_tool(
                 CallToolRequestParams::new("bug_info".to_string()).with_arguments(
                     json!({ "bug_ids": [7] })
                         .as_object()
                         .expect("object")
                         .clone(),
                 ),
-            )
-            .await
-            .expect_err("a request with no scope must reach no tool");
-        let unknown = client
-            .call_tool(CallToolRequestParams::new(
+            ),
+        )
+        .await
+        .expect_err("a request with no scope must reach no tool");
+        let unknown = bounded(
+            "the no_such_tool_at_all call",
+            client.call_tool(CallToolRequestParams::new(
                 "no_such_tool_at_all".to_string(),
-            ))
-            .await
-            .expect_err("an unknown tool is an error");
+            )),
+        )
+        .await
+        .expect_err("an unknown tool is an error");
         assert_eq!(refused.to_string(), unknown.to_string());
     }
 
@@ -7084,14 +7127,16 @@ mod tests {
             }
         });
         let client: RunningService<RoleClient, ()> =
-            ().serve(client_io)
+            bounded("the MCP handshake", ().serve(client_io))
                 .await
                 .expect("MCP handshake must succeed");
 
-        client
-            .call_tool(CallToolRequestParams::new("add_comment".to_string()))
-            .await
-            .expect_err("the call must be refused");
+        bounded(
+            "the scope-refused add_comment call",
+            client.call_tool(CallToolRequestParams::new("add_comment".to_string())),
+        )
+        .await
+        .expect_err("the call must be refused");
         drop(client);
 
         let events = read_audit_events(&audit_path);
@@ -7389,37 +7434,20 @@ mod tests {
         )
     }
 
-    /// Every call in this cluster is bounded by this. A request the server
-    /// never answers must fail one test, not hang the whole binary (#254),
-    /// and that is the exact defect under test.
-    const PROBE_DEADLINE: std::time::Duration = std::time::Duration::from_secs(10);
-
     /// Call the probe and return the protocol error the request must be
-    /// answered with.
+    /// answered with. Bounded like every request here, and here the bound
+    /// is the point: a panicking handler that answers nothing is the exact
+    /// defect under test.
     async fn panic_probe_error(client: &RunningService<RoleClient, ()>) -> McpError {
-        let answered = tokio::time::timeout(
-            PROBE_DEADLINE,
+        let answered = bounded(
+            "the panic probe",
             client.call_tool(CallToolRequestParams::new(PANIC_PROBE.to_string())),
         )
-        .await
-        .expect("a panicking handler must still answer its request");
+        .await;
         match answered {
             Err(rmcp::service::ServiceError::McpError(err)) => err,
             other => panic!("a recovered panic is a protocol error, got {other:?}"),
         }
-    }
-
-    /// [`call`] under [`PROBE_DEADLINE`]. The follow-up matters as much as
-    /// the panicking call: "the session survives" is a claim about a reply
-    /// arriving, so an unbounded await would turn its absence into a hang.
-    async fn call_bounded(
-        client: &RunningService<RoleClient, ()>,
-        tool: &str,
-        args: Value,
-    ) -> CallToolResult {
-        tokio::time::timeout(PROBE_DEADLINE, call(client, tool, args))
-            .await
-            .expect("the next call on the same session must still be answered")
     }
 
     /// The reply is fixed, carries no `data`, and nothing derived from the
@@ -7461,7 +7489,7 @@ mod tests {
         assert_panic_reply(&err);
 
         // The session survives the unwind: the next call is served.
-        let served = call_bounded(&client, "mcp_server_info", json!({})).await;
+        let served = call(&client, "mcp_server_info", json!({})).await;
         assert!(!is_error(&served), "the session must keep serving");
 
         let events = read_audit_events(&audit_path);
@@ -7484,7 +7512,7 @@ mod tests {
         let client = mcp_client_routed("", NO_BUGZILLA, None, true).await;
         let err = panic_probe_error(&client).await;
         assert_panic_reply(&err);
-        let served = call_bounded(&client, "mcp_server_info", json!({})).await;
+        let served = call(&client, "mcp_server_info", json!({})).await;
         assert!(!is_error(&served), "the session must keep serving");
     }
 
@@ -7560,7 +7588,9 @@ mod tests {
         let (client_io, server_io) = tokio::io::duplex(1 << 16);
         let serving = server.clone();
         let task = tokio::spawn(async move { serving.serve(server_io).await });
-        let _client = ().serve(client_io).await.expect("MCP handshake must succeed");
+        let _client = bounded("the MCP handshake", ().serve(client_io))
+            .await
+            .expect("MCP handshake must succeed");
         task.await
             .expect("serve task must not panic")
             .expect("server must serve")
@@ -7639,9 +7669,12 @@ mod tests {
         for (row, client, _) in &rows {
             let mut context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer.clone());
             context.meta = per_request_meta(ProtocolVersion::V_2026_07_28, client.clone());
-            ServerHandler::call_tool(&server, local_call(), context)
-                .await
-                .unwrap_or_else(|e| panic!("{row}: a per-request call is served: {e}"));
+            bounded(
+                &format!("{row}: the in-process call"),
+                ServerHandler::call_tool(&server, local_call(), context),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("{row}: a per-request call is served: {e}"));
         }
 
         let events = read_audit_events(&audit_path);
@@ -7674,11 +7707,14 @@ mod tests {
         let (client_io, server_io) = tokio::io::duplex(1 << 16);
         let serving = server.clone();
         let task = tokio::spawn(async move { serving.serve(server_io).await });
-        let _client = InitializeRequestParams::new(
-            ClientCapabilities::default(),
-            Implementation::new(name.to_owned(), "1"),
+        let _client = bounded(
+            "the MCP handshake",
+            InitializeRequestParams::new(
+                ClientCapabilities::default(),
+                Implementation::new(name.to_owned(), "1"),
+            )
+            .serve(client_io),
         )
-        .serve(client_io)
         .await
         .expect("MCP handshake must succeed");
         task.await
@@ -7720,9 +7756,12 @@ mod tests {
             "no version key, so this request belongs to the handshake arm"
         );
 
-        ServerHandler::call_tool(&server, local_call(), context)
-            .await
-            .expect("an ordinary in-session call is served");
+        bounded(
+            "the in-process call",
+            ServerHandler::call_tool(&server, local_call(), context),
+        )
+        .await
+        .expect("an ordinary in-session call is served");
 
         let events = read_audit_events(&audit_path);
         let calls = tool_calls(&events);
@@ -7764,9 +7803,12 @@ mod tests {
             ProtocolVersion::V_2026_07_28,
             Some(json!({ "name": "stdio-client", "version": "1" })),
         );
-        ServerHandler::call_tool(&server, local_call(), context)
-            .await
-            .expect("a per-request call is served over stdio too");
+        bounded(
+            "the in-process call",
+            ServerHandler::call_tool(&server, local_call(), context),
+        )
+        .await
+        .expect("a per-request call is served over stdio too");
 
         let events = read_audit_events(&audit_path);
         let calls: Vec<&AuditEvent> = events
@@ -7807,11 +7849,14 @@ mod tests {
         let (client_io, server_io) = tokio::io::duplex(1 << 16);
         let serving = server.clone();
         let task = tokio::spawn(async move { serving.serve(server_io).await });
-        let _client = InitializeRequestParams::new(
-            ClientCapabilities::default(),
-            Implementation::new(long_name.clone(), long_version.clone()),
+        let _client = bounded(
+            "the MCP handshake",
+            InitializeRequestParams::new(
+                ClientCapabilities::default(),
+                Implementation::new(long_name.clone(), long_version.clone()),
+            )
+            .serve(client_io),
         )
-        .serve(client_io)
         .await
         .expect("MCP handshake must succeed");
         let peer = task
@@ -7826,9 +7871,12 @@ mod tests {
             ProtocolVersion::V_2026_07_28,
             Some(json!({ "name": long_name, "version": long_version })),
         );
-        ServerHandler::call_tool(&server, local_call(), context)
-            .await
-            .expect("a per-request call is served");
+        bounded(
+            "the in-process call",
+            ServerHandler::call_tool(&server, local_call(), context),
+        )
+        .await
+        .expect("a per-request call is served");
 
         let events = read_audit_events(&audit_path);
         let recorded: Vec<&audit::ClientInfo> = events
@@ -7906,10 +7954,13 @@ mod tests {
             if *out_of_contract {
                 context.meta = per_request_meta(ProtocolVersion::V_2025_06_18, None);
             }
-            ServerHandler::call_tool(
-                &server,
-                CallToolRequestParams::new((*sent).to_string()),
-                context,
+            bounded(
+                &format!("the {sent} call"),
+                ServerHandler::call_tool(
+                    &server,
+                    CallToolRequestParams::new((*sent).to_string()),
+                    context,
+                ),
             )
             .await
             .expect_err("refused either way, and the refusal is not what moves");
@@ -7976,10 +8027,13 @@ mod tests {
             if out_of_contract {
                 context.meta = per_request_meta(ProtocolVersion::V_2025_06_18, None);
             }
-            ServerHandler::call_tool(
-                &server,
-                CallToolRequestParams::new("no_such_tool".to_string()),
-                context,
+            bounded(
+                "the no_such_tool call",
+                ServerHandler::call_tool(
+                    &server,
+                    CallToolRequestParams::new("no_such_tool".to_string()),
+                    context,
+                ),
             )
             .await
             .expect_err("refused either way, and the refusal is not what moves");
@@ -8027,10 +8081,13 @@ mod tests {
         }) else {
             panic!("tool arguments must be a JSON object");
         };
-        ServerHandler::call_tool(
-            &server,
-            CallToolRequestParams::new("bug_url".to_string()).with_arguments(args),
-            context,
+        bounded(
+            "the bug_url call",
+            ServerHandler::call_tool(
+                &server,
+                CallToolRequestParams::new("bug_url".to_string()).with_arguments(args),
+                context,
+            ),
         )
         .await
         .expect("an off-schema object key is ignored, not rejected");
@@ -8101,10 +8158,13 @@ mod tests {
             .with_audit(Arc::clone(&audit));
         let peer = peer_of(&server).await;
         let context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer);
-        ServerHandler::call_tool(
-            &server,
-            CallToolRequestParams::new("bug_url".to_string()).with_arguments(args),
-            context,
+        bounded(
+            "the bug_url call",
+            ServerHandler::call_tool(
+                &server,
+                CallToolRequestParams::new("bug_url".to_string()).with_arguments(args),
+                context,
+            ),
         )
         .await
         .expect("off-schema keys are ignored, not rejected");
@@ -8244,7 +8304,11 @@ mod tests {
                 serde_json::from_value(json!(declared)).expect("a wire revision parses");
             let mut context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer.clone());
             context.meta = per_request_meta(version, None);
-            let answer = ServerHandler::call_tool(&server, local_call(), context).await;
+            let answer = bounded(
+                &format!("{declared}: the in-process call"),
+                ServerHandler::call_tool(&server, local_call(), context),
+            )
+            .await;
             assert_eq!(
                 answer.is_ok(),
                 served,
@@ -8265,9 +8329,12 @@ mod tests {
         // And a request declaring nothing keeps the handshake arm: the
         // session's own revision never routes a request per-request.
         let context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer);
-        ServerHandler::call_tool(&server, local_call(), context)
-            .await
-            .expect("an ordinary in-session call is served");
+        bounded(
+            "the in-process call",
+            ServerHandler::call_tool(&server, local_call(), context),
+        )
+        .await
+        .expect("an ordinary in-session call is served");
     }
 
     #[tokio::test]
@@ -8297,7 +8364,12 @@ mod tests {
             async move {
                 let context = context_with_scope(peer, Some(Scope::Read));
                 let params = CallToolRequestParams::new(name.to_string());
-                match ServerHandler::call_tool(&server, params, context).await {
+                match bounded(
+                    &format!("the {name} call"),
+                    ServerHandler::call_tool(&server, params, context),
+                )
+                .await
+                {
                     Ok(ok) => format!("ok {ok:?}"),
                     Err(e) => format!("err {e}"),
                 }
@@ -8383,7 +8455,9 @@ mod tests {
         let (client_io, server_io) = tokio::io::duplex(1 << 16);
         let serving = server.clone();
         let server_task = tokio::spawn(async move { serving.serve(server_io).await });
-        let _client = ().serve(client_io).await.expect("MCP handshake must succeed");
+        let _client = bounded("the MCP handshake", ().serve(client_io))
+            .await
+            .expect("MCP handshake must succeed");
         let running = server_task
             .await
             .expect("serve task must not panic")
@@ -8403,9 +8477,12 @@ mod tests {
             "the hand-built context must carry no meta — the params struct is the only source"
         );
 
-        let result = ServerHandler::call_tool(&server, params, context)
-            .await
-            .expect("the in-process call must not be a protocol error");
+        let result = bounded(
+            "the traced in-process call",
+            ServerHandler::call_tool(&server, params, context),
+        )
+        .await
+        .expect("the in-process call must not be a protocol error");
         let CallToolResponse::Complete(result) = result else {
             panic!("a served tool call completes; this build serves no other response kind")
         };
@@ -8460,9 +8537,12 @@ mod tests {
         request_row.meta = per_request_meta(ProtocolVersion::V_2026_07_28, None);
 
         for (row, context) in [("negotiated session", session_row), ("_meta", request_row)] {
-            let listed = ServerHandler::list_tools(&server, None, context)
-                .await
-                .expect("a 2026 listing is served");
+            let listed = bounded(
+                &format!("{row}: the in-process tools/list"),
+                ServerHandler::list_tools(&server, None, context),
+            )
+            .await
+            .expect("a 2026 listing is served");
             // On the JSON, not the enum: the wire spelling is what a caching
             // intermediary reads, and `CacheScope` renames lowercase.
             let json = serde_json::to_value(&listed).expect("the listing must serialize");
@@ -8522,9 +8602,12 @@ mod tests {
             ("no peer info", bare),
         ] {
             let context = RequestContext::<RoleServer>::new(RequestId::Number(1), peer);
-            let listed = ServerHandler::list_tools(&server, None, context)
-                .await
-                .expect("a legacy listing is served, not refused");
+            let listed = bounded(
+                &format!("{row}: the in-process tools/list"),
+                ServerHandler::list_tools(&server, None, context),
+            )
+            .await
+            .expect("a legacy listing is served, not refused");
             let json = serde_json::to_value(&listed).expect("the listing must serialize");
             assert!(
                 json.get("ttlMs").is_none(),
@@ -8609,8 +8692,7 @@ mod tests {
                 Implementation::new(name, "1"),
             )
             .with_protocol_version(asked);
-            let client = probe
-                .serve(client_io)
+            let client = bounded("the MCP handshake", probe.serve(client_io))
                 .await
                 .expect("the handshake must succeed");
 
@@ -8661,7 +8743,9 @@ mod tests {
         let (client_io, server_io) = tokio::io::duplex(1 << 16);
         let serving = server.clone();
         let server_task = tokio::spawn(async move { serving.serve(server_io).await });
-        let client = ().serve(client_io).await.expect("the handshake must succeed");
+        let client = bounded("the MCP handshake", ().serve(client_io))
+            .await
+            .expect("the handshake must succeed");
         // Held, not dropped: this is the live session's own peer, and it is
         // the only way to read back what the handler stored.
         let running = server_task
@@ -8689,11 +8773,13 @@ mod tests {
         // 2026-07-28 is served, and moves the session in the last row.
         let asked: ProtocolVersion =
             serde_json::from_value(json!("9999-01-01")).expect("a wire revision parses");
-        let answered = client
-            .peer()
-            .send_request(ClientRequest::InitializeRequest(InitializeRequest::new(
-                ClientInfo::default().with_protocol_version(asked),
-            )))
+        let second =
+            client
+                .peer()
+                .send_request(ClientRequest::InitializeRequest(InitializeRequest::new(
+                    ClientInfo::default().with_protocol_version(asked),
+                )));
+        let answered = bounded("the second initialize", second)
             .await
             .expect("a second initialize is answered, not dropped");
         let ServerResult::InitializeResult(answered) = answered else {
@@ -8721,15 +8807,16 @@ mod tests {
         // mirror of the one fixed: stored disagreeing with answered. Both
         // ends of the served range, so a list that lost either end fails.
         for probe in [ProtocolVersion::V_2024_11_05, ProtocolVersion::V_2026_07_28] {
-            let answered = client
-                .peer()
-                .send_request(ClientRequest::InitializeRequest(InitializeRequest::new(
+            let again = client.peer().send_request(ClientRequest::InitializeRequest(
+                InitializeRequest::new(
                     InitializeRequestParams::new(
                         ClientCapabilities::default(),
                         Implementation::new("renegotiating-client", "9.9"),
                     )
                     .with_protocol_version(probe.clone()),
-                )))
+                ),
+            ));
+            let answered = bounded(&format!("{probe}: the renegotiating initialize"), again)
                 .await
                 .expect("a supported renegotiation is answered");
             let ServerResult::InitializeResult(answered) = answered else {
@@ -8826,11 +8913,8 @@ mod tests {
                 let _ = running.waiting().await;
             }
         });
-        // Bounded: a handler that never answers should fail this test, not
-        // stall the run until CI's own timeout kills it.
-        let client = tokio::time::timeout(std::time::Duration::from_secs(10), ().serve(client_io))
+        let client = bounded("the MCP handshake", ().serve(client_io))
             .await
-            .expect("the handshake must not hang")
             .expect("the handshake must succeed");
 
         let advertised = client

--- a/crates/bugwarden/tests/audit_wiremock.rs
+++ b/crates/bugwarden/tests/audit_wiremock.rs
@@ -28,9 +28,12 @@ use serde_json::{json, Value};
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+#[path = "common/deadline.rs"]
+mod deadline;
 #[path = "common/pinned_cli.rs"]
 mod pinned_cli;
 
+use deadline::bounded;
 use pinned_cli::pinned;
 
 /// The pin's own self-check, run in each binary that relies on it so a
@@ -107,7 +110,9 @@ async fn audited_client_with(
             let _ = running.waiting().await;
         }
     });
-    let client = ().serve(client_io).await.expect("MCP handshake must succeed");
+    let client = bounded("the MCP handshake", ().serve(client_io))
+        .await
+        .expect("MCP handshake must succeed");
     Audited {
         client,
         audit_path,
@@ -138,7 +143,7 @@ async fn plain_client_for(policy: &str, mock: &MockServer) -> RunningService<Rol
             let _ = running.waiting().await;
         }
     });
-    ().serve(client_io)
+    bounded("the MCP handshake", ().serve(client_io))
         .await
         .expect("MCP handshake must succeed")
 }
@@ -147,10 +152,12 @@ async fn call(client: &RunningService<RoleClient, ()>, tool: &str, args: Value) 
     let Value::Object(args) = args else {
         panic!("tool arguments must be a JSON object");
     };
-    client
-        .call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(args))
-        .await
-        .expect("tool call must not be a protocol error")
+    bounded(
+        &format!("the {tool} call"),
+        client.call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(args)),
+    )
+    .await
+    .expect("tool call must not be a protocol error")
 }
 
 /// Parse every line of the audit file (empty lines skipped, as the sink's
@@ -360,9 +367,7 @@ async fn every_routed_tool_writes_exactly_one_record_per_call() {
     // (I16) — is exercised by this one-record-per-call guarantee (I15).
     let audited = audited_client_for("[global]\nallow_discovery = true\n", &mock, "test-key").await;
 
-    let tools = audited
-        .client
-        .list_all_tools()
+    let tools = bounded("tools/list", audited.client.list_all_tools())
         .await
         .expect("list_tools must succeed");
     assert!(!tools.is_empty(), "the router lists the tool surface");
@@ -618,15 +623,20 @@ async fn unknown_and_stripped_tools_error_identically_and_still_record() {
 
     // Unknown tool: the same protocol error with auditing on or off,
     // plus exactly one record with outcome error.
-    let with_audit = audited
-        .client
-        .call_tool(CallToolRequestParams::new("no_such_tool".to_string()))
-        .await
-        .expect_err("unknown tool is a protocol error");
-    let without = plain
-        .call_tool(CallToolRequestParams::new("no_such_tool".to_string()))
-        .await
-        .expect_err("unknown tool is a protocol error");
+    let with_audit = bounded(
+        "the audited no_such_tool call",
+        audited
+            .client
+            .call_tool(CallToolRequestParams::new("no_such_tool".to_string())),
+    )
+    .await
+    .expect_err("unknown tool is a protocol error");
+    let without = bounded(
+        "the unaudited no_such_tool call",
+        plain.call_tool(CallToolRequestParams::new("no_such_tool".to_string())),
+    )
+    .await
+    .expect_err("unknown tool is a protocol error");
     assert_eq!(
         format!("{with_audit:?}"),
         format!("{without:?}"),
@@ -643,29 +653,32 @@ async fn unknown_and_stripped_tools_error_identically_and_still_record() {
     assert!(tc.guard.is_none(), "no guard ran for an unknown tool");
 
     // A write tool stripped by read-only mode (I13) is an unknown tool.
-    let with_audit = audited
-        .client
-        .call_tool(
+    let with_audit = bounded(
+        "the audited add_comment call",
+        audited.client.call_tool(
             CallToolRequestParams::new("add_comment".to_string()).with_arguments(
                 serde_json::Map::from_iter([
                     ("bug_id".to_string(), json!(7)),
                     ("comment".to_string(), json!("hi")),
                 ]),
             ),
-        )
-        .await
-        .expect_err("a stripped tool is a protocol error");
-    let without = plain
-        .call_tool(
+        ),
+    )
+    .await
+    .expect_err("a stripped tool is a protocol error");
+    let without = bounded(
+        "the unaudited add_comment call",
+        plain.call_tool(
             CallToolRequestParams::new("add_comment".to_string()).with_arguments(
                 serde_json::Map::from_iter([
                     ("bug_id".to_string(), json!(7)),
                     ("comment".to_string(), json!("hi")),
                 ]),
             ),
-        )
-        .await
-        .expect_err("a stripped tool is a protocol error");
+        ),
+    )
+    .await
+    .expect_err("a stripped tool is a protocol error");
     assert_eq!(format!("{with_audit:?}"), format!("{without:?}"));
     let events = read_events(&audited.audit_path);
     assert_eq!(events.len(), 3, "one more record for the stripped call");
@@ -679,15 +692,20 @@ async fn unknown_and_stripped_tools_error_identically_and_still_record() {
     // file and the OTLP export, and it is recorded whatever it is. Four
     // times the cap, through the real transport.
     let huge = "z".repeat(RECORDED_MAX_CHARS * 4);
-    let with_audit = audited
-        .client
-        .call_tool(CallToolRequestParams::new(huge.clone()))
-        .await
-        .expect_err("an unknown tool is a protocol error whatever its length");
-    let without = plain
-        .call_tool(CallToolRequestParams::new(huge.clone()))
-        .await
-        .expect_err("an unknown tool is a protocol error whatever its length");
+    let with_audit = bounded(
+        "the audited oversized-name call",
+        audited
+            .client
+            .call_tool(CallToolRequestParams::new(huge.clone())),
+    )
+    .await
+    .expect_err("an unknown tool is a protocol error whatever its length");
+    let without = bounded(
+        "the unaudited oversized-name call",
+        plain.call_tool(CallToolRequestParams::new(huge.clone())),
+    )
+    .await
+    .expect_err("an unknown tool is a protocol error whatever its length");
     assert_eq!(
         format!("{with_audit:?}"),
         format!("{without:?}"),
@@ -2552,11 +2570,14 @@ async fn a_protocol_error_records_no_response_size() {
     mount_fixture(&mock).await;
     let audited = audited_client_for("", &mock, "test-key").await;
 
-    let err = audited
-        .client
-        .call_tool(CallToolRequestParams::new("no_such_tool".to_string()))
-        .await
-        .expect_err("an unknown tool is a protocol error");
+    let err = bounded(
+        "the no_such_tool call",
+        audited
+            .client
+            .call_tool(CallToolRequestParams::new("no_such_tool".to_string())),
+    )
+    .await
+    .expect_err("an unknown tool is a protocol error");
     drop(err);
 
     let events = read_events(&audited.audit_path);

--- a/crates/bugwarden/tests/binary_shutdown.rs
+++ b/crates/bugwarden/tests/binary_shutdown.rs
@@ -76,12 +76,16 @@ use tokio::process::Child;
 use tokio::process::ChildStdin;
 use tokio::process::Command;
 
+#[path = "common/deadline.rs"]
+mod deadline;
+
 #[path = "common/scrub_env.rs"]
 mod scrub_env;
 
 #[path = "common/startup_line.rs"]
 mod startup_line;
 
+use deadline::bounded;
 use startup_line::HTTP_READY;
 
 /// Bounded so a binary that ignores the signal fails this test rather than
@@ -605,7 +609,7 @@ async fn connect_insecure(addr: SocketAddr) -> RunningService<RoleClient, ()> {
         reqwest::Client::new(),
         StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp")),
     );
-    ().serve(transport)
+    bounded("the MCP handshake", ().serve(transport))
         .await
         .expect("MCP handshake must succeed under --insecure-no-auth")
 }

--- a/crates/bugwarden/tests/common/deadline.rs
+++ b/crates/bugwarden/tests/common/deadline.rs
@@ -1,0 +1,64 @@
+//! The deadline these harnesses hold every request to, and the helper that
+//! applies it to a future (#254). A hand-built POST has no single future
+//! to wrap and takes the same number from `common/raw_client.rs` instead.
+//!
+//! Included by `#[path]` from each user rather than declared in
+//! `common/mod.rs`: that module is compiled into every test binary that
+//! says `mod common;`, so a helper only some of them use would be
+//! `dead_code` in the rest, which `-D warnings` rejects (#167, #214). Only
+//! two binaries say it, and most of the client-driving harnesses are not
+//! among them.
+
+use std::future::Future;
+use std::time::Duration;
+
+/// Bound on every request one of these harnesses awaits an answer to.
+///
+/// rmcp 3.1.4 sends with `PeerRequestOptions::default()`, whose `timeout`
+/// is `None` (`service.rs`), and the `initialize` handshake reads its
+/// response off the transport with no deadline either. So a request the
+/// server never answers waits forever: it hangs its test, its whole test
+/// binary, and — cargo runs the `bugwarden` crate's binaries before
+/// `bugwarden-core`'s — every binary queued behind it. A defect must fail
+/// ONE test, not decide how long the run takes; under cargo-mutants it must
+/// come back CAUGHT rather than TIMEOUT with the verdict unknown.
+///
+/// 30s is far above anything legitimate here. None of the harnesses that
+/// include this file delays a mock reply — the workspace's one
+/// `set_delay` sits in bugwarden-core's `guard_wiremock`, which drives no
+/// rmcp client — and every mock listens on loopback, so what this bounds
+/// is milliseconds: across the green suite the slowest of 480 bounded
+/// executions took 49ms. What it bounds is one REQUEST, which is why a
+/// binary's wall time is the wrong quantity to compare against — that
+/// moves with `--test-threads` (the slowest of these binaries is 2.0s at
+/// 32 and 5.8s at 2) while a single request does not.
+///
+/// The addresses aimed at a dead port refuse at connect instead of
+/// hanging: `common/refused.rs` panics rather than hand out one that timed
+/// out, and the single tool call routed through one carries a tighter
+/// bound of its own (`REFUSED_CONNECT_BUDGET`, 2s) that fires first and
+/// keeps its own message. A blackholed upstream is the case this value
+/// could not absorb, and it would not cost one leg: `BugzillaClient`'s own
+/// 30s timeout is per HTTP request, and one tool call can issue several in
+/// sequence — up to `SEARCH_SCAN_REQUESTS` (10) behind a guarded search,
+/// one per named field for `bug_fields`. Such a test would need minutes
+/// here, not a nudge; none exists, and writing one means revisiting this
+/// constant rather than assuming it already covers the case.
+///
+/// `server.rs`'s test module declares this number a second time, because a
+/// `#[cfg(test)]` module in the library cannot reach `tests/`. The two are
+/// equal by hand and nothing checks it, so a change here is a change
+/// there.
+pub const CALL_DEADLINE: Duration = Duration::from_secs(30);
+
+/// Await `fut` under [`CALL_DEADLINE`], panicking if it does not resolve.
+///
+/// `what` names the request, because the panic is all a reader of a CI log
+/// gets: "a deadline fired" is not a diagnosis. The value is passed
+/// through untouched, so a caller keeps its own `expect`/`expect_err` on
+/// the request's own `Result`.
+pub async fn bounded<T>(what: &str, fut: impl Future<Output = T>) -> T {
+    tokio::time::timeout(CALL_DEADLINE, fut)
+        .await
+        .unwrap_or_else(|_| panic!("{what} was not answered within {CALL_DEADLINE:?}"))
+}

--- a/crates/bugwarden/tests/common/raw_client.rs
+++ b/crates/bugwarden/tests/common/raw_client.rs
@@ -1,0 +1,33 @@
+//! A reqwest client for the harnesses that POST to `/mcp` by hand, under
+//! the same deadline every other request in the suite carries (#254).
+//!
+//! Included by `#[path]` from each user rather than declared in
+//! `common/mod.rs`: that module is compiled into every test binary that
+//! says `mod common;`, so a helper only two of them use would be
+//! `dead_code` in the rest, which `-D warnings` rejects (#167, #214). A
+//! sibling of `common/deadline.rs` rather than an item inside it for that
+//! same reason: six binaries need `bounded`, only two need this.
+
+/// A reqwest client carrying `CALL_DEADLINE` as a total request deadline.
+///
+/// These harnesses hand-build POSTs that no rmcp client would send, and
+/// they reach the same `dispatch` a session request does — so they need
+/// the same bound. `bounded` cannot give it to them: `send()` resolves
+/// when the response HEADERS arrive and the body, which for the
+/// per-request path is an SSE stream, is read afterwards, so a server that
+/// answered a header and then stopped would still park the test.
+/// `ClientBuilder::timeout` spans both halves — reqwest documents it as
+/// running from the start of the connect until the body has finished — and
+/// every request built from the client inherits it, so the deadline is set
+/// once here instead of at each call. `Client::new()` sets none at all.
+///
+/// The number is read out of `common/deadline.rs` rather than repeated
+/// here: two constants that must agree and are written down twice are two
+/// constants that drift apart. A binary including this file must therefore
+/// include that one as well, and the compiler says so if it does not.
+pub fn raw_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(crate::deadline::CALL_DEADLINE)
+        .build()
+        .expect("reqwest client")
+}

--- a/crates/bugwarden/tests/http_auth_wiremock.rs
+++ b/crates/bugwarden/tests/http_auth_wiremock.rs
@@ -52,6 +52,12 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 #[path = "common/raw_post.rs"]
 mod raw_post;
 
+#[path = "common/deadline.rs"]
+mod deadline;
+
+#[path = "common/raw_client.rs"]
+mod raw_client;
+
 #[path = "common/pinned_cli.rs"]
 mod pinned_cli;
 
@@ -61,7 +67,9 @@ mod scrub_env;
 #[path = "common/startup_line.rs"]
 mod startup_line;
 
+use deadline::bounded;
 use pinned_cli::pinned;
+use raw_client::raw_client;
 
 /// The pin's own self-check, run in each binary that relies on it so a
 /// single-binary `cargo test --test ...` still proves what its harness
@@ -176,15 +184,14 @@ async fn connect(addr: SocketAddr, token: Option<&str>) -> RunningService<RoleCl
         client,
         StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp")),
     );
-    ().serve(transport)
+    bounded("the MCP handshake", ().serve(transport))
         .await
         .expect("MCP handshake must succeed")
 }
 
 /// The tool names this credential is offered.
 async fn listed_tools(client: &RunningService<RoleClient, ()>) -> Vec<String> {
-    client
-        .list_all_tools()
+    bounded("tools/list", client.list_all_tools())
         .await
         .expect("tools/list must succeed")
         .into_iter()
@@ -268,7 +275,7 @@ async fn every_unauthenticated_request_gets_one_byte_identical_refusal() {
         .mount(&mock)
         .await;
     let addr = serve_guarded(&mock, &both_tokens(), false).await;
-    let http = reqwest::Client::new();
+    let http = raw_client();
     let mcp = format!("http://{addr}/mcp");
 
     let baseline = probe(&http, &mcp, &[]).await;
@@ -387,17 +394,19 @@ async fn the_write_token_reaches_the_whole_tool_surface() {
     }
     assert!(listed.iter().any(|t| t == "bug_info"), "{listed:?}");
 
-    let result = client
-        .call_tool(
+    let result = bounded(
+        "the add_comment call",
+        client.call_tool(
             CallToolRequestParams::new("add_comment".to_owned()).with_arguments(
                 json!({ "bug_id": 7, "comment": "hello" })
                     .as_object()
                     .expect("object")
                     .clone(),
             ),
-        )
-        .await
-        .expect("the write scope must reach a write tool");
+        ),
+    )
+    .await
+    .expect("the write scope must reach a write tool");
     assert_ne!(result.is_error, Some(true), "{result:?}");
 }
 
@@ -446,38 +455,44 @@ async fn a_read_scope_write_call_is_refused_as_unrouted_and_reaches_no_bugzilla(
 
     // A read tool still works, so the refusal below is about the scope and
     // not about the session being broken.
-    let served = client
-        .call_tool(
+    let served = bounded(
+        "the bug_info call",
+        client.call_tool(
             CallToolRequestParams::new("bug_info".to_owned()).with_arguments(
                 json!({ "bug_ids": [7] })
                     .as_object()
                     .expect("object")
                     .clone(),
             ),
-        )
-        .await
-        .expect("the read scope must reach a read tool");
+        ),
+    )
+    .await
+    .expect("the read scope must reach a read tool");
     assert_ne!(served.is_error, Some(true), "{served:?}");
 
-    let refused = client
-        .call_tool(
+    let refused = bounded(
+        "the scope-refused add_comment call",
+        client.call_tool(
             CallToolRequestParams::new("add_comment".to_owned()).with_arguments(
                 json!({ "bug_id": 7, "comment": "hello" })
                     .as_object()
                     .expect("object")
                     .clone(),
             ),
-        )
-        .await
-        .expect_err("the read scope must not reach a write tool");
+        ),
+    )
+    .await
+    .expect_err("the read scope must not reach a write tool");
 
     // Compared against the router's OWN answer for a name it does not route,
     // not against a literal: a scope-hidden tool must be indistinguishable
     // from one that does not exist, and this stays true across rmcp bumps.
-    let unknown = client
-        .call_tool(CallToolRequestParams::new("no_such_tool_at_all".to_owned()))
-        .await
-        .expect_err("an unknown tool is an error");
+    let unknown = bounded(
+        "the no_such_tool_at_all call",
+        client.call_tool(CallToolRequestParams::new("no_such_tool_at_all".to_owned())),
+    )
+    .await
+    .expect_err("an unknown tool is an error");
     assert_eq!(
         refused.to_string(),
         unknown.to_string(),
@@ -509,7 +524,7 @@ async fn per_request_post(
         "io.modelcontextprotocol/protocolVersion": PER_REQUEST_REVISION,
         "io.modelcontextprotocol/clientCapabilities": {},
     });
-    let mut builder = reqwest::Client::new()
+    let mut builder = raw_client()
         .post(format!("http://{addr}/mcp"))
         .header("Accept", "application/json, text/event-stream")
         .header("Content-Type", "application/json")

--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -80,10 +80,18 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 #[path = "common/raw_post.rs"]
 mod raw_post;
 
+#[path = "common/deadline.rs"]
+mod deadline;
+
+#[path = "common/raw_client.rs"]
+mod raw_client;
+
 #[path = "common/pinned_cli.rs"]
 mod pinned_cli;
 
+use deadline::bounded;
 use pinned_cli::pinned;
+use raw_client::raw_client;
 
 /// Build the http-transport `Cli` against `mock`, with `key_file` when the
 /// test runs in server-held mode.
@@ -191,7 +199,7 @@ async fn connect(addr: SocketAddr, header_value: Option<&str>) -> RunningService
         builder.build().expect("reqwest client"),
         StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp")),
     );
-    ().serve(transport)
+    bounded("the MCP handshake", ().serve(transport))
         .await
         .expect("MCP handshake must succeed")
 }
@@ -205,9 +213,11 @@ async fn try_call(
     let Value::Object(args) = args else {
         panic!("tool arguments must be a JSON object");
     };
-    client
-        .call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(args))
-        .await
+    bounded(
+        &format!("the {tool} call"),
+        client.call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(args)),
+    )
+    .await
 }
 
 /// All text blocks of a result, concatenated.
@@ -455,7 +465,7 @@ async fn a_client_addressing_the_server_by_name_is_served() {
     let cli = http_cli(&mock, Some(file.path()));
     let addr = serve_http(cli, "", &mock, None).await;
 
-    let response = reqwest::Client::new()
+    let response = raw_client()
         .post(format!("http://{addr}/mcp"))
         .header("Host", "bugwarden.example:8080")
         .header("Accept", "application/json, text/event-stream")
@@ -498,7 +508,7 @@ async fn allowed_hosts_serve_the_named_authority_and_refuse_the_others() {
     let addr = serve_http(Arc::new(cli), "", &mock, None).await;
 
     for (host, served) in [("bugwarden.example:8080", true), ("evil.example", false)] {
-        let response = reqwest::Client::new()
+        let response = raw_client()
             .post(format!("http://{addr}/mcp"))
             .header("Host", host)
             .header("Accept", "application/json, text/event-stream")
@@ -538,7 +548,7 @@ async fn an_allowed_hosts_entry_naming_no_host_leaves_validation_off() {
     cli.allowed_hosts = vec![String::new()];
     let addr = serve_http(Arc::new(cli), "", &mock, None).await;
 
-    let response = reqwest::Client::new()
+    let response = raw_client()
         .post(format!("http://{addr}/mcp"))
         .header("Host", "bugwarden.example:8080")
         .header("Accept", "application/json, text/event-stream")
@@ -622,7 +632,7 @@ async fn a_handshake_free_call_is_refused_and_never_names_a_client() {
     let addr = serve_http(cli, "", &mock, Some(audit)).await;
 
     // Raw HTTP: no rmcp client will build this request, which is the point.
-    let response = reqwest::Client::new()
+    let response = raw_client()
         .post(format!("http://{addr}/mcp"))
         .header("Accept", "application/json, text/event-stream")
         .header("Content-Type", "application/json")
@@ -702,7 +712,7 @@ async fn discover_names_this_build_and_reaches_nothing_else() {
     let cli = http_cli(&mock, Some(file.path()));
     let addr = serve_http(cli, "", &mock, None).await;
 
-    let response = reqwest::Client::new()
+    let response = raw_client()
         .post(format!("http://{addr}/mcp"))
         .header("Accept", "application/json, text/event-stream")
         .header("Content-Type", "application/json")
@@ -914,8 +924,7 @@ async fn traceparent_over_http_lands_in_the_audit_record() {
     let mut meta = rmcp::model::RequestMetaObject::new();
     meta.set_traceparent(traceparent);
     params.meta = Some(meta);
-    let traced = client
-        .call_tool(params)
+    let traced = bounded("the traced bug_info call", client.call_tool(params))
         .await
         .expect("a traced bug_info must not be a protocol error");
 

--- a/crates/bugwarden/tests/otel_wiremock.rs
+++ b/crates/bugwarden/tests/otel_wiremock.rs
@@ -29,11 +29,14 @@ use serde_json::{json, Value};
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+#[path = "common/deadline.rs"]
+mod deadline;
 #[path = "common/pinned_cli.rs"]
 mod pinned_cli;
 #[path = "common/refused.rs"]
 mod refused;
 
+use deadline::bounded;
 use pinned_cli::pinned;
 
 /// The pin's own self-check, run in each binary that relies on it so a
@@ -275,7 +278,9 @@ async fn server_with_sinks(
             let _ = running.waiting().await;
         }
     });
-    let client = ().serve(client_io).await.expect("MCP handshake must succeed");
+    let client = bounded("the MCP handshake", ().serve(client_io))
+        .await
+        .expect("MCP handshake must succeed");
     Exported {
         client,
         audit,
@@ -362,8 +367,7 @@ async fn call(
         meta.set_traceparent(traceparent);
         params.meta = Some(meta);
     }
-    client
-        .call_tool(params)
+    bounded(&format!("the {tool} call"), client.call_tool(params))
         .await
         .expect("tool call must not be a protocol error")
 }

--- a/crates/bugwarden/tests/tools_wiremock.rs
+++ b/crates/bugwarden/tests/tools_wiremock.rs
@@ -35,11 +35,14 @@ use serde_json::{json, Value};
 use wiremock::matchers::{body_partial_json, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+#[path = "common/deadline.rs"]
+mod deadline;
 #[path = "common/pinned_cli.rs"]
 mod pinned_cli;
 #[path = "common/refused.rs"]
 mod refused;
 
+use deadline::bounded;
 use pinned_cli::pinned;
 
 /// The pin's own self-check, run in each binary that relies on it so a
@@ -81,7 +84,7 @@ async fn client_for(policy: &str, mock: &MockServer) -> RunningService<RoleClien
             let _ = running.waiting().await;
         }
     });
-    ().serve(client_io)
+    bounded("the MCP handshake", ().serve(client_io))
         .await
         .expect("MCP handshake must succeed")
 }
@@ -91,10 +94,12 @@ async fn call(client: &RunningService<RoleClient, ()>, tool: &str, args: Value) 
     let Value::Object(args) = args else {
         panic!("tool arguments must be a JSON object");
     };
-    client
-        .call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(args))
-        .await
-        .expect("tool call must not be a protocol error")
+    bounded(
+        &format!("the {tool} call"),
+        client.call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(args)),
+    )
+    .await
+    .expect("tool call must not be a protocol error")
 }
 
 /// All text blocks of a result, concatenated.
@@ -1809,8 +1814,7 @@ async fn mark_as_duplicate_sends_only_dupe_of_and_comment() {
 /// `tools/list` request over the wire, so the handler's own listing path
 /// is what answers.
 async fn listed_tools(client: &RunningService<RoleClient, ()>) -> Vec<String> {
-    client
-        .list_all_tools()
+    bounded("tools/list", client.list_all_tools())
         .await
         .expect("list_tools must succeed")
         .into_iter()
@@ -2545,10 +2549,9 @@ async fn whoami_transport_error_does_not_leak_the_api_key_i12() {
             let _ = running.waiting().await;
         }
     });
-    let client: RunningService<RoleClient, ()> =
-        ().serve(client_io)
-            .await
-            .expect("MCP handshake must succeed");
+    let client: RunningService<RoleClient, ()> = bounded("the MCP handshake", ().serve(client_io))
+        .await
+        .expect("MCP handshake must succeed");
 
     let result = tokio::time::timeout(
         common::REFUSED_CONNECT_BUDGET,
@@ -2859,8 +2862,7 @@ async fn bug_fields_over_cap_makes_no_upstream_request() {
 async fn discovery_tools_absent_from_the_listing_by_default() {
     let mock = MockServer::start().await;
     let client = client_for("", &mock).await;
-    let tools = client
-        .list_all_tools()
+    let tools = bounded("tools/list", client.list_all_tools())
         .await
         .expect("list_tools must succeed");
     let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
@@ -2868,8 +2870,7 @@ async fn discovery_tools_absent_from_the_listing_by_default() {
     assert!(!names.contains(&"bug_fields"));
 
     let client = client_for(DISCOVERY_POLICY, &mock).await;
-    let tools = client
-        .list_all_tools()
+    let tools = bounded("tools/list", client.list_all_tools())
         .await
         .expect("list_tools must succeed");
     let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3258,10 +3258,18 @@ wired, `server.rs` and `main.rs` are the reference.
   payload absent from the reply and from every captured tracing line
   (#253; the probe is a panicking route added through rmcp's own
   `ToolRoute::new_dyn`, so no production path carries a test-only branch,
-  and every call is bounded by a deadline so the old defect fails a test
-  instead of hanging the run), and that recovery line is pinned at WARN
-  rather than ERROR (#270), which is a level decision and not a weakened
-  assertion — the same test also refuses a line that still says ERROR;
+  and a 30s deadline now bounds three classes of await across these tests
+  — every request sent through an rmcp client, the `initialize` handshake
+  and a re-`initialize` on a live session included; every direct
+  in-process `ServerHandler` await, `call_tool` reaching the same
+  `dispatch` with no client or transport in between and `list_tools`
+  alongside it; and every raw reqwest POST a harness aims at `/mcp`, which
+  reqwest bounds because there is no single future to wrap — so a request
+  the server never answers fails ONE test rather than parking the binary
+  and everything cargo queues behind it, #254), and that recovery line is
+  pinned at WARN rather than ERROR (#270), which is a level decision and
+  not a weakened assertion — the same test also refuses a line that still
+  says ERROR;
   the refusal map is total over the full router; responses are
   byte-identical with auditing off, on, and failing-open; suppressed ids
   are in the record and never in the envelope; content and API-key


### PR DESCRIPTION
Closes #254.

## What was wrong

Every request the test harnesses sent through an rmcp client was awaited with no deadline, and rmcp 3.1.4 sets none of its own (`PeerRequestOptions::default()` has `timeout: None`; the `initialize` handshake reads its response with no timer). Raw `reqwest::Client::new()` POSTs in two harnesses had none either. A request the server never answers therefore hung its test, its binary, and everything cargo queued behind it — and cargo runs the `bugwarden` crate's binaries before `bugwarden-core`'s. The #253 review showed it twice: a `CatchUnwind::poll` mutant returning `Pending` for a ready value, and one swapping the `Context`, each parked the in-process suite past `timeout 120` while the bounded probe cluster failed in 0 s.

## What changes (test-only; no production line moves)

- One 30 s deadline, three classes of await. Requests through an rmcp client — the six client-driving harnesses' call, list and handshake helpers, their inline `call_tool` sites, and a re-`initialize` on a live session — go through a `bounded` helper (`tests/common/deadline.rs`, `#[path]`-included per the `common/` discipline). So does every direct `ServerHandler::call_tool`/`list_tools` await in `server.rs`'s test module, which has no client but reaches the same `dispatch`. The raw POSTs in `http_auth_wiremock` and `http_transport_wiremock` take a client from `raw_client()` (`tests/common/raw_client.rs`) with reqwest's own total timeout, because `send()` resolves at the response headers and the SSE body is read afterwards.
- The panic-probe cluster's 10 s `PROBE_DEADLINE` folds into the module's one constant; the two `CALL_DEADLINE`s (lib test module and `tests/common`) name each other, since neither compilation unit can see the other.
- 62 `bounded` sites and 7 `raw_client` sites; two `peer().send_request(InitializeRequest)` awaits the issue did not list are bounded too. No wrapper changes what a test asserts: `bounded` returns the inner value untouched and every `expect`/`expect_err`/`match` stays.
- DESIGN.md's Testing bullet and a new AGENTS.md rule name the three site classes; `.cargo/mutants.toml`'s barrier list gains the deadline with its cost arithmetic.

## Evidence

With the `Pending` mutant hand-applied: before, `timeout 120 cargo test -p bugwarden --lib` is killed with 18 tests past 60 s and no result line, and `audit_wiremock`, `tools_wiremock` and `http_auth_wiremock` the same. After, every binary in the workspace terminates: the lib suite fails 22 tests in 30.6 s, `audit_wiremock` 36 in 60.4 s, `tools_wiremock` 82 in 90.6 s, `http_auth_wiremock` 3 in 30.4 s, each panic naming its request; the `Context`-swap mutant behaves the same way. The healthy suite is unchanged at ~20 s. The deadline's margin was measured per request, not per test: over 480 bounded executions on the green suite the slowest single request took 49 ms. No harness that uses the helper delays a mock; the one `set_delay` in the workspace is 200 ms in `bugwarden-core`'s `guard_wiremock`, which drives no rmcp client.

## Review before opening

Three parallel refutation-lens reviews over the uncommitted diff, then one fold pass:

- **Security / invariants — NOT MERGE-SAFE**, one real gap: `http_auth_wiremock`'s per-request POST used an untimed reqwest client and still hung the whole run under the mutant, making the new DESIGN.md and AGENTS.md sentences false. Bounded, with five sibling sites in `http_transport_wiremock`; the same binary now fails in 30.4 s. Verified sound: production byte-identical to `main` (the resume agent had already reverted a hand-applied mutant the rate-limited first agent left in `server.rs`); no assertion weakened; rmcp-client coverage complete; the reqwest 30 s upstream timeout never on a bounded path.
- **Correctness / edge cases — MERGE-SAFE.** Reproduced both mutant directions; swept every rmcp `Peer` request method across all harnesses and found none unbounded; showed the remaining bare awaits (server-side `serve` handles) cannot hang. Finding: the hang-conversion cost is `ceil(failing tests / test threads) × 30 s` per binary — `tools_wiremock` at four threads is 632 s, past the 300 s mutants floor — now stated in `mutants.toml` and tracked as #283.
- **Docs / prose — MERGE-SAFE.** Five sentences corrected: a binary wall time offered as the margin (the per-request figure replaces it), a one-leg upstream timeout mistaken for a whole call's (a search issues up to ten), direct `ServerHandler` awaits described as rmcp-client requests, an AGENTS.md rule that covered one of three site classes, and the `mutants.toml` arithmetic.

Out of scope, tracked: #283 (mutants hang budget on a small runner), #280 (`NO_BUGZILLA` is an unprobed refused-port assumption).
