### PR TITLE
ci(release): attest container image provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,8 +315,12 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-      # Push the per-architecture images to ghcr.io.
+      # Push the per-architecture images to ghcr.io, and the attestation
+      # bundle (`push-to-registry` on the attest step).
       packages: write
+      # Same pair as `release`: OIDC for the Sigstore cert, store the bundle.
+      id-token: write
+      attestations: write
     env:
       CTR: bugwarden-smoke
     strategy:
@@ -354,9 +358,23 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           build-args: VERSION=${{ env.VERSION }}
+          # Pin mode=max: public repos already default to it, a fork/private
+          # clone would silently drop to min. VERSION is not a secret (max
+          # exposes build-args).
+          provenance: mode=max
           # No cache-from/cache-to: releases build hermetically, same rule as
           # the cargo-cache-free `build` job above.
           outputs: type=image,name=ghcr.io/plusky/bugwarden,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Attest the image digest
+        # Attest before named tags: a provenance failure must fail this
+        # job so container-manifest never publishes :$VERSION / :latest.
+        # The digest is already in ghcr.io; that residue is accepted.
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
+        with:
+          subject-name: ghcr.io/plusky/bugwarden
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
       - name: Pull the pushed image by digest
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,11 @@ A release is one push of an annotated tag; nothing is released by hand.
   are `dist/*` less the `.sha256` files, so a new artifact is covered
   without editing the step. Verify with `gh attestation verify <file>
   --repo plusky/bugwarden`. crates.io gets its own provenance from Trusted
-  Publishing; the container image has none yet.
+  Publishing. Each architecture's container digest is attested in the
+  `container` job after push-by-digest and before smoke, so a provenance
+  failure cannot publish `:$VERSION` / `:latest`; verify with
+  `gh attestation verify oci://ghcr.io/plusky/bugwarden@<digest>
+  --repo plusky/bugwarden`.
 - The same tag also ships the multi-arch container image
   `ghcr.io/plusky/bugwarden` (jobs `container`, `container-manifest`).
   `container` runs `scripts/container-smoke.sh` — ci.yml's own assertions —


### PR DESCRIPTION
Closes #196.

Tarballs/`.deb`/`.rpm` already use `actions/attest-build-provenance`. crates.io has Trusted Publishing. Remaining gap: the container image.

## What changes

- `provenance: mode=max` on `docker/build-push-action` (public default, now pinned).
- After push-by-digest, before smoke: same attest pin as the `release` job, `subject-name: ghcr.io/plusky/bugwarden`, `subject-digest` from the build step, `push-to-registry: true`. Failed provenance fails `container`, so `container-manifest` never publishes `:$VERSION` / `:latest`.
- `container` permissions: `id-token: write` + `attestations: write`.
- AGENTS.md: verify with `gh attestation verify oci://ghcr.io/plusky/bugwarden@<digest> --repo plusky/bugwarden`.

`ci.yml` docker smoke (`load: true`) unchanged. No `cargo auditable`.

## Review before opening

- **Security — MERGE-SAFE.** OIDC is job-scoped; JWT goes to Sigstore not GHCR. `VERSION` is the public tag. Attest before named tags.
- **Correctness — MERGE-SAFE.** Digest already `sha256:<hex>`. Pin matches the release job. actionlint clean. `gh attestation verify oci://` is documented.
- **Docs — MERGE-SAFE.** "none yet" is gone; subject is each arch digest.
