### PR TITLE
fix(audit): bounds-check the export record slice

### DIFF
--- a/crates/bugwarden/src/audit.rs
+++ b/crates/bugwarden/src/audit.rs
@@ -1472,15 +1472,17 @@ impl AuditSink {
             // it, so what the exporter gets is byte-for-byte the record
             // line the file holds. Still under the state lock, so export
             // order equals `seq` order — accepting only queues.
-            let start = usize::from(healed);
             // Load-bearing since 2026-08-18 (#31): a record the exporter
             // cannot even accept is a record that will not be delivered,
             // and saying so here is what puts the call in front of the
             // same fail-mode gate a failed file write does. The file, if
             // any, keeps the record — the loss accounting over-reports
             // rather than under-reports, as it does under `fsync`.
+            let Some(payload) = export_record_bytes(&line, healed) else {
+                return Err(AuditError::Export);
+            };
             export
-                .accept(&event, &line[start..line.len() - 1])
+                .accept(&event, payload)
                 .map_err(|ExportRefused| AuditError::Export)?;
         }
         Ok(seq)
@@ -1629,6 +1631,14 @@ impl AuditSink {
         self.fail_rotation
             .store(fail, std::sync::atomic::Ordering::Relaxed);
     }
+}
+
+/// Bytes the exporter sees: no repair prefix, no terminating `\n`.
+/// `get` rather than index — a panic here is outside the #253 catcher.
+fn export_record_bytes(line: &[u8], healed: bool) -> Option<&[u8]> {
+    let start = usize::from(healed);
+    let end = line.len().saturating_sub(1);
+    line.get(start..end)
 }
 
 /// Open the live audit file append-only, creating it mode 0600 if absent.
@@ -3317,6 +3327,26 @@ mod tests {
     }
 
     // ---------- the exporter as a load-bearing sink ----------
+
+    #[test]
+    fn export_record_bytes_strips_repair_prefix_and_terminator() {
+        let record = br#"{"v":2,"seq":1}"#;
+        let mut line = record.to_vec();
+        line.push(b'\n');
+        assert_eq!(export_record_bytes(&line, false), Some(&record[..]));
+
+        let mut healed = vec![b'\n'];
+        healed.extend_from_slice(&line);
+        assert_eq!(export_record_bytes(&healed, true), Some(&record[..]));
+
+        // start > end: a repair prefix on a line shorter than two bytes.
+        assert_eq!(export_record_bytes(b"\n", true), None);
+        assert_eq!(export_record_bytes(b"x", true), None);
+
+        // saturating_sub: empty unhealed is an empty slice, not a panic.
+        assert_eq!(export_record_bytes(b"", false), Some(&b""[..]));
+        assert_eq!(export_record_bytes(b"", true), None);
+    }
 
     /// A scriptable exporter for sink-side tests.
     #[derive(Debug, Default)]

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3674,9 +3674,10 @@ wired, `server.rs` and `main.rs` are the reference.
   `config.rs`, `http_auth.rs`, `otel.rs`, `stdio.rs` or `audit.rs` holds a
   production `expect`, `unwrap`, `panic!` or `unreachable!`; the index and
   slice sites that do exist there — `audit.rs`'s traceparent parser,
-  `otel.rs`'s `hex_bytes`, `stdio.rs`'s newline scan — each check the
-  length or the position before they index, so no operator or client value
-  reaches one out of bounds. The one numeric CLI value is `--port`, a
+  `audit.rs`'s export record slice (#279), `otel.rs`'s `hex_bytes`,
+  `stdio.rs`'s newline scan — each check the length or the position
+  before they index, so no operator or client value reaches one out of
+  bounds. The one numeric CLI value is `--port`, a
   `u16` clap parses and no arithmetic touches; the rotation check adds the
   live file's own length, which no operator value can drive to a `u64`
   overflow even under the overflow checks a debug build has; and the


### PR DESCRIPTION
Closes #279.

## What was wrong

`export.accept(&event, &line[start..line.len() - 1])` was the one production slice on the record path with no length check. Safe by construction (repair `\n` + JSON + trailing `\n`), but a panic there is inside `AuditSink::write`, **outside the #253 catcher**: the request is answered by nobody and the record is half-written.

## What changes

`export_record_bytes`: `get` + `saturating_sub(1)`. `None` is `AuditError::Export`, same as an exporter refusal (file keeps the record; sink goes failing). Unit rows pin a normal line, a healed line, `start > end`, and empty. DESIGN.md inventory names this site (#279) among the length-checked slices.

I15: audit still not an MCP surface. I12: Export stays content-free.

## Review before opening

- **Security — MERGE-SAFE.** `None` after the file write takes the same dropped/`failing()` path as `ExportRefused`. No underflow. MCP cannot read the stream.
- **Correctness — MERGE-SAFE.** Helper drops only the repair prefix and trailing `\n`. Tests panic if `get` is reverted to `[]`.
- **Docs — MERGE-SAFE.** Inventory is present-tense with `(#279)`; does not claim it always checked.
