### PR TITLE
ci: prune rust-cache generations and skip MSRV target/

### DIFF
--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -1,0 +1,39 @@
+---
+name: cache-prune
+# `save-if` is main-only across ci.yml, so every rust-cache entry is a
+# `main` generation. Older generations are pure LRU pressure once a newer
+# one for the same key prefix exists — keep the newest per prefix, delete
+# the rest.
+on:
+  schedule:
+    # Weekly, at a quiet hour so a prune is unlikely to
+    # race a running job.
+    - cron: '23 3 * * 0'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Delete superseded cache generations
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # A key's trailing hash segment (Cargo.lock hash, or
+          # rust-cache's lockfile-hash component) is what changes
+          # per generation; stripping it groups a key's generations
+          # together for the keep-newest pass.
+          gh cache list --repo "$REPO" --limit 100 --json id,key,createdAt |
+            jq -r '.[] | [(.key | sub("-[0-9a-fA-F]{6,64}$"; "")), .createdAt, .id] | @tsv' |
+            sort -t $'\t' -k1,1 -k2,2r |
+            awk -F'\t' '{ if ($1 != prev) { prev = $1 } else { print $3 } }' |
+            while read -r id; do
+              echo "Deleting superseded cache id $id"
+              gh cache delete "$id" --repo "$REPO"
+            done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
           # A PR-written cache is invisible to main and evicts main's own by
           # LRU once the repo is over quota; PRs restore main's entry either
           # way, since nothing ref-specific enters the key. So: main writes,
-          # PRs only read.
+          # PRs only read. Older generations of the same key prefix
+          # are pruned weekly by cache-prune.yml.
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Format
         run: cargo fmt --check
@@ -218,6 +219,10 @@ jobs:
         with:
           workspaces: . -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Registry only: a full target/ key for the MSRV is a second
+          # multi-hundred-MB entry next to rust's pin, and this job only
+          # `cargo check`s.
+          cache-targets: false
       - name: Assert the toolchain is the MSRV
         # If the export above ever stops working, fail here instead of
         # silently re-testing the pinned channel.


### PR DESCRIPTION
Weekly keep-newest prune so lockfile churn does not fill the 10 GB cap and LRU-evict the pin's cache. Same pass as openSUSE/mtui (attribution in the commit, not the YAML).

`rust-msrv` caches the registry only (`cache-targets: false`): it `cargo check`s on 1.88 and a full `target/` key would sit next to rust's 1.98.0 one for no gain.

`save-if` stays main-only. PRs only restore. Tags skip the cache step.

## Review before opening

Three parallel refutation-lens reviews, then one fold.

- **Security / invariants — MERGE-SAFE.** `actions: write` is the documented minimum for cache delete; `GITHUB_TOKEN` cannot touch other repos. Keep-newest never emits the newest id. rust-cache keys do not collapse across jobs. Triggers are schedule + workflow_dispatch only.
- **Correctness / edge cases — MERGE-SAFE.** awk/sort keep-newest; `cache-targets: false` omits `target/` even with `workspaces:`; `RUSTUP_TOOLCHAIN` is in `GITHUB_ENV` before the cache step so MSRV does not share the pin's key. `jq`/`gh` are on ubuntu-latest. Extracted `run:` block is shellcheck-clean.
- **Docs / prose — MERGE-SAFE** after fold. Dropped the false mtui-msrv analogy (`actions/cache` restore/save vs rust-cache `cache-targets: false`). Dropped the YAML mtui citation (kept in the commit body). rust-job comment now says key *prefix*. Wrapped the hash-strip / cron comments.
