### PR TITLE
test(otel): probe the refused collector address

### DIFF
--- a/crates/bugwarden-core/tests/guard_wiremock.rs
+++ b/crates/bugwarden-core/tests/guard_wiremock.rs
@@ -43,6 +43,10 @@ fn client(server: &MockServer) -> BugzillaClient {
 /// ephemeral port fails the helper. A 500 ms TCP probe refuses to
 /// return an address that accepted or timed out; the URL is built from
 /// the probed socket so the two cannot drift.
+///
+/// `crates/bugwarden/tests/common/refused.rs` is this function's twin —
+/// it says where the probe belongs and why this package cannot share it
+/// — and nothing pairs them: a change here is a change there (#280).
 fn refused_base_url() -> String {
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 1));
     assert!(

--- a/crates/bugwarden/src/lib.rs
+++ b/crates/bugwarden/src/lib.rs
@@ -28,3 +28,11 @@ mod testlog;
 #[cfg(test)]
 #[path = "../tests/common/pinned_cli.rs"]
 mod pinned_cli;
+
+// The probed refused address, reached by `#[path]` for the same reason:
+// `use` cannot see an integration-test file. A unit test that DIALS an
+// unreachable upstream checks the address instead of assuming it, and
+// that file says where the probe belongs (#280).
+#[cfg(test)]
+#[path = "../tests/common/refused.rs"]
+mod refused;

--- a/crates/bugwarden/src/otel.rs
+++ b/crates/bugwarden/src/otel.rs
@@ -1363,6 +1363,7 @@ mod tests {
         AuditEvent, AuditEventKind, ClientInfo, GuardInfo, InitializeEvent, OutcomeClass,
         OutcomeInfo, RequestInfo, SessionInfo, ToolCallEvent, TraceContext, TransportKind, Verdict,
     };
+    use crate::refused::refused_base_url;
     use crate::testlog::{assert_logged, capture_logs};
 
     fn env(endpoint: &str) -> OtelEnv {
@@ -1370,6 +1371,35 @@ mod tests {
             endpoint: Some(endpoint.to_owned()),
             ..OtelEnv::default()
         }
+    }
+
+    /// A collector address bare by the probe's rule
+    /// (`tests/common/refused.rs`): the rows below that use it shut the
+    /// pipeline down before a record is queued, so nothing here ever
+    /// opens a connection and there is no wait to buy out (#280). A row
+    /// that posts to the collector takes [`refused_base_url`] instead.
+    const NO_COLLECTOR: &str = "http://127.0.0.1:1";
+
+    /// The dead collector's base URL, and the two needles a refusal must
+    /// never carry (I12): its host, and its port with the colon a
+    /// message would print in front of it.
+    ///
+    /// Both are parsed back out of the URL the exporter is pointed at,
+    /// as a [`std::net::SocketAddr`] rather than by hand: splitting on
+    /// the first colon would read `[::1]:1` as host `[`, which no
+    /// refusal can contain, and that assertion would then pass on any
+    /// message at all. Whatever the helper hands out — v4, or a
+    /// bracketed v6 — is what these rows forbid.
+    ///
+    /// For the URL alone, call [`refused_base_url`] directly.
+    fn dead_collector() -> (String, String, String) {
+        let base = refused_base_url();
+        let addr: std::net::SocketAddr = base
+            .trim_start_matches("http://")
+            .parse()
+            .expect("the probed base is `http://` and a socket address");
+        let (host, port) = (addr.ip().to_string(), format!(":{}", addr.port()));
+        (base, host, port)
     }
 
     // -- configuration ------------------------------------------------------
@@ -2406,7 +2436,7 @@ mod tests {
         // must be able to account for (take_lost -> audit_gap), never a
         // silent drop; the diagnostics counter stays at zero for it, and
         // delivery is marked failing so the fail-mode gate closes.
-        let cfg = resolve(&env("http://127.0.0.1:1/"))
+        let cfg = resolve(&env(&refused_base_url()))
             .expect("resolves")
             .expect("export is on");
         let pipeline = Arc::new(Pipeline::start(cfg).expect("the pipeline must start"));
@@ -2439,7 +2469,7 @@ mod tests {
 
     #[tokio::test]
     async fn an_unreachable_collector_counts_diagnostics_as_drops() {
-        let cfg = resolve(&env("http://127.0.0.1:1/"))
+        let cfg = resolve(&env(&refused_base_url()))
             .expect("resolves")
             .expect("export is on");
         let pipeline = Arc::new(Pipeline::start(cfg).expect("the pipeline must start"));
@@ -2468,7 +2498,7 @@ mod tests {
         // The audit queue REFUSES what it cannot take: the sink turns the
         // refusal into a failed record and the fail mode decides what the
         // caller sees. Only diagnostics are dropped-and-counted.
-        let cfg = resolve(&env("http://127.0.0.1:1/"))
+        let cfg = resolve(&env(NO_COLLECTOR))
             .expect("resolves")
             .expect("export is on");
         let pipeline = Arc::new(Pipeline::start(cfg).expect("the pipeline must start"));
@@ -2495,7 +2525,7 @@ mod tests {
         // send an operator looking for a volume problem that is not
         // there. The line is lost either way — this is about the
         // vocabulary being true.
-        let cfg = resolve(&env("http://127.0.0.1:1/"))
+        let cfg = resolve(&env(NO_COLLECTOR))
             .expect("resolves")
             .expect("export is on");
         let pipeline = Arc::new(Pipeline::start(cfg).expect("the pipeline must start"));
@@ -2552,7 +2582,8 @@ mod tests {
     async fn the_startup_probe_refuses_a_dead_collector_without_naming_it() {
         // The refusal names the variables the operator has to check and
         // never the endpoint they hold (I12) — port 1 would be the tell.
-        let cfg = resolve(&env("http://127.0.0.1:1/"))
+        let (base, host, port) = dead_collector();
+        let cfg = resolve(&env(&base))
             .expect("resolves")
             .expect("export is on");
         let pipeline = Arc::new(Pipeline::start(cfg).expect("the pipeline must start"));
@@ -2570,7 +2601,7 @@ mod tests {
             "a general-variable config must not blame the logs-specific pair: {message}"
         );
         assert!(
-            !message.contains("127.0.0.1") && !message.contains(":1"),
+            !message.contains(&host) && !message.contains(&port),
             "the refusal must not carry the endpoint: {message}"
         );
         assert!(
@@ -2582,8 +2613,9 @@ mod tests {
 
     #[tokio::test]
     async fn the_startup_probe_names_the_logs_specific_variables_when_those_won() {
+        let (base, host, port) = dead_collector();
         let cfg = resolve(&OtelEnv {
-            logs_endpoint: Some("http://127.0.0.1:1/v1/logs".to_owned()),
+            logs_endpoint: Some(format!("{base}/v1/logs")),
             logs_headers: Some("authorization=Bearer x".to_owned()),
             ..OtelEnv::default()
         })
@@ -2602,7 +2634,7 @@ mod tests {
             "the refusal must name the variables that actually won: {message}"
         );
         assert!(
-            !message.contains("127.0.0.1") && !message.contains("Bearer"),
+            !message.contains(&host) && !message.contains(&port) && !message.contains("Bearer"),
             "the refusal must not carry the endpoint or the credential: {message}"
         );
         pipeline.shutdown().await;
@@ -2610,7 +2642,7 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_is_idempotent_and_bounded() {
-        let cfg = resolve(&env("http://127.0.0.1:1/"))
+        let cfg = resolve(&env(NO_COLLECTOR))
             .expect("resolves")
             .expect("export is on");
         let pipeline = Arc::new(Pipeline::start(cfg).expect("the pipeline must start"));

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -6740,10 +6740,13 @@ mod tests {
     /// 30s is far above anything legitimate here — no test delays a mock
     /// and every upstream is loopback or absent — and it is the number
     /// `tests/common/deadline.rs` gives the integration harnesses. Two
-    /// definitions of it exist, not one: a `#[cfg(test)]` module in the
-    /// library cannot reach `tests/`, so nothing but this sentence keeps
-    /// them equal. Move one and move the other; the reasoning for the
-    /// value itself lives in that file.
+    /// definitions of it exist, not one: a known duplication, not a
+    /// necessity — a `#[cfg(test)]` module in the library cannot `use`
+    /// an integration-test file, but it can include one by `#[path]`,
+    /// as `lib.rs` does for `pinned_cli` and `refused` (#280). Until
+    /// that is done nothing but this sentence keeps the two equal: move
+    /// one and move the other; the reasoning for the value itself lives
+    /// in that file.
     const CALL_DEADLINE: std::time::Duration = std::time::Duration::from_secs(30);
 
     /// Await `fut` under [`CALL_DEADLINE`], panicking if it does not
@@ -7407,6 +7410,12 @@ mod tests {
     /// A base URL nothing dials: the probe panics before it could, and the
     /// follow-up call (`mcp_server_info`) contacts nothing either. Keeping
     /// wiremock out makes these tests about the dispatch boundary alone.
+    ///
+    /// Bare by the rule in `tests/common/refused.rs` (#280): pointed at
+    /// an address that black-holes connections these rows still pass in
+    /// milliseconds, so no client here ever connects and there is no
+    /// wait for the probe to buy out. A row that does route a call
+    /// upstream takes `crate::refused::refused_base_url` instead.
     const NO_BUGZILLA: &str = "http://127.0.0.1:1";
 
     /// A handler that panics on every call. A free `fn` rather than a

--- a/crates/bugwarden/tests/common/deadline.rs
+++ b/crates/bugwarden/tests/common/deadline.rs
@@ -45,9 +45,12 @@ use std::time::Duration;
 /// here, not a nudge; none exists, and writing one means revisiting this
 /// constant rather than assuming it already covers the case.
 ///
-/// `server.rs`'s test module declares this number a second time, because a
-/// `#[cfg(test)]` module in the library cannot reach `tests/`. The two are
-/// equal by hand and nothing checks it, so a change here is a change
+/// `server.rs`'s test module declares this number a second time. That is
+/// a known duplication rather than a necessity: a `#[cfg(test)]` module in
+/// the library cannot `use` an integration-test file, but it can include
+/// one by `#[path]`, which is how `lib.rs` reaches `pinned_cli` and
+/// `refused.rs` (#280). Until this file is shared that way the two values
+/// are equal by hand and nothing checks it, so a change here is a change
 /// there.
 pub const CALL_DEADLINE: Duration = Duration::from_secs(30);
 

--- a/crates/bugwarden/tests/common/refused.rs
+++ b/crates/bugwarden/tests/common/refused.rs
@@ -7,6 +7,27 @@
 //! `dead_code` in the rest, which `-D warnings` rejects (#167, #214).
 //! `REFUSED_CONNECT_BUDGET` stayed behind because only the guard-client
 //! harnesses bound a call with it.
+//!
+//! The library's `#[cfg(test)]` tree includes this file the same way
+//! (`lib.rs`): an integration-test file is out of reach for `use`, not
+//! for `#[path]`, so a unit test that DIALS an unreachable upstream
+//! checks the address instead of assuming it (#280).
+//!
+//! Where it belongs, one rule: take the probe wherever a test's client
+//! actually connects to the address, because that is where a box that
+//! filters port 1 instead of closing it costs a wait on the caller's
+//! client timeout, and the probe spends 500 ms to name the cause here
+//! rather than fail obscurely there. An address handed to a client that
+//! never opens a connection has no such wait to buy out and stays a
+//! bare literal; `server::tests::NO_BUGZILLA` and
+//! `otel::tests::NO_COLLECTOR` are those, and point back here.
+//!
+//! `bugwarden-core` keeps its own copy — the private `refused_base_url`
+//! in `crates/bugwarden-core/tests/guard_wiremock.rs` — because a
+//! `#[path]` out of that package into this one's `tests/` reaches
+//! outside the package directory and would not survive packaging.
+//! Nothing but the pointer in each rustdoc pairs the two: edit one, edit
+//! the other.
 
 /// Connect-time failure nothing in this process can answer (#115, #229).
 ///
@@ -32,8 +53,9 @@ pub fn refused_base_url() -> String {
              that wiremock's 127.0.0.1:0 pool cannot occupy (#115)"
         ),
         Err(e) if e.kind() == std::io::ErrorKind::TimedOut => panic!(
-            "{addr} timed out; refusing to point a 30s client at an address \
-             that would hang the test (#115)"
+            "{addr} timed out; refusing to hand out an address whose failure \
+             would arrive on the caller's client timeout instead of at \
+             connect (#115, #280)"
         ),
         Err(_) => format!("http://{addr}"),
     }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3067,7 +3067,11 @@ wired, `server.rs` and `main.rs` are the reference.
   `127.0.0.1:1` (a privileged port a non-root wiremock `bind(127.0.0.1:0)`
   cannot occupy); `assert!(addr.port() < 1024)` is the mutation-kill for a
   bind-then-drop of an ephemeral port, a 500 ms TCP probe refuses an
-  address that accepted or timed out, the client call is capped at 2 s,
+  address that accepted or timed out (this package's own copy of the
+  probe the `bugwarden` crate shares from `tests/common/refused.rs` —
+  see the otel unit-test bullet; a `#[path]` out of this package could
+  not reach it, and the two are paired by their rustdoc alone),
+  the client call is capped at 2 s,
   and the assertion requires reqwest's `error sending request` so an
   empty or HTTP-status error cannot pass a bare `!contains(KEY)`
   (issue #115; known history, issue #127: PR #124 landed as `a0f535f`
@@ -3765,7 +3769,24 @@ wired, `server.rs` and `main.rs` are the reference.
   hand-written `Debug`
   carries neither, since `AuditSink`'s derived one would print it;
   the startup probe refuses a dead collector without naming the endpoint
-  (I12) and leaves delivery marked failing.
+  (I12) and leaves delivery marked failing. Four of these rows — the two
+  delivery-accounting ones and the two startup-probe ones — post to the
+  collector, and take the probed address the integration harnesses use
+  (`refused_base_url`, `tests/common/refused.rs`, included into the
+  library's test tree by `#[path]` the way `pinned_cli` is; that file
+  states the rule and `bugwarden-core` keeps a copy it cannot share, see
+  the `guard_wiremock.rs` bullet above). The three that shut the pipeline
+  down before a record is queued never connect, so they keep a bare
+  literal (issue #280). Where port 1 is filtered rather than closed the
+  four now fail together inside `refused_base_url`, which names the
+  address and the cause; before, the two delivery-accounting rows failed
+  on pipeline state alone — a delivery not marked failing, a drop not
+  counted — saying nothing about the box, while the two startup-probe
+  rows still PASSED, each only once `PROBE_ATTEMPTS` had run out, at ten
+  seconds an attempt. The host and the port their I12 assertions forbid
+  are parsed back out of that same URL as a socket address, so neither
+  the address nor a bracketed-v6 spelling of it can leave the assertions
+  passing vacuously.
 - Sink-selection tests (#[cfg(test)] in crates/bugwarden/src/audit.rs):
   the four deployments resolve, the two ambiguous spellings refuse naming
   both ways out, and `none` is exact bytes (`None` and `./none` are


### PR DESCRIPTION
Closes #280.

## What was wrong, and what the issue got wrong

The issue read `server.rs`'s `NO_BUGZILLA` as an unprobed copy of the refused-port assumption the integration harnesses probe through `refused_base_url()`. Measured while fixing: the three rows that use it issue zero `connect()` calls (strace-verified by two reviewers) and pass in 0.13 s against a black-holing address, so a probe there would guard nothing. The rows that do post to an unprobed `127.0.0.1:1` from the lib's test module are `otel.rs`'s dead-collector rows: against a black-holing address two of them fail on pipeline-state assertions that say nothing about the box, and the two startup-probe rows pass only after 55 s each, sitting on five export timeouts. The issue's other premise was wrong too: the library can reach a `tests/common` file by `#[path]`, which `lib.rs` already does for `pinned_cli.rs`. The issue body and title were amended to say so.

## What changes

- `tests/common/refused.rs` is included into the library's `#[cfg(test)]` tree by `#[path]`, and the four `otel.rs` rows that post to the collector take `refused_base_url()`. Their two startup-probe rows derive the host and port their I12 assertions forbid from that URL, parsed as a `SocketAddr` (splitting on the first colon would read a bracketed IPv6 authority as host `[` and pass vacuously); the second row now checks the port needle too, which a hand-patched refusal leaking `:1` showed it did not.
- One rule, stated once in the helper's module doc and cited from the two constants that opt out: the probe goes where a test's client actually connects, because that is where a filtering box costs a wait on the caller's client timeout; an address handed to a client that never opens a connection stays a bare literal. So `otel.rs`'s three shutdown-first rows keep a bare `NO_COLLECTOR`, and `server.rs`'s `NO_BUGZILLA` stays bare with a rustdoc saying why.
- `bugwarden-core` keeps its own copy of the helper because a `#[path]` out of that package would reach outside its directory and not survive packaging; the two copies now point at each other. Two #254 sentences that claimed the library cannot reach `tests/` now say the `CALL_DEADLINE` duplication is known rather than necessary (#286 tracks unifying it).

## Evidence

Test-only; no production line moves. On a box where port 1 is filtered (a `connect()` shim redirecting to 192.0.2.1:1), the unchanged tree's seven otel rows take 118 s with two obscure failures; with this change the four posting rows fail in 0.5 s inside the helper with its own message, and the three shutdown-first rows still pass in 0.1 s. Lib suite unchanged at 5.7–5.9 s wall.

## Review before opening

Three parallel refutation-lens reviews over the uncommitted diff (correctness MERGE-SAFE; security and docs NOT MERGE-SAFE), then one fold pass. All three verified the refutation of the issue's premise independently, with strace and the connect shim.

- **Security / invariants:** the diff had probed three rows that never connect while `NO_BUGZILLA`'s rustdoc stated the opposite rule; resolved by stating the rule once and applying it uniformly. The host/port derivation's "cannot drift" claim was false for IPv6; now parsed as a socket address. Two #254 sentences asserting the library cannot reach `tests/` were refuted by this very diff and corrected.
- **Correctness / edge cases:** the second startup-probe row discarded the port needle, proven by patching the built binary's refusal string; closed. An accepting address trips the `port() < 1024` assertion first (13 µs), so the helper's "accepted" arm is unreachable non-root (#287).
- **Docs / prose:** DESIGN.md's one new sentence paired the export-timeout wait with the rows that fail, when no row does both; rewritten with the two groups kept apart. The `#[path]` rationale was mis-stated as a dependency direction and is now the packaging boundary; the copy pairing was one-way and is now reciprocal.

Out of scope, tracked: #286 (unify `CALL_DEADLINE`/`bounded` by `#[path]`), #287 (the helper's two copies, unreachable arm and unguarded exemption).
