### PR TITLE
test: pin the refused-address helper copies and drop the dead arm

### DIFF
--- a/crates/bugwarden-core/tests/guard_wiremock.rs
+++ b/crates/bugwarden-core/tests/guard_wiremock.rs
@@ -41,28 +41,24 @@ fn client(server: &MockServer) -> BugzillaClient {
 /// pooled listener from another test cannot answer this request. The
 /// load-bearing assertion is `port() < 1024` — a bind-then-drop of an
 /// ephemeral port fails the helper. A 500 ms TCP probe refuses to
-/// return an address that accepted or timed out; the URL is built from
-/// the probed socket so the two cannot drift.
+/// return an address that timed out; the URL is built from the probed
+/// socket so the two cannot drift.
 ///
 /// `crates/bugwarden/tests/common/refused.rs` is this function's twin —
 /// it says where the probe belongs and why this package cannot share it
-/// — and nothing pairs them: a change here is a change there (#280).
+/// — and `the_core_copy_matches` there pins the bodies (#287).
 fn refused_base_url() -> String {
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 1));
     assert!(
         addr.port() < 1024,
-        "I12 transport tests must use a privileged port; wiremock binds 127.0.0.1:0 (#115)"
+        "these tests must use a privileged port; wiremock binds 127.0.0.1:0 (#115, #229)"
     );
     match std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(500)) {
-        Ok(_) => panic!(
-            "{addr} accepted a connection; I12 tests need a refused address \
-             that wiremock's 127.0.0.1:0 pool cannot occupy (#115)"
-        ),
         Err(e) if e.kind() == std::io::ErrorKind::TimedOut => panic!(
             "{addr} timed out; refusing to point the 30s client at an address \
              that would hang the test (#115)"
         ),
-        Err(_) => format!("http://{addr}"),
+        _ => format!("http://{addr}"),
     }
 }
 

--- a/crates/bugwarden/src/server.rs
+++ b/crates/bugwarden/src/server.rs
@@ -7506,6 +7506,9 @@ mod tests {
     /// milliseconds, so no client here ever connects and there is no
     /// wait for the probe to buy out. A row that does route a call
     /// upstream takes `crate::refused::refused_base_url` instead.
+    ///
+    /// Unprobed on purpose (#287): that is a call-site contract with no
+    /// mechanical guard. Revisit if this cluster grows.
     const NO_BUGZILLA: &str = "http://127.0.0.1:1";
 
     /// A handler that panics on every call. A free `fn` rather than a

--- a/crates/bugwarden/tests/common/refused.rs
+++ b/crates/bugwarden/tests/common/refused.rs
@@ -26,8 +26,8 @@
 //! in `crates/bugwarden-core/tests/guard_wiremock.rs` — because a
 //! `#[path]` out of that package into this one's `tests/` reaches
 //! outside the package directory and would not survive packaging.
-//! Nothing but the pointer in each rustdoc pairs the two: edit one, edit
-//! the other.
+//! `the_core_copy_matches` is the pin: the two function bodies, modulo
+//! the timeout-panic sentence #280 reworded.
 
 /// Connect-time failure nothing in this process can answer (#115, #229).
 ///
@@ -36,8 +36,8 @@
 /// stranger racing an ephemeral port can answer this request. The
 /// load-bearing assertion is `port() < 1024` — a bind-then-drop of an
 /// ephemeral port fails the helper. A 500 ms TCP probe refuses to
-/// return an address that accepted or timed out; the URL is built from
-/// the probed socket so the two cannot drift.
+/// return an address that timed out; the URL is built from the probed
+/// socket so the two cannot drift.
 ///
 /// Scheme and authority only: a caller needing a path (`/v1/logs` for
 /// the OTLP export) appends its own.
@@ -48,15 +48,53 @@ pub fn refused_base_url() -> String {
         "these tests must use a privileged port; wiremock binds 127.0.0.1:0 (#115, #229)"
     );
     match std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(500)) {
-        Ok(_) => panic!(
-            "{addr} accepted a connection; these tests need a refused address \
-             that wiremock's 127.0.0.1:0 pool cannot occupy (#115)"
-        ),
         Err(e) if e.kind() == std::io::ErrorKind::TimedOut => panic!(
             "{addr} timed out; refusing to hand out an address whose failure \
              would arrive on the caller's client timeout instead of at \
              connect (#115, #280)"
         ),
-        Err(_) => format!("http://{addr}"),
+        _ => format!("http://{addr}"),
     }
