### PR TITLE
ci: raise the mutants timeout floor past a 4-vCPU wiremock hang

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -30,18 +30,20 @@ test_workspace = true
 # ceil(failing tests / test threads) x 30s, since libtest defaults its
 # thread count to the core count. Measured under a hand-applied
 # CatchUnwind mutant that answers nothing, on a 32-core box and then at
-# --test-threads=4 to stand in for a small runner: the lib binary's 22
-# failures take 31s and 158s, audit_wiremock's 36 take 60s and 271s,
-# tools_wiremock's 82 take 91s and 632s. Four threads is thus already the
-# edge -- the floor holds for a mutant the lib binary catches, and cargo
-# reaches that binary first, but one that hangs ONLY a wiremock harness
-# outruns the floor and reports TIMEOUT with its verdict unknown. That
-# residual is #254's and is left standing on purpose: a shorter deadline
-# converts hangs sooner but flakes sooner too, on the smaller runners
-# ci.yml's rust-macos job and this workflow use, and the lever for the
-# residual is this floor or a --test-threads pinned in mutants.yml rather
-# than the constant the tests share.
+# --test-threads=4 to stand in for ubuntu-latest's 4-vCPU runner: the
+# lib binary's 22 failures take 31s and 158s, audit_wiremock's 36 take
+# 60s and 271s, tools_wiremock's 82 take 91s and 632s. Size the floor
+# from that 4-thread side of the largest harness: tools_wiremock has
+# 85 tests, ceil(85 / 4) x 30s = 660s, call it 720 (#283). A hang
+# confined to that harness used to report TIMEOUT with the verdict
+# unknown; 720s clears the measured 632s with margin.
+#
+# The floor is per mutant. Caught mutants still finish in tens of
+# seconds, so raising it costs only when a mutant actually hangs. A
+# shard of real hangs would still trip mutants.yml's timeout-minutes
+# (720s x ~36 is past 240 min) and that is the finding -- the job cap
+# is the outer bound, not this floor.
 #
 # A floor and not --timeout, so the 5x multiplier still scales past it on a
 # slow runner or once upstream fixes the baseline.
-minimum_test_timeout = 300
+minimum_test_timeout = 720

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -41,17 +41,19 @@ jobs:
     # reason is gone -- quicksearch_window's panicking mutants no longer hang
     # the in-process client to the timeout floor, because a tool handler that
     # panics is now answered with an internal error (#253) and those tests
-    # fail in seconds. Worth revisiting once some scheduled runs have shown
-    # the timeout floor holds.
+    # fail in seconds. A hang confined to a wiremock harness pays
+    # ceil(failing tests / cores) x 30s; that floor is sized in
+    # .cargo/mutants.toml, not here.
     runs-on: ubuntu-latest
     # Measured at 30-46s of incremental build plus 6-23s of tests per mutant on
     # a 32-core box -- main.rs averaged 43s there, inside that band, so the
     # startup scope costs no more per mutant than the guard one. Call it ~3 min
     # on a 4-core runner. Doubled for margin -- a shard that outruns this has
-    # itself become the finding. Unsharded the scope below does not fit
-    # GitHub's 360-minute ceiling, so the shards are load-bearing rather than
-    # a convenience. Live per-file counts are the Mutate step's summary, not
-    # this comment.
+    # itself become the finding, including a run of hangs each paying the
+    # floor in .cargo/mutants.toml (ceil(largest harness / 4) x 30s). Unsharded
+    # the scope below does not fit GitHub's 360-minute ceiling, so the shards
+    # are load-bearing rather than a convenience. Live per-file counts are the
+    # Mutate step's summary, not this comment.
     timeout-minutes: 240
     strategy:
       # A survivor in one shard must not cancel the rest: the run's value is


### PR DESCRIPTION
Closes #283.

## What was wrong

A mutant that hangs only a wiremock harness pays `ceil(failing tests / threads) × 30s`. On 4-vCPU, `tools_wiremock` was 632s measured, above `minimum_test_timeout = 300`. Verdict TIMEOUT, unknown — the outcome #254 set out to remove.

## What changes

Direction (a): `minimum_test_timeout = 720` (`ceil(85/4)×30s = 660`, with margin). Formula and box written into `mutants.toml`. `mutants.yml` points at that floor; a shard of real hangs still trips `timeout-minutes: 240` and that is the finding. Rebased onto #277 so comments do not restore the rotting 9/134 counts. `CALL_DEADLINE` and `--test-threads` unchanged.

## Review before opening

- **Security — MERGE-SAFE.** Production tests and `CALL_DEADLINE` untouched. Floor is per-mutant and paid only on a hang.
- **Correctness — MERGE-SAFE.** 720 > 660. Key is `minimum_test_timeout`, not `--timeout`. Residual-left-standing comments gone.
- **Docs — MERGE-SAFE.** No leftover 300.
