### PR TITLE
chore: release 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "bugwarden"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "bugwarden-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Martin Pluskal <martin@pluskal.org>"]

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -34,7 +34,7 @@ gen = ["dep:clap_complete", "dep:clap_mangen"]
 workspace = true
 
 [dependencies]
-bugwarden-core = { path = "../bugwarden-core", version = "0.5.0" }
+bugwarden-core = { path = "../bugwarden-core", version = "0.6.0" }
 
 rmcp = { version = "3.1", features = [
     "server",

--- a/crates/bugwarden/man/bugwarden.1
+++ b/crates/bugwarden/man/bugwarden.1
@@ -1,4 +1,4 @@
-.TH bugwarden 1 "" "bugwarden 0.5.0" "General Commands Manual"
+.TH bugwarden 1 "" "bugwarden 0.6.0" "General Commands Manual"
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SH NAME


### PR DESCRIPTION
Version bump for the 0.6.0 release; the tag goes on this PR's merge commit, as AGENTS.md's release section prescribes.

0.6.0 rather than 0.5.1: audit records are schema v2 since #34's follow-ups (the single `suppressed_count` is gone in favour of `suppressed_ids_count` and `suppressed_other_count`; the upstream block and `response_bytes` are new), so an operator's v1 reader keyed on the old field stops matching. Everything else since 0.5.0 is additive or a fix.

What moved, the same four files as the 0.5.0 bump (`527e580`):

- `Cargo.toml` workspace version, and the `bugwarden-core` version requirement in `crates/bugwarden/Cargo.toml` that must match it for the crates.io publish.
- `Cargo.lock`: the two workspace members' entries, via `cargo update -w`; no dependency moved.
- `crates/bugwarden/man/bugwarden.1`: regenerated with `bugwarden-gen` from empty `man/` and `completions/` directories, the way `rust-assets-drift` does; only the `.TH` version changed and the completions came back byte-identical.

No behaviour change. `release.yml` has seven unrehearsed changes since the last tag (attestation, the container smoke test, the toolchain-guard gate, deb/rpm); attestation runs before the release is created, so a failure there publishes nothing.
