### PR TITLE
fix(stdio): classify a pre-initialize stdin I/O error as failed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "prost",
  "reqwest",
  "rmcp",
+ "rustix",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/bugwarden/Cargo.toml
+++ b/crates/bugwarden/Cargo.toml
@@ -116,6 +116,11 @@ tokio = { version = "1", features = [
 ] }
 wiremock = "0.6"
 
+# `binary_shutdown`'s pre-handshake stdin EIO row (#285) opens a pty and
+# closes the master. Already in the lock file through tempfile.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+rustix = { version = "1", features = ["pty"] }
+
 # Distribution packages for the GitHub release (x86_64 Linux only, matching
 # the only Linux tarball target). Layout mirrors the openSUSE spec in
 # devel:tools so the two packagings do not disagree about where things go;

--- a/crates/bugwarden/src/main.rs
+++ b/crates/bugwarden/src/main.rs
@@ -248,10 +248,12 @@ async fn main() -> anyhow::Result<()> {
                 // arm — the cap comes from `server`'s own policy, and
                 // `serve` takes it by value.
                 let (stdin, stdout) = server.stdio_transport();
-                // rmcp maps the over-cap read error to `receive() -> None`,
-                // which the service reports as an ordinary close, so this
-                // flag is the only thing that tells the two apart below.
+                // rmcp maps every read error to `receive() -> None`, which
+                // the service reports as an ordinary close. Two flags tell
+                // the cases apart: the cap, and a failure that was not the
+                // cap (#285).
                 let over_cap = stdin.over_cap();
+                let io_failed = stdin.io_failed();
                 // `server/discover` is answered by the transport, never by
                 // rmcp's lifecycle picker: rmcp commits the session to the
                 // handshake-free lifecycle on the first non-`initialize`
@@ -269,11 +271,12 @@ async fn main() -> anyhow::Result<()> {
                         Ok(service) => service,
                         // A probe-only client is a peer hangup, not a
                         // serving failure: exit 0, as before #267. Not a
-                        // refused frame though — that closes the same way
-                        // and must stay a failure exit.
+                        // refused frame or a failed read though — those
+                        // close the same way and must stay a failure exit.
                         Err(rmcp::service::ServerInitializeError::ConnectionClosed(_))
                             if probed.load(Ordering::Acquire)
-                                && !over_cap.load(Ordering::Acquire) =>
+                                && !over_cap.load(Ordering::Acquire)
+                                && !io_failed.load(Ordering::Acquire) =>
                         {
                             tracing::info!("peer hung up after a server/discover probe");
                             return Ok(());
@@ -292,6 +295,18 @@ async fn main() -> anyhow::Result<()> {
                         {
                             tracing::error!("serving error: {OVER_CAP_CLOSE}");
                             anyhow::bail!("{OVER_CAP_CLOSE}");
+                        }
+                        // A real stdin failure, not a hangup: rmcp still
+                        // reports `ConnectionClosed` because it maps every
+                        // read error to `None`. The reader recorded that
+                        // this was not EOF and not the cap (#285).
+                        Err(rmcp::service::ServerInitializeError::ConnectionClosed(_))
+                            if io_failed.load(Ordering::Acquire) =>
+                        {
+                            tracing::error!("serving error: {INPUT_STREAM_FAILED}");
+                            return Err(anyhow::anyhow!(
+                                "stdio serving failed: {INPUT_STREAM_FAILED}"
+                            ));
                         }
                         // Never `e` itself, in either line: rmcp's error
                         // carries the client's whole first frame (#261).
@@ -418,6 +433,13 @@ async fn main() -> anyhow::Result<()> {
 /// descriptions on either side of `initialize`.
 const OVER_CAP_CLOSE: &str = "stdio transport closed: an inbound frame exceeded the request cap";
 
+/// Pre-handshake stdin I/O error, as opposed to a hangup.
+///
+/// Same `ConnectionClosed` as EOF; the reader recorded that the last
+/// read failed, so the caller names a failed stream rather than an
+/// ended one (#285). Post-handshake the same error still exits 0 (#272).
+const INPUT_STREAM_FAILED: &str = "the input stream failed before initialize";
+
 /// A fixed, server-authored classification of a failed stdio handshake —
 /// the only thing either exit path may say about one (#261).
 ///
@@ -471,10 +493,9 @@ fn serve_failure(error: &rmcp::service::ServerInitializeError) -> &'static str {
         },
         // Unreachable on rmcp 3.1.4: both construction sites pass `Some`.
         Failure::ExpectedInitializeRequest(None) => "no first frame was received",
-        // Actor-neutral on purpose: an EOF, a read error and this build's
-        // own frame-cap refusal all arrive here as the same `None`, and
-        // the arm cannot tell them apart. The caller names the cap when it
-        // knows; rmcp logs a read error itself.
+        // EOF before initialize. A read error and this build's own
+        // frame-cap refusal reach the same variant; the caller names
+        // those from the reader's flags. This arm is the remainder.
         Failure::ConnectionClosed(_) => "the stream ended before initialize",
         // Unreachable too: rmcp builds the value it checks here by mapping
         // this handler's own `InitializeResult` into `ServerResult`.

--- a/crates/bugwarden/src/stdio.rs
+++ b/crates/bugwarden/src/stdio.rs
@@ -17,10 +17,12 @@
 //! An over-cap frame is fatal, not skippable: the request id lives inside
 //! the unparsed frame, so no response can name it, and rmcp clients set no
 //! default request timeout — a peer that resumed would hang forever, which
-//! is worse than a closed transport. rmcp maps the read error to
+//! is worse than a closed transport. rmcp maps every read error to
 //! `receive() -> None`, i.e. a silent close indistinguishable from a clean
 //! peer hangup, so the trip is also published through [`BoundedLines::over_cap`]
-//! for `main` to turn into a non-zero exit.
+//! for `main` to turn into a non-zero exit. A failure that is not the cap
+//! is published through [`BoundedLines::io_failed`], so a descriptor error
+//! is not classified as a hangup (#285).
 //!
 //! [`DiscoverAnswering`] is the other half: rmcp reads the stdio lifecycle
 //! off the first frame, so a `server/discover` probe committed the session
@@ -70,6 +72,10 @@ pub struct BoundedLines<R> {
     /// Set once, never cleared: the read stays failed, and `main` reads it
     /// after `waiting()` to tell an over-cap close from a clean one.
     over_cap: Arc<AtomicBool>,
+    /// Set once a delegated read fails for a reason other than the cap.
+    /// Distinct from `over_cap`: that is this reader's refusal, this is
+    /// the inner stream failing. `main` names the two separately (#285).
+    io_failed: Arc<AtomicBool>,
 }
 
 impl<R> BoundedLines<R> {
@@ -80,6 +86,7 @@ impl<R> BoundedLines<R> {
             cap,
             since_newline: 0,
             over_cap: Arc::new(AtomicBool::new(false)),
+            io_failed: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -101,6 +108,17 @@ impl<R> BoundedLines<R> {
     /// non-zero.
     pub fn over_cap(&self) -> Arc<AtomicBool> {
         self.over_cap.clone()
+    }
+
+    /// The inner-read-error flag,
+    /// shared with whoever outlives the transport.
+    ///
+    /// rmcp turns every read error into `receive() -> None`, which before
+    /// the handshake is `ConnectionClosed` — the same shape as EOF. Without
+    /// this flag a failed descriptor and a hangup are the same sentence.
+    /// `main` reads it to say the input stream failed (#285).
+    pub fn io_failed(&self) -> Arc<AtomicBool> {
+        self.io_failed.clone()
     }
 
     /// The error a tripped reader returns, on the trip and on every read
@@ -161,7 +179,10 @@ impl<R: AsyncRead + Unpin> AsyncRead for BoundedLines<R> {
             return Poll::Ready(Err(this.refusal()));
         }
         let before = buf.filled().len();
-        ready!(Pin::new(&mut this.inner).poll_read(cx, buf))?;
+        if let Err(e) = ready!(Pin::new(&mut this.inner).poll_read(cx, buf)) {
+            this.io_failed.store(true, Ordering::Release);
+            return Poll::Ready(Err(e));
+        }
         let mut rest = &buf.filled()[before..];
         while let Some(newline) = rest.iter().position(|&byte| byte == b'\n') {
             if this.since_newline.saturating_add(newline) > this.cap {
@@ -361,12 +382,16 @@ impl<T: Transport<RoleServer>> Transport<RoleServer> for DiscoverAnswering<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::io;
+    use std::pin::Pin;
+    use std::sync::atomic::Ordering;
+    use std::task::{Context, Poll};
     use std::time::Duration;
 
     use rmcp::transport::async_rw::AsyncRwTransport;
     use rmcp::transport::Transport as _;
     use rmcp::RoleServer;
-    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _, DuplexStream};
+    use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWriteExt as _, DuplexStream, ReadBuf};
 
     use super::BoundedLines;
 
@@ -558,6 +583,46 @@ mod tests {
             received.is_none(),
             "an over-cap frame must close the transport, not yield a message"
         );
+    }
+
+    #[tokio::test]
+    async fn a_cap_trip_is_not_recorded_as_an_io_failure() {
+        let mut reader = BoundedLines::new(&b"0123456789abcdefg\n"[..], 16);
+        let mut buf = [0u8; 64];
+        reader.read(&mut buf).await.expect_err("over the cap");
+        assert!(reader.over_cap().load(Ordering::Acquire));
+        assert!(
+            !reader.io_failed().load(Ordering::Acquire),
+            "the cap is this reader's refusal, not the inner stream failing"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_read_error_is_recorded_as_an_io_failure() {
+        struct Fail;
+        impl AsyncRead for Fail {
+            fn poll_read(
+                self: Pin<&mut Self>,
+                _: &mut Context<'_>,
+                _: &mut ReadBuf<'_>,
+            ) -> Poll<io::Result<()>> {
+                Poll::Ready(Err(io::Error::other("injected")))
+            }
+        }
+        let mut reader = BoundedLines::new(Fail, 16);
+        let mut buf = [0u8; 8];
+        reader.read(&mut buf).await.expect_err("inner I/O error");
+        assert!(reader.io_failed().load(Ordering::Acquire));
+        assert!(!reader.over_cap().load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn eof_is_not_recorded_as_an_io_failure() {
+        let mut reader = BoundedLines::new(&b""[..], 16);
+        let mut buf = [0u8; 8];
+        assert_eq!(reader.read(&mut buf).await.expect("EOF is Ok(0)"), 0);
+        assert!(!reader.io_failed().load(Ordering::Acquire));
+        assert!(!reader.over_cap().load(Ordering::Acquire));
     }
 }
 

--- a/crates/bugwarden/tests/binary_shutdown.rs
+++ b/crates/bugwarden/tests/binary_shutdown.rs
@@ -45,6 +45,8 @@
 //!   directive DESIGN.md documents addressing nothing;
 //! - either handshake-failure line formatting rmcp's error instead of the
 //!   classification, or the classification naming the wrong frame kind;
+//! - a pre-handshake stdin I/O error described as a hangup ("the stream
+//!   ended") rather than a failed input stream (#285);
 //! - any `serve_failure` arm deleted so its failure falls to the wildcard,
 //!   or any two of its literals exchanged. Three arms have no row, and
 //!   cannot: `ExpectedInitializeRequest(None)` is constructed nowhere in
@@ -248,9 +250,14 @@ impl Server {
     /// [`Self::spawn`] with the child's stdout chosen by the caller, for
     /// the one row that needs a stdout nothing will ever read.
     fn spawn_with_stdout(args: &[&str], stdout: Stdio) -> Self {
+        Self::spawn_with_io(args, Stdio::piped(), stdout)
+    }
+
+    /// [`Self::spawn`] with both pipes chosen by the caller.
+    fn spawn_with_io(args: &[&str], stdin: Stdio, stdout: Stdio) -> Self {
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_bugwarden"));
         cmd.args(args)
-            .stdin(Stdio::piped())
+            .stdin(stdin)
             .stdout(stdout)
             .stderr(Stdio::piped());
         for var in scrub_env::AMBIENT_VARS {
@@ -602,6 +609,69 @@ fn stdout_with_no_reader() -> Stdio {
     panic!("a pipe whose only reader was dropped never became BrokenPipe");
 }
 
+/// A pty slave as stdin, and the master to close once the child is
+/// blocked in a read. Closing the last master makes a slave read fail
+/// `EIO` rather than EOF — the hangup row's pipe cannot.
+///
+/// `CLOEXEC` on the master is load-bearing: if the child inherited it,
+/// dropping the parent's copy would leave a master open and the read
+/// would hang until this file's budget, not fail.
+#[cfg(target_os = "linux")]
+fn stdin_from_pty() -> (Stdio, std::fs::File) {
+    use rustix::pty::{ioctl_tiocgptpeer, openpt, unlockpt, OpenptFlags};
+
+    let flags = OpenptFlags::RDWR | OpenptFlags::NOCTTY | OpenptFlags::CLOEXEC;
+    let master = openpt(flags).expect("the test host must provide a pty");
+    unlockpt(&master).expect("the pty must unlock");
+    let slave = ioctl_tiocgptpeer(&master, flags).expect("the pty slave must open");
+    (
+        Stdio::from(std::fs::File::from(slave)),
+        std::fs::File::from(master),
+    )
+}
+
+/// Close-the-master *before* a slave read is outstanding is EOF; during
+/// one is `EIO`. The startup line is logged before `serve` polls stdin,
+/// so it is not this barrier.
+#[cfg(target_os = "linux")]
+async fn wait_until_stdin_read_is_outstanding(pid: u32) {
+    let ready = tokio::time::timeout(EXIT_TIMEOUT, async {
+        loop {
+            if a_thread_is_reading_stdin(pid) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await;
+    assert!(
+        ready.is_ok(),
+        "the child must block in a stdin read before the master is closed: pid={pid}"
+    );
+}
+
+/// `/proc/<pid>/task/*/syscall`: a blocked `read`/`readv` of fd 0.
+/// x86_64 `read`/`readv` are 0/19; aarch64 and riscv64 are 63/65.
+#[cfg(target_os = "linux")]
+fn a_thread_is_reading_stdin(pid: u32) -> bool {
+    let Ok(tasks) = std::fs::read_dir(format!("/proc/{pid}/task")) else {
+        return false;
+    };
+    tasks.flatten().any(|task| {
+        let Ok(syscall) = std::fs::read_to_string(task.path().join("syscall")) else {
+            return false;
+        };
+        let mut words = syscall.split_whitespace();
+        let Some(nr) = words.next() else {
+            return false;
+        };
+        let Some(fd) = words.next() else {
+            return false;
+        };
+        matches!(nr, "0" | "19" | "63" | "65") && matches!(fd, "0" | "0x0")
+    })
+}
+
 /// `run` copies of `filler`, as one string: the needle a leaked client
 /// string would put on stderr.
 fn run_of(filler: char, run: usize) -> String {
@@ -927,12 +997,12 @@ async fn stdio_a_pre_initialize_error_reply_never_logs_its_message() {
 
 #[tokio::test]
 async fn stdio_a_hangup_before_initialize_is_classified_not_echoed() {
-    // `ConnectionClosed`, which an EOF, a read error and this build's own
-    // frame-cap refusal all reach — so the classification is deliberately
-    // neutral about who ended the stream, and the over-cap rows above pin
-    // the one case `main` can name. Its payload is server-authored today,
-    // which is exactly why it must not be echoed either: a `String` on a
-    // `#[non_exhaustive]` enum is an upstream bump away from client text.
+    // `ConnectionClosed` from a pipe EOF. A read error and this build's
+    // own frame-cap refusal reach the same variant;
+    // those have their own rows and the reader's flags name them. Its
+    // payload is server-authored today, which is exactly why it must not
+    // be echoed either: a `String` on a `#[non_exhaustive]` enum is an
+    // upstream bump away from client text.
     let mut server = spawn_stdio();
     server.wait_for_stderr(STDIO_READY).await;
     server.close_stdin();
@@ -940,6 +1010,28 @@ async fn stdio_a_hangup_before_initialize_is_classified_not_echoed() {
         .assert_bounded_handshake_failure(
             "stdio pre-handshake hangup",
             "the stream ended before initialize",
+            None,
+        )
+        .await;
+}
+
+/// A genuine stdin I/O error before initialize, not a hangup (#285).
+///
+/// Closing a pipe is EOF. Closing the last pty master makes a slave
+/// read fail `EIO`, which rmcp still maps to `ConnectionClosed`. Linux
+/// only, the way the `/dev/full` row is.
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn stdio_a_pre_initialize_stdin_error_is_classified_as_failed() {
+    let (stdin, master) = stdin_from_pty();
+    let mut server = Server::spawn_with_io(&STDIO_ARGS, stdin, Stdio::piped());
+    server.wait_for_stderr(STDIO_READY).await;
+    wait_until_stdin_read_is_outstanding(server.pid()).await;
+    drop(master);
+    server
+        .assert_bounded_handshake_failure(
+            "stdio pre-handshake stdin I/O error",
+            "the input stream failed before initialize",
             None,
         )
         .await;

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1432,17 +1432,20 @@ Decisions, all deliberate:
   into the outer wildcard, which is there for `ServerInitializeError`'s
   `#[non_exhaustive]` alone.
 
-  One failure is named by the CALLER instead, because the classifier
-  cannot see it: this build's own frame-cap refusal reaches rmcp as a
-  read error, rmcp turns every read error into `receive() -> None`, and
-  `None` before the handshake is `ConnectionClosed` — indistinguishable
-  from the peer walking away. So the arm's own text stays neutral about
-  who ended the stream, and the `over_cap` flag the #267 arm already
-  reads picks the cap's sentence out of `OVER_CAP_CLOSE`, the same
-  constant the post-handshake refusal bails with: one refusal keeps one
-  description on either side of `initialize`. Nothing else moves: exit
-  status stays 1, and the `probed && !over_cap` hangup arm (#267) still
-  returns 0 ahead of both.
+  Two failures are named by the CALLER instead, because the classifier
+  cannot see them: this build's own frame-cap refusal and a genuine stdin
+  I/O error both reach rmcp as a read error, rmcp turns every read error
+  into `receive() -> None`, and `None` before the handshake is
+  `ConnectionClosed` — the same variant as the peer walking away. The
+  arm's own text stays the hangup sentence, and the reader's flags pick
+  the others out: `over_cap` selects `OVER_CAP_CLOSE` (the same constant
+  the post-handshake refusal bails with, so one refusal keeps one
+  description on either side of `initialize`); a non-cap read error
+  selects "the input stream failed before initialize" (#285). Nothing
+  client-authored enters either line — an `io::ErrorKind` name would be
+  server text, and is not used. Exit status stays 1, and the
+  `probed && !over_cap && !io_failed` hangup arm (#267) still returns 0
+  ahead of both.
 - **The params caps bound content, not record size — and a total cap is a
   decided no** (#220). Array element and map entry counts are uncapped, so
   an allowlisted value's SHAPE can still make a large record; what bounds
@@ -2400,9 +2403,11 @@ wired, `server.rs` and `main.rs` are the reference.
   where it used to return a live session. `main` reads that as the peer hangup
   it is and exits 0, as before #267, but only where
   `DiscoverAnswering::answered` says a probe was answered AND the frame cap is
-  untripped: an over-cap frame closes the transport the same way and stays a
-  failure exit (`stdio_a_probe_then_an_over_cap_frame_still_exits_one`). Every
-  other `ConnectionClosed` still exits 1, and
+  untripped AND the input stream did not fail (#285): an over-cap frame
+  closes the transport the same way and stays a failure exit
+  (`stdio_a_probe_then_an_over_cap_frame_still_exits_one`); a failed read
+  does too (`stdio_a_pre_initialize_stdin_error_is_classified_as_failed`).
+  Every other `ConnectionClosed` still exits 1, and
   `a_probe_only_client_hangs_up_cleanly` pins the code and the log line. HTTP
   needs none of this and gets none: `serve_negotiated_request_directly` answers
   a discover per POST and sets no flag, which
@@ -2604,7 +2609,7 @@ wired, `server.rs` and `main.rs` are the reference.
   dispatch line above is WARN for the other half of the rule: before #270
   it was the only per-request, client-repeatable ERROR in THIS
   WORKSPACE's code. `server.rs`'s sole other production `tracing::error!`
-  is behind a `Once`; of the rest, `main.rs`'s two serving-error arms end
+  is behind a `Once`; of the rest, `main.rs`'s three serving-error arms end
   the process, `audit.rs`'s sink diagnostic is rate-limited, and `main.rs`'s
   signal-arming failure runs at most once per signal kind at startup — so
   none of them is a lever a client can pull twice. `stdio.rs`'s over-cap
@@ -2870,7 +2875,9 @@ wired, `server.rs` and `main.rs` are the reference.
   dependency's ERROR as the only sign of it, is pre-existing and outside
   #272's scope; it is recorded here as a fact, not fixed. It is also why the
   directive stays OUT of the default filter: a default that hides a genuine
-  read error is worse than a noisy refusal.
+  read error is worse than a noisy refusal. Pre-handshake, the same `EIO`
+  is classified: `serve` returns `ConnectionClosed` and `main` names it a
+  failed input stream rather than a hangup (#285).
 
   Not done, deliberately: emitting a null-id `-32700` on stdout before
   closing. It is new stdout-after-close behaviour bought for a nicety, and
@@ -3773,10 +3780,15 @@ wired, `server.rs` and `main.rs` are the reference.
   (`serving error`) before the handshake and none after it, and rmcp's echo
   is still an ERROR on `rmcp::transport::async_rw` — asserted rather than
   merely tolerated, because that target and that level are exactly what the
-  `RUST_LOG` directive documented above addresses. The `serving error` line
-  of the OTHER handshake-failure arm is pinned at ERROR in the same file
-  (`assert_bounded_handshake_failure`), so neither arm can be demoted
-  unnoticed; before this, no test read either arm's level.
+  `RUST_LOG` directive documented above addresses. A pre-handshake stdin
+  I/O error is a separate row
+  (`stdio_a_pre_initialize_stdin_error_is_classified_as_failed`, Linux):
+  closing the pty master under an outstanding slave read must classify as
+  "the input stream failed before initialize", not "the stream ended"
+  (#285). The `serving error` line of every handshake-failure arm is
+  pinned at ERROR in the same file (`assert_over_cap_exit`,
+  `assert_bounded_handshake_failure`), so none of those arms can be
+  demoted unnoticed; before this, no test read either arm's level.
 - Startup-wiring tests (crates/bugwarden/tests/binary_startup_policy.rs,
   the SHIPPED BINARY): the three `main.rs` sites only a process executes,
   which is why a hand mutation run found all three bare (#269). The I9


### PR DESCRIPTION
Closes #285.

## What was wrong

rmcp maps every stdin read error to `receive() -> None`, which before handshake is `ServerInitializeError::ConnectionClosed`. `serve_failure` rendered that as "the stream ended" — EOF, a genuine I/O error, and the over-cap trip were not distinguished. Over-cap already had a flag; I/O did not. Measured: close a pty master while a read is outstanding, before any frame → `Input/output error` from rmcp, then "the stream ended before initialize". Post-handshake half is #272 (exit 0) and stays there.

## What changes

- `BoundedLines` records `io_failed` on an inner `Err` only (not cap trip, not EOF).
- Pre-handshake `ConnectionClosed` consults that flag like `over_cap` and says **the input stream failed before initialize**. Nothing client-authored: sticky bool + `'static` sentence.
- Linux pty row in `binary_shutdown`: wait until `/proc/…/syscall` shows a blocked stdin read, drop the master, assert the failed-stream wording. Closing too early yields "ended", which fails the assertion.
- Pipe hangup still pins "ended". Over-cap still pins `OVER_CAP_CLOSE`.
- `rustix` is a linux-only test dep (`pty`); not in the shipped binary.

## Review before opening

- **Security — MERGE-SAFE.** Classification is a bool + `'static` text. No `ErrorKind` on the line. Flag not set on cap/EOF. Post-handshake #272 unchanged. rustix not in normal deps. Store `Release` before `Poll::Ready(Err)`; `Acquire` after `serve` returns.
- **Correctness — MERGE-SAFE.** Same `Arc` as the `BoundedLines` moved into `framed`. Pty wait-on-syscall is the race kill. 20/20 locally. macOS compiles the file, strips the row.
- **Docs — MERGE-SAFE** after fold. Testing names the EIO row and counts three serving-error arms. #285 is the classified pre-handshake counterpart, not a half of the unfixed #272 gap. `io_failed` rustdoc wrap.
