### PR TITLE
docs(core): say the search chunk clamp is overrun-only

### DIFF
--- a/crates/bugwarden-core/src/guard.rs
+++ b/crates/bugwarden-core/src/guard.rs
@@ -347,6 +347,9 @@ impl Guard {
             && scanned < Self::SEARCH_SCAN_MAX
             && requests < Self::SEARCH_SCAN_REQUESTS
         {
+            // Reachable only when upstream overruns `limit`. Pin:
+            // quicksearch_window_never_asks_for_more_rows_than_its_budget
+            // in guard_wiremock.rs.
             let chunk = Self::SEARCH_SCAN_CHUNK.min(Self::SEARCH_SCAN_MAX - scanned);
             let envelope = bz
                 .quicksearch(key, query, status, include_fields, chunk, scanned)


### PR DESCRIPTION
Closes #259.

## What was wrong

`Guard::quicksearch_window`'s chunk clamp never bites against an upstream that honours `limit`. It is defence against an over-returning upstream. Nothing said so.

## What changes

Three comment lines on the clamp. Pin: `quicksearch_window_never_asks_for_more_rows_than_its_budget`. No behaviour change.

## Review before opening

- **Security — MERGE-SAFE.** Clamp expression and `SEARCH_SCAN_MAX` unchanged. I3 untouched.
- **Correctness — MERGE-SAFE.** Comment is true for a conformant upstream; test name is the 1950-row pin.
- **Docs — MERGE-SAFE.** When-plus-pin, not a `min()` walkthrough.
