### PR TITLE
test(server): share CALL_DEADLINE via path include

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,8 +146,8 @@ are never a justification for undoing them.
   response headers and only reqwest's own total timeout also covers the
   body. `bounded` and `CALL_DEADLINE` live in
   `crates/bugwarden/tests/common/deadline.rs`, `raw_client()` beside them
-  in `common/raw_client.rs`, and `server.rs`'s test module keeps its own
-  equal copy of the constant.
+  in `common/raw_client.rs`, and the library's test module includes the
+  same file by `#[path]`.
 - A dependency change must update `Cargo.lock`, preserve the MSRV, and pass
   `cargo deny check`. Prefer the smallest compatible version change; do not
   run a broad `cargo update` as part of an unrelated change.

--- a/crates/bugwarden/src/lib.rs
+++ b/crates/bugwarden/src/lib.rs
@@ -36,3 +36,10 @@ mod pinned_cli;
 #[cfg(test)]
 #[path = "../tests/common/refused.rs"]
 mod refused;
+
+// The request deadline the crate's own unit tests share with the
+// integration harnesses, reached by `#[path]` because `use` cannot
+// see an integration-test file (#286).
+#[cfg(test)]
+#[path = "../tests/common/deadline.rs"]
+mod deadline;

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -5093,6 +5093,7 @@ mod tests {
     }
 
     use super::*;
+    use crate::deadline::bounded;
     use crate::pinned_cli::pinned;
     use bugwarden_core::policy::Policy;
 
@@ -6872,43 +6873,7 @@ mod tests {
             .expect("MCP handshake must succeed")
     }
 
-    /// Bound on every request these tests await — over the duplex
-    /// transport and in process alike.
-    ///
-    /// rmcp 3.1.4 sends with `PeerRequestOptions::default()`, whose
-    /// `timeout` is `None` (`service.rs`), and its `initialize` handshake
-    /// reads the response off the transport with no deadline either. A
-    /// request the server never answers therefore waits forever: it hangs
-    /// its test, this whole binary, and every binary cargo queues behind
-    /// it. That failure is the one this module hunts (#253, #254), so it
-    /// must fail ONE test rather than decide how long the run takes. A
-    /// direct `ServerHandler::call_tool` await is bounded for the same
-    /// reason: it reaches the same dispatch, and the mutants that hung the
-    /// suite were inside it. So is a hand-sent second `initialize` — over
-    /// a live session that is an ordinary request, answered or not.
-    ///
-    /// 30s is far above anything legitimate here — no test delays a mock
-    /// and every upstream is loopback or absent — and it is the number
-    /// `tests/common/deadline.rs` gives the integration harnesses. Two
-    /// definitions of it exist, not one: a known duplication, not a
-    /// necessity — a `#[cfg(test)]` module in the library cannot `use`
-    /// an integration-test file, but it can include one by `#[path]`,
-    /// as `lib.rs` does for `pinned_cli` and `refused` (#280). Until
-    /// that is done nothing but this sentence keeps the two equal: move
-    /// one and move the other; the reasoning for the value itself lives
-    /// in that file.
-    const CALL_DEADLINE: std::time::Duration = std::time::Duration::from_secs(30);
-
-    /// Await `fut` under [`CALL_DEADLINE`], panicking if it does not
-    /// resolve. `what` names the request, because the panic is all a
-    /// reader of a CI log gets.
-    async fn bounded<T>(what: &str, fut: impl std::future::Future<Output = T>) -> T {
-        tokio::time::timeout(CALL_DEADLINE, fut)
-            .await
-            .unwrap_or_else(|_| panic!("{what} was not answered within {CALL_DEADLINE:?}"))
-    }
-
-    /// Call `tool` over the session, under [`CALL_DEADLINE`].
+    /// Call `tool` over the session, under [`crate::deadline::CALL_DEADLINE`].
     ///
     /// The bound carries weight wherever this follows a call that panicked:
     /// "the session survives" is a claim that a reply ARRIVES, so an

--- a/crates/bugwarden/tests/common/deadline.rs
+++ b/crates/bugwarden/tests/common/deadline.rs
@@ -8,6 +8,10 @@
 //! `dead_code` in the rest, which `-D warnings` rejects (#167, #214). Only
 //! two binaries say it, and most of the client-driving harnesses are not
 //! among them.
+//!
+//! The library's `#[cfg(test)]` tree includes this file the same way
+//! as `pinned_cli` and `refused` (`lib.rs`), so the crate's own unit
+//! tests share one `CALL_DEADLINE` (#286).
 
 use std::future::Future;
 use std::time::Duration;
@@ -44,14 +48,6 @@ use std::time::Duration;
 /// one per named field for `bug_fields`. Such a test would need minutes
 /// here, not a nudge; none exists, and writing one means revisiting this
 /// constant rather than assuming it already covers the case.
-///
-/// `server.rs`'s test module declares this number a second time. That is
-/// a known duplication rather than a necessity: a `#[cfg(test)]` module in
-/// the library cannot `use` an integration-test file, but it can include
-/// one by `#[path]`, which is how `lib.rs` reaches `pinned_cli` and
-/// `refused.rs` (#280). Until this file is shared that way the two values
-/// are equal by hand and nothing checks it, so a change here is a change
-/// there.
 pub const CALL_DEADLINE: Duration = Duration::from_secs(30);
 
 /// Await `fut` under [`CALL_DEADLINE`], panicking if it does not resolve.


### PR DESCRIPTION
Closes #286.

## What was wrong

`server.rs`'s test module kept a hand copy of `CALL_DEADLINE` / `bounded()` on the premise that a `#[cfg(test)]` module cannot reach `tests/`. #280 already disproved that (`#[path]` works; `pinned_cli` and `refused` already use it). Two definitions, equal by hand, nothing checking them.

## What changes

- `lib.rs` includes `tests/common/deadline.rs` by `#[path]`, same as `pinned_cli` and `refused`.
- The local copy in `server.rs`'s test module is gone; those 33 sites call `crate::deadline::bounded`.
- `deadline.rs` and AGENTS.md no longer describe a second copy.

Test-only; no production line moves. The 30s value is unchanged.

## Tests

`cargo fmt --check`, clippy workspace + gen (`-D warnings`), `cargo test --workspace --all-targets --locked` (lib 315, `tools_wiremock` 85).

## Review before opening

Three parallel refutation-lens reviews over the diff, then one fold pass.

- **Security / invariants — MERGE-SAFE.** Production slices of `lib.rs` / `server.rs` byte-identical to `main`; the new `mod deadline` is `#[cfg(test)]`; every request await in the module is still `bounded(...)`; I1–I16 untouched.
- **Correctness / edge cases — MERGE-SAFE.** All 33 `bounded(` sites still wrap the future; integration-test `mod deadline` cannot link-clash with `crate::deadline` (separate crates); rustdoc `-D warnings` does not see the `#[cfg(test)]` intra-doc link.
- **Docs / prose — MERGE-SAFE** after fold. The new `lib.rs` comment named the integration harnesses as this include's consumer; they already `#[path]` the file themselves. Rewritten to name the crate's own unit tests, same shape as `pinned_cli` / `refused`.
