### PR TITLE
build: fat LTO and one codegen unit for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,10 @@ all = { level = "warn", priority = -1 }
 # (do not enable pedantic as warn-as-error — it blocks scaffolding with style
 # nits).
 pedantic = { level = "allow", priority = -1 }
+
+# Shipped binary only (tarball, deb/rpm, container). CI tests stay on the
+# default profile. CGU=1 so pre-LTO optimize sees one module per crate;
+# fat LTO then merges across crates either way.
+[profile.release]
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
## What changes

Workspace `[profile.release]`: `lto = "fat"`, `codegen-units = 1`.

Applies only to `--release` (tarball, deb/rpm, container). CI `cargo test` / clippy / `bugwarden-gen` stay on the default profile.

`codegen-units` is how many LLVM modules rustc splits **one crate** into (release default 16). More units compile in parallel and block intra-crate inlining. `1` is one module per crate for the pre-LTO optimize pass. Fat LTO then merges **across** crates at link; it does that with or without CGU=1. Both together are the usual max-opt pair.

No PGO. No `strip` / `panic` change. Tarballs still keep symbols; deb/rpm still strip after link.

## Tests

Local `cargo build --release --locked -p bugwarden` was started on this tree. A `-v` build from the correctness review actually passed `-C lto=fat -C codegen-units=1` on the bin and `-C linker-plugin-lto -C codegen-units=1` on rlibs. aws-lc-sys C is not in the LLVM LTO unit.

## Review before opening

Three parallel refutation-lens reviews, then one fold.

- **Security / invariants — MERGE-SAFE.** Source unchanged; LTO is as-if on safe Rust (`unsafe_code = forbid`). I2/I4/I12 paths untouched. Panic stays unwind; #270 hook does not depend on `RUST_BACKTRACE`. MSRV 1.88 parses both keys.
- **Correctness / edge cases — MERGE-SAFE.** Profile is in the workspace root (the only place Cargo honors it). CI does not pass `--release`. `codegen-units = 1` is not redundant with fat LTO (rustc documents 16 CGU + fat LTO as a distinct mode). Suggestion: macos-latest tag `build` is 7GB/30 min and is not covered by this PR's 16GB docker rehearsal — accepted; bump that job only if a tag OOMs.
- **Docs / prose — MERGE-SAFE** after fold. The first comment claimed fat LTO serializes codegen and that CGU=1 stops LLVM splitting before LTO sees the crate. Both clauses were the wrong mechanism. Comment and commit body now: CGU=1 is for pre-LTO optimize; fat LTO merges either way.