+}
+
+/// Core cannot `#[path]` into this package's `tests/`; the bodies stay
+/// identical except the timeout-panic sentence #280 reworded.
+#[test]
+fn the_core_copy_matches() {
+    fn body(src: &str) -> &str {
+        const SIG: &str = "fn refused_base_url() -> String {";
+        let start = src.find(SIG).unwrap_or_else(|| panic!("{SIG} must exist")) + SIG.len();
+        let rest = &src[start..];
+        let end = rest
+            .find("\n}")
+            .unwrap_or_else(|| panic!("{SIG} body must close"));
+        &rest[..end]
+    }
+
+    // The one allowed difference: the string inside this panic!(...).
+    fn without_timeout_sentence(body: &str) -> String {
+        const ARM: &str = "Err(e) if e.kind() == std::io::ErrorKind::TimedOut => panic!(";
+        let start = body
+            .find(ARM)
+            .unwrap_or_else(|| panic!("the timeout-panic arm must exist"));
+        let rest = &body[start + ARM.len()..];
+        let close = rest
+            .find("),")
+            .unwrap_or_else(|| panic!("the timeout panic must close"));
+        let mut out = String::with_capacity(body.len());
+        out.push_str(&body[..start + ARM.len()]);
+        out.push_str(" SENTENCE ");
+        out.push_str(&rest[close..]);
+        out
+    }
+
+    let here = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let ours = std::fs::read_to_string(here.join("tests/common/refused.rs")).expect("this file");
+    let core = std::fs::read_to_string(here.join("../bugwarden-core/tests/guard_wiremock.rs"))
+        .expect("core's packaging-bound copy");
+    assert_eq!(
+        without_timeout_sentence(body(&ours)),
+        without_timeout_sentence(body(&core)),
+        "the two refused_base_url bodies must match modulo the timeout-panic sentence (#287)"
+    );
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3154,11 +3154,13 @@ wired, `server.rs` and `main.rs` are the reference.
   error text (I12) — the I12 transport-error sites connect to
   `127.0.0.1:1` (a privileged port a non-root wiremock `bind(127.0.0.1:0)`
   cannot occupy); `assert!(addr.port() < 1024)` is the mutation-kill for a
-  bind-then-drop of an ephemeral port, a 500 ms TCP probe refuses an
-  address that accepted or timed out (this package's own copy of the
-  probe the `bugwarden` crate shares from `tests/common/refused.rs` —
-  see the otel unit-test bullet; a `#[path]` out of this package could
-  not reach it, and the two are paired by their rustdoc alone),
+  bind-then-drop of an ephemeral port (occupy; the accepted-connect arm
+  is dropped), a 500 ms TCP probe refuses an address that timed out
+  (this package's own copy of the probe the `bugwarden` crate shares
+  from `tests/common/refused.rs` — see the otel unit-test bullet; a
+  `#[path]` out of this package could not reach it, and
+  `the_core_copy_matches` there pins the bodies modulo the timeout-panic
+  sentence),
   the client call is capped at 2 s,
   and the assertion requires reqwest's `error sending request` so an
   empty or HTTP-status error cannot pass a bare `!contains(KEY)`


### PR DESCRIPTION
Closes #287.

## What was wrong

Three leftovers from #280, none of them the defect it fixed:

1. Two hand copies of `refused_base_url()` (`tests/common/refused.rs` and a private fn in `bugwarden-core/tests/guard_wiremock.rs`). Core cannot `#[path]` into `bugwarden/tests/`.
2. The `Ok(_)` "accepted a connection" arm was unreachable non-root (`port() < 1024` fires first; bind `:1023` is EPERM).
3. `NO_BUGZILLA` is unprobed (zero `connect()`); rustdoc only.

## What changes

- Drop the `Ok(_)` arm in both copies. `port() < 1024` is occupy; timeout still panics.
- `the_core_copy_matches` reads both files and asserts the bodies identical modulo the TimedOut panic sentence.
- `NO_BUGZILLA` rustdoc records the unprobed contract; no strace row (accepted).
- DESIGN.md I12 inventory matches: no "accepted or timed out", pin is the body-equality test not rustdoc alone.

Test-only + rustdoc. Production connect paths unchanged.

## Review before opening

- **Security — MERGE-SAFE.** Helper is `#[cfg(test)]`. Never binds. TimedOut still panics. I2/I12 untouched.
- **Correctness — MERGE-SAFE.** Pin compares bodies modulo that one sentence; `_` arm stays in the compared region. `Ok(_)` gone. Pin runs in the lib harness and the path-including integration binaries.
- **Docs — MERGE-SAFE** after fold. DESIGN.md still described the pre-#287 probe; updated.
