### PR TITLE
fix(stdio): the over-cap refusal is a WARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,16 +415,21 @@ be provided up front via `--api-key` / `BUGZILLA_API_KEY` or `--api-key-file`
 line, bounded by the same cap as an HTTP POST body (see
 `global.max_attachment_bytes` below); a line that runs past it is refused,
 the transport closes and the process exits `1`, since nothing can be sent
-back for a request that was never parsed. The first JSON-RPC message the
-server parses has to open a session — `initialize`, or a request whose
-`_meta` declares the handshake-free lifecycle (see *MCP protocol revisions*
-below); a `ping` or a `server/discover` probe may come first and commits
-neither. A line that is no JSON-RPC message at all does not count as that
-first message: an unparsable one is dropped, a well-formed one of the wrong
-shape is answered `-32600`, and the server goes on waiting either way. Any
-other opening message ends the process with exit `1`, and there the log line
-and the `Error:` line the process exits with name only the *kind* of message
-that arrived — never its content, whose size only the cap bounds.
+back for a request that was never parsed. That refusal is logged at `WARN` —
+it is the cap doing its job, not something to page an operator about. Beside
+it the MCP library echoes the same reason at `ERROR`, and before a completed
+handshake the server adds one `ERROR` of its own, the line that reports the
+session is over; after a completed handshake the library's echo is the only
+`ERROR` there is. The first JSON-RPC message the server parses has to open a
+session — `initialize`, or a request whose `_meta` declares the handshake-free
+lifecycle (see *MCP protocol revisions* below); a `ping` or a `server/discover`
+probe may come first and commits neither. A line that is no JSON-RPC message at
+all does not count as that first message: an unparsable one is dropped, a
+well-formed one of the wrong shape is answered `-32600`, and the server goes on
+waiting either way. Any other opening message ends the process with exit `1`,
+and there the log line and the `Error:` line the process exits with name only
+the *kind* of message that arrived — never its content, whose size only the
+cap bounds.
 
 ```bash
 BUGZILLA_API_KEY=your_api_key \
@@ -627,7 +632,7 @@ Command-line arguments take precedence over environment variables.
 | — | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | — | Logs-specific endpoint. Overrides `OTEL_EXPORTER_OTLP_ENDPOINT` per the OTLP spec, and is used **as given** — write the whole URL including `/v1/logs`. Set alone it still turns export on |
 | — | `OTEL_EXPORTER_OTLP_LOGS_HEADERS` | — | Logs-specific headers; overrides `OTEL_EXPORTER_OTLP_HEADERS`. Same secrecy rules |
 | — | `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL` | — | Logs-specific protocol; overrides `OTEL_EXPORTER_OTLP_PROTOCOL`. Same single accepted value |
-| — | `RUST_LOG` | `info` | Tracing filter for the diagnostic log, which always goes to **stderr** — stdout belongs to the stdio transport. An unparsable value falls back to `info`. Whatever the filter, every FIELD of every line — the MCP library's own included — is cut at 1024 characters and has every control character and every mandatory line break escaped (U+0000–U+001F, U+007F, U+0080–U+009F, U+2028 and U+2029), so no single client string can fill the terminal, open an escape sequence in it, or end one line and start another. One limit worth knowing: the bound is per field per line and says nothing about how many lines a client can cause. Panics are reported through this filter too, never straight to the descriptor: the first panic of a process is ERROR and every later one WARN, and neither carries the panic payload, so `RUST_LOG=error` reports only the first — use `RUST_LOG=error,bugwarden::panic_hook=warn` to keep every panic on stderr under an otherwise quiet filter |
+| — | `RUST_LOG` | `info` | Tracing filter for the diagnostic log, which always goes to **stderr** — stdout belongs to the stdio transport. An unparsable value falls back to `info`. Whatever the filter, every FIELD of every line — the MCP library's own included — is cut at 1024 characters and has every control character and every mandatory line break escaped (U+0000–U+001F, U+007F, U+0080–U+009F, U+2028 and U+2029), so no single client string can fill the terminal, open an escape sequence in it, or end one line and start another. One limit worth knowing: the bound is per field per line and says nothing about how many lines a client can cause. Panics are reported through this filter too, never straight to the descriptor: the first panic of a process is ERROR and every later one WARN, and neither carries the panic payload, so `RUST_LOG=error` reports only the first — use `RUST_LOG=error,bugwarden::panic_hook=warn` to keep every panic on stderr under an otherwise quiet filter. A stdio frame over the request cap is a WARN for the other half of the same rule — a refusal the server chose is not an operator's problem. The ERROR lines beside it are the MCP library's echo of the same reason and, before a completed handshake only, the server's own line reporting that the session is over. Removing the library's echo takes `rmcp::transport::async_rw=off` (a level here is a ceiling on verbosity, so `=warn` still lets ERROR through), and it is worth keeping: that is also where a genuine stdin read failure is reported, and after the handshake it is the only report of one |
 
 An empty value counts as unset for `--api-key`, `--api-key-file`,
 `--allowed-hosts`, `BUGWARDEN_HTTP_TOKEN` and `BUGWARDEN_HTTP_READ_TOKEN`, so

--- a/crates/bugwarden/src/stdio.rs
+++ b/crates/bugwarden/src/stdio.rs
@@ -115,11 +115,22 @@ impl<R> BoundedLines<R> {
 
     /// Trip the flag, log once from bugwarden's side, and return the error.
     ///
-    /// The log matters: rmcp's own `Error reading from stream` is the only
-    /// other trace of this, and it names neither the cap nor the transport.
+    /// The log matters: this is the only line that names the byte bound it
+    /// applied. rmcp echoes this error's `Display` (`Error reading from
+    /// stream: …`), which stops before the tail added here and names
+    /// neither the bound nor the transport; before `initialize` `main` adds
+    /// a line saying the session is over, which names the refusal but not
+    /// the number.
+    ///
+    /// WARN and not ERROR (#272): the line IS the refusal, the cap doing
+    /// what it exists for, so no operator has anything to act on and a
+    /// client repeats it as often as it can reconnect. ERROR stays with
+    /// `main`'s statement that the process ended — which only the
+    /// pre-`initialize` half writes, the other bailing out of `waiting()`
+    /// silently, so a refused frame costs bugwarden one ERROR or none.
     fn trip(&mut self) -> io::Error {
         self.over_cap.store(true, Ordering::Release);
-        tracing::error!(
+        tracing::warn!(
             "stdio frame exceeds the {}-byte request cap; closing the transport",
             self.cap
         );

--- a/crates/bugwarden/tests/binary_shutdown.rs
+++ b/crates/bugwarden/tests/binary_shutdown.rs
@@ -36,6 +36,13 @@
 //!   which exits 0 on a refusal it was the point of refusing;
 //! - the over-cap frame refused BEFORE the handshake described as a peer
 //!   hangup, or in any wording but the one the post-handshake refusal uses;
+//! - the reader's refusal line raised back to ERROR, dropped to a level the
+//!   default filter hides, or deleted altogether (#272);
+//! - either `serving error` arm demoted below ERROR, which is what says the
+//!   process ended;
+//! - rmcp's echo of the reader's error removed or moved off
+//!   `rmcp::transport::async_rw`, which would leave the `RUST_LOG`
+//!   directive DESIGN.md documents addressing nothing;
 //! - either handshake-failure line formatting rmcp's error instead of the
 //!   classification, or the classification naming the wrong frame kind;
 //! - any `serve_failure` arm deleted so its failure falls to the wildcard,
@@ -118,9 +125,21 @@ const OVER_CAP_FRAME: usize = 5 * 1024 * 1024;
 /// logs anything at all — the tail after the `;` is what makes the needle
 /// bugwarden's line and not the SDK's. The cap is spelled out because the
 /// default policy derives the 4 MiB floor, so a derivation that stopped
-/// following the policy would show up here too.
+/// following the policy would show up here too. Because rmcp's echo stops
+/// short of that tail, a search for the WHOLE constant can only land on
+/// bugwarden's line — which is a WARN since #272, while rmcp's is an
+/// ERROR, so the two are told apart twice over.
 const OVER_CAP_LINE: &str =
     "stdio frame exceeds the 4194304-byte request cap; closing the transport";
+
+/// rmcp's target for that echo.
+///
+/// Named because the level rule (#272) leaves it the only ERROR a refusal
+/// writes after the handshake, and DESIGN.md documents the per-target
+/// `RUST_LOG` directive that removes it. Asserting the target keeps that
+/// documentation measured: were rmcp to move the line, the directive named
+/// there would address nothing.
+const RMCP_READ_ERROR_TARGET: &str = "rmcp::transport::async_rw";
 
 /// The refusal `main` itself reports for that frame, and the whole of the
 /// line the process then exits with.
@@ -162,6 +181,46 @@ const FILLER_CHARS: usize = 100_000;
 /// usual 1024-char bound would still fail — these two lines carry no
 /// client text at all, not a shortened copy of it.
 const FILLER_RUN: usize = 64;
+
+/// The level token of one `Full`-format stderr line, if it has one.
+///
+/// tracing writes `<timestamp> <LEVEL> [<span>: ]<target>: <message>` and
+/// the timestamp holds no space, so the second whitespace-separated token
+/// IS the level. Read positionally rather than searched for: a line whose
+/// MESSAGE contains the word `ERROR` satisfies a `contains(" ERROR ")` and
+/// does not satisfy this. `main` builds the fmt layer `.with_ansi(false)`,
+/// so no escape sequence is wrapped around the token. Lines the runtime
+/// writes rather than tracing — the `Error:` exit line — have no level and
+/// yield whatever their second word is, so callers ask about lines they
+/// have already identified.
+fn level_of(line: &str) -> Option<&str> {
+    line.split_whitespace().nth(1)
+}
+
+/// Whether one stderr line is at `level`.
+fn at_level(line: &str, level: &str) -> bool {
+    level_of(line) == Some(level)
+}
+
+/// Whether one stderr line is at `level` AND carries a target from this
+/// workspace rather than from a dependency.
+///
+/// The target follows the level and any span prefix (`serve_inner:`, on the
+/// post-handshake rows), and a target here is always a module path, so the
+/// needles are the two crates' roots with the space and colon the format
+/// brackets them with — never `rmcp::…`. `bugwarden-core` has no `error!`
+/// site today and is matched anyway, so the count below is the WORKSPACE's
+/// invariant and not one crate's. Only a message carrying one of the
+/// needles itself could forge a match, and no line these rows produce does.
+fn from_bugwarden_at(line: &str, level: &str) -> bool {
+    const TARGETS: [&str; 4] = [
+        " bugwarden: ",
+        " bugwarden::",
+        " bugwarden_core: ",
+        " bugwarden_core::",
+    ];
+    at_level(line, level) && TARGETS.iter().any(|target| line.contains(target))
+}
 
 /// A spawned binary, its pipes, and every stderr line it has written.
 struct Server {
@@ -276,6 +335,17 @@ impl Server {
     /// refusal (#261). `pre_handshake` says the refusal came out of
     /// `serve`, which additionally writes the classified `serving error`
     /// line; the post-handshake arm writes only the exit line.
+    ///
+    /// The levels are asserted here too (#272), because one refused frame
+    /// used to be three ERROR lines before the handshake and two after it.
+    /// The reader's line is a WARN — the cap doing what it exists for, and
+    /// a client repeats it by reconnecting — which leaves bugwarden one
+    /// ERROR for the whole refusal, `main` saying the process ended, and
+    /// none at all on the post-handshake row, where `main` bails out of
+    /// `waiting()` without a line. rmcp's echo is asserted to still BE an
+    /// ERROR rather than dropped from the count: it is a dependency's line
+    /// that this build documents rather than owns, and the `RUST_LOG`
+    /// directive DESIGN.md names addresses that target at that level.
     async fn assert_over_cap_exit(mut self, what: &str, pre_handshake: bool) {
         let status = tokio::time::timeout(EXIT_TIMEOUT, self.child.wait())
             .await
@@ -295,11 +365,59 @@ impl Server {
              silent close would produce: status={status:?} stderr={log}",
             log = self.log
         );
+        let refusal = self
+            .log
+            .lines()
+            .find(|line| line.contains(OVER_CAP_LINE))
+            .unwrap_or_else(|| {
+                panic!(
+                    "{what}: bugwarden must log the cap it enforced: {log}",
+                    log = self.log
+                )
+            });
+        assert_eq!(
+            level_of(refusal),
+            Some("WARN"),
+            "{what}: the refusal is the cap doing its job and a client \
+             repeats it by reconnecting, so the reader's line is a WARN and \
+             not an ERROR: {refusal}"
+        );
+        let rmcp_echo = self
+            .log
+            .lines()
+            .find(|line| line.contains(RMCP_READ_ERROR_TARGET));
         assert!(
-            self.log.contains(OVER_CAP_LINE),
-            "{what}: bugwarden must log the cap it enforced: {log}",
+            rmcp_echo.is_some_and(|line| at_level(line, "ERROR")),
+            "{what}: rmcp still echoes the reader's error at ERROR — the \
+             line DESIGN.md documents, and the reason the directive that \
+             quiets it is documented with it: {log}",
             log = self.log
         );
+        let own_errors: Vec<&str> = self
+            .log
+            .lines()
+            .filter(|line| from_bugwarden_at(line, "ERROR"))
+            .collect();
+        if pre_handshake {
+            assert_eq!(
+                own_errors.len(),
+                1,
+                "{what}: one refusal earns bugwarden one ERROR line, the one \
+                 that ends the process: {own_errors:?}"
+            );
+            assert!(
+                own_errors[0].contains(SERVING_ERROR_PREFIX),
+                "{what}: and that line is `serving error`, not the reader's \
+                 refusal wearing its level: {line}",
+                line = own_errors[0]
+            );
+        } else {
+            assert!(
+                own_errors.is_empty(),
+                "{what}: after the handshake `main` bails with no line of its \
+                 own, so bugwarden says nothing at ERROR here: {own_errors:?}"
+            );
+        }
         assert!(
             self.log.lines().any(|line| line == OVER_CAP_EXIT_LINE),
             "{what}: the process must exit naming the cap, in the one wording \
@@ -397,6 +515,18 @@ impl Server {
                 "{what}: {prefix:?} must be followed by the classification and \
                  nothing else: {line}"
             );
+            // Only the tracing line has a level; the exit line is the
+            // runtime's. ERROR because it reports that the PROCESS ended
+            // (#272) — the half of the level rule the refusal rows read
+            // from the other side.
+            if prefix == SERVING_ERROR_PREFIX {
+                assert_eq!(
+                    level_of(line),
+                    Some("ERROR"),
+                    "{what}: a handshake failure ends the process, which is \
+                     what this workspace keeps ERROR for: {line}"
+                );
+            }
             assert!(
                 line.chars().count() <= HANDSHAKE_LINE_MAX,
                 "{what}: {prefix:?} must stay under {HANDSHAKE_LINE_MAX} chars, \

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2516,12 +2516,25 @@ wired, `server.rs` and `main.rs` are the reference.
   dispatch line above is WARN for the other half of the rule: before #270
   it was the only per-request, client-repeatable ERROR in THIS
   WORKSPACE's code. `server.rs`'s sole other production `tracing::error!`
-  is behind a `Once`; of the rest, `stdio.rs`'s over-cap refusal closes
-  the transport, `main.rs`'s two serving-error arms end the process,
-  `audit.rs`'s sink diagnostic is rate-limited, and `main.rs`'s
+  is behind a `Once`; of the rest, `main.rs`'s two serving-error arms end
+  the process, `audit.rs`'s sink diagnostic is rate-limited, and `main.rs`'s
   signal-arming failure runs at most once per signal kind at startup — so
-  none of them is a lever a client can pull twice. Whether the first of
-  those is ERROR under this rule is #272's question and stays open here.
+  none of them is a lever a client can pull twice. `stdio.rs`'s over-cap
+  refusal LEFT that enumeration under this same rule (#272), and which half
+  of the rule moved it matters: a client that reconnects can cause every
+  line a refusal writes, so repeatability alone would demote all of them.
+  What separates them is the other half. The reader's line reports a
+  refusal this server made ON PURPOSE — the cap doing exactly what it is
+  configured to do, with nothing to inspect and nothing to change — so
+  there is no operator action behind it at all, and it is WARN now, text
+  unchanged. `main`'s line says something a client cannot make routine:
+  that this PROCESS is over. That is the statement every handshake-failure
+  arm makes (#261), it happens once in a process's life however often a
+  peer reconnects, and it is what the level is being kept for, so it stays
+  ERROR. The post-handshake half writes no such line — `main` bails out of
+  `waiting()` without one — so a refused frame costs bugwarden one ERROR
+  before `initialize` and none after it. What each side actually puts on
+  stderr is listed under "That number is the request cap" below.
   The linked crates are outside the enumeration: rmcp logs at ERROR on
   paths of its own, none shown to be client-repeatable on demand, and a
   panic inside any dependency now routes through this hook like any
@@ -2721,16 +2734,55 @@ wired, `server.rs` and `main.rs` are the reference.
     unrecordable, and on the same terms: no tool name, no caller, no guard
     verdict.
 
-  The stdio trace is a log line and an exit code: bugwarden's own `error!`
-  naming the cap, deliberately not rmcp's `Error reading from stream`, and
-  exit `1` at BOTH stages. Pre-handshake the refusal already propagates out
-  of `serve`; post-handshake rmcp maps the read error to `receive() -> None`,
-  which the service reports as `QuitReason::Closed` — the same `Ok` a clean
-  peer hangup produces — so `main` reads a shared over-cap flag after
-  `waiting()` and bails on it, or the same refusal would exit `0` at one
-  stage and `1` at the other. An operator diagnosing either refusal compares
-  the request size against the derived cap, because nothing server-side
-  recorded the attempt.
+  What identifies a stdio refusal is bugwarden's own `warn!` naming the cap —
+  deliberately not rmcp's `Error reading from stream`, which names neither the
+  bound nor the transport — and exit `1` at BOTH stages; the full set of lines
+  each stage writes is enumerated below. Pre-handshake the refusal already
+  propagates out of `serve`; post-handshake rmcp maps the read error to
+  `receive() -> None`, which the service reports as `QuitReason::Closed` — the
+  same `Ok` a clean peer hangup produces — so `main` reads a shared over-cap
+  flag after `waiting()` and bails on it, or the same refusal would exit `0`
+  at one stage and `1` at the other. An operator diagnosing either refusal
+  compares the request size against the derived cap, because nothing
+  server-side recorded the attempt.
+
+  **What one refused frame writes** (#272), measured on the shipped binary at
+  the default filter, in order. Before `initialize`: `bugwarden::stdio` at
+  WARN, naming the cap and the close; `rmcp::transport::async_rw` at ERROR,
+  echoing this reader's error `Display` (rmcp logs every read error there
+  before turning it into `receive() -> None`, so the cap's own sentence
+  reaches stderr whether or not bugwarden logs at all, minus the `; closing
+  the transport` tail this build adds); `bugwarden` at ERROR, `serving error:`
+  and then `main`'s `OVER_CAP_CLOSE`; and the `Error:` line the runtime prints
+  for the `anyhow::Error` `main` returned. Three log lines and the exit line.
+  After `initialize` there are MORE, not fewer: the same WARN and the same
+  rmcp ERROR, then two `rmcp::service` INFO lines (`input stream terminated`,
+  `serve finished quit_reason=Closed`) that the pre-handshake half never
+  reaches, then the exit line — four log lines and the exit line, none of the
+  four bugwarden's own beyond the WARN, because `main` bails after `waiting()`
+  with no tracing line of its own. So one refusal costs ONE bugwarden ERROR
+  before the handshake and NONE after it, and after it rmcp's echo is the only
+  ERROR on stderr. The directive that quiets that echo is
+  `RUST_LOG=info,rmcp::transport::async_rw=off`, and it is `off` and not the
+  `warn` #272 proposed: an `EnvFilter` level is a CEILING on verbosity, so
+  `=warn` enables WARN *and* ERROR and leaves the line exactly where it was —
+  measured both ways. Everything else that target logs is `debug!` or
+  `trace!`, so under the default filter it shows nothing but ERROR, and of its
+  two ERROR sites only the read-error one is reachable through this transport:
+  the other sits behind a `Serde` arm that already catches every error
+  `try_parse_with_compatibility` can return. `off` therefore removes the echo
+  and nothing else. What it does cost is stated here rather than paid by
+  default: that ERROR is EVERY read error rmcp sees, not only a refused frame.
+  A genuine stdin I/O failure after the handshake is the same line, and there
+  it is the only line that says anything WENT WRONG — measured with `EIO` from
+  a closed pty master, where rmcp logs the echo, reports the close with the
+  same two INFO lines a clean hangup gets, `waiting()` returns `Ok`, the
+  over-cap flag is clear, bugwarden writes nothing of its own and the process
+  exits `0`. That a real stdin failure ends the process successfully, with a
+  dependency's ERROR as the only sign of it, is pre-existing and outside
+  #272's scope; it is recorded here as a fact, not fixed. It is also why the
+  directive stays OUT of the default filter: a default that hides a genuine
+  read error is worse than a noisy refusal.
 
   Not done, deliberately: emitting a null-id `-32700` on stdout before
   closing. It is new stdout-after-close behaviour bought for a nicety, and
@@ -3613,14 +3665,24 @@ wired, `server.rs` and `main.rs` are the reference.
   that only `return Ok(())` cannot go green on an EOF the harness handed
   it: the test's `Server` takes stdin out of the `Child` at spawn and
   holds it past `Child::wait`, which closes whatever stdin the `Child`
-  still owns. The same spawned binary pins the stdio frame cap (#234): 5 MiB
-  with NO delimiter, written before the handshake and again after a
-  completed one, must exit `1` within the same bound and log bugwarden's own
-  cap line — served on a bare `stdio()` neither case exits at all, and
-  without the over-cap flag `main` checks after `waiting()` the
-  post-handshake case exits `0`, which is what rmcp's silent close makes of
+  still owns. The same spawned binary pins the stdio frame cap (#234) on
+  three rows: 5 MiB with NO delimiter, written before the handshake, after
+  an answered `server/discover` probe (#267) and after a completed
+  handshake, each of which must exit `1` within the same bound and log
+  bugwarden's own cap line — served on a bare `stdio()` no row exits at all,
+  and without the over-cap flag `main` checks after `waiting()` the
+  post-handshake row exits `0`, which is what rmcp's silent close makes of
   it. The needle is bugwarden's line, not rmcp's `Error reading from
-  stream`, so an SDK reword cannot pass for the bound.
+  stream`, so an SDK reword cannot pass for the bound. All three rows also
+  read the LEVELS off the same stderr (#272): the cap line is a WARN, the
+  ERROR lines carrying a target of this workspace's own number exactly one
+  (`serving error`) before the handshake and none after it, and rmcp's echo
+  is still an ERROR on `rmcp::transport::async_rw` — asserted rather than
+  merely tolerated, because that target and that level are exactly what the
+  `RUST_LOG` directive documented above addresses. The `serving error` line
+  of the OTHER handshake-failure arm is pinned at ERROR in the same file
+  (`assert_bounded_handshake_failure`), so neither arm can be demoted
+  unnoticed; before this, no test read either arm's level.
 - Startup-wiring tests (crates/bugwarden/tests/binary_startup_policy.rs,
   the SHIPPED BINARY): the three `main.rs` sites only a process executes,
   which is why a hand mutation run found all three bare (#269). The I9


### PR DESCRIPTION
Closes #272.

## What was wrong

One stdio frame over the request cap wrote three ERROR lines and an exit line for one refusal: the bounded reader's own line naming the cap, rmcp echoing that reader's error Display, and `main`'s serving-error classification (#261). Post-handshake, two of the three plus the exit line. Content was all server-authored; it was one event told three times at ERROR.

## What changes

- The reader's line drops to WARN, text unchanged. Under DESIGN.md's level rule (#270) it is the refusal itself: the cap doing what it is configured to do, nothing for an operator to inspect, repeated by any client that reconnects. `main`'s classification stays ERROR on both arms: those lines say the process is over, the statement every handshake-failure arm makes, once per process life. So a refused frame now costs bugwarden one ERROR before the handshake and none after it. rmcp's echo is rmcp's and stays.
- Two things the issue assumed are corrected in DESIGN.md, both measured. The directive that quiets rmcp's echo is `rmcp::transport::async_rw=off`, not `=warn`: an `EnvFilter` level is a verbosity ceiling, so `=warn` still admits ERROR. And that directive's cost is real: the same target's ERROR is every read error rmcp sees, so a genuine stdin I/O failure after the handshake is the same line and the only sign anything went wrong (measured with EIO from a closed pty master: rmcp's echo, two INFO close lines, no bugwarden line, exit 0). That is pre-existing and is why the directive stays out of the default filter.
- DESIGN.md gains the measured line list for each side of the handshake, writer by writer and level by level: the post-handshake side writes more lines, not fewer (rmcp's two `serve` close lines), with none of them bugwarden's beyond the WARN.

## Tests

`binary_shutdown.rs` reads levels off the stderr it already captures. A `level_of` helper takes the level token positionally, so a message containing the word ERROR cannot satisfy it. The three over-cap rows assert the reader's line is WARN, that workspace-targeted ERROR lines number exactly one before the handshake and none after, and that rmcp's echo is still an ERROR on its target (asserted, since that is what the documented directive addresses). The seven #261 rows gain the matching ERROR pin on the other classification arm. Before this change no test read either `serving error` arm's level: `error!` → `warn!` at `main.rs:299` survived the whole suite and now fails seven rows. Every new assertion shown to fail on the unchanged tree. cargo-mutants `--in-diff` lists one mutant, unviable (`io::Error` has no `Default`); a macro level change generates none, so the binary rows are the pin.

## Review before opening

Three parallel refutation-lens reviews over the uncommitted diff (correctness MERGE-SAFE; security and docs NOT MERGE-SAFE on prose), then one fold pass. All three found the code and tests sound and verified the two corrections above independently, with the pty measurement reproduced.

- **Security / invariants:** the post-handshake line list said "the first two and the exit line only" and it was four log lines plus the exit line; the test constant's rustdoc called rmcp's echo "the same text" when it lacks the `; closing the transport` tail that makes the needle bugwarden's; README's "the ERROR beside it" named one ERROR where the pre-handshake side has two. All rewritten as measured. The ERROR-count predicate widened from the `bugwarden` crate to the workspace.
- **Correctness / edge cases:** the hand mutants (reader at INFO, reader removed, `main.rs:292` at WARN) each mapped to a failing assertion; the sibling arm at `main.rs:299` was pinned nowhere and now is.
- **Docs / prose:** the `trip` rustdoc's new sentence was false after the handshake and contradicted the one above it; the `at_level` rustdoc claimed a word inside a message could not satisfy it when the body was a substring search (now a positional token read); the rule paragraph used "client-repeatable" in two senses and was rewritten around the distinction that actually decides it; a `trace!` site, a "two rows" that are three, and the file's coverage contract were corrected.

Out of scope, tracked: #285 (a pre-`initialize` stdin I/O error is classified as a hangup).
