### PR TITLE
docs(audit): pin rmcp pre-dispatch refusals as unrecorded

### DIFF
--- a/crates/bugwarden/tests/http_transport_wiremock.rs
+++ b/crates/bugwarden/tests/http_transport_wiremock.rs
@@ -1946,6 +1946,89 @@ async fn a_header_only_2026_declaration_is_refused_by_the_transport() {
 }
 
 #[tokio::test]
+async fn a_pre_dispatch_rmcp_refusal_writes_no_tool_call_record() {
+    // Issue #182: rmcp refuses these in the blanket `Service` impl before
+    // `call_tool`, so the stream has no record. Logged (`tracing::warn`
+    // `response error`), not audited; no hook that works on both
+    // transports. If a future rmcp stops refusing first, the arms split:
+    // `"9999-01-01"` is `OutOfContract` (recorded refusal); missing
+    // `clientCapabilities` at served `2026-07-28` is `PerRequest` and
+    // would run the tool. Either way a `tool_call` appears and this
+    // fails. The `-32022` itself is
+    // `an_http_probe_never_commits_the_session_lifecycle`; this pins the
+    // stream boundary.
+    //
+    // `Mcp-Method` / `Mcp-Name` are load-bearing: `"9999-01-01"` outranks
+    // 2026-07-28, so without them the transport answers -32020 first.
+    // `clientCapabilities` on the unserved row keeps the missing-keys
+    // check from stealing it as -32602.
+    let mock = MockServer::start().await;
+    let dir = tempfile::tempdir().expect("audit temp dir");
+    let file = key_file("srv-key\n");
+    let (addr, audit_path) = served_with_audit(&mock, &dir, &file).await;
+
+    let session = raw_initialize(addr, "pre-dispatch-client").await;
+
+    for (revision, caps, code, why) in [
+        ("9999-01-01", true, -32022, "unserved revision"),
+        (
+            PER_REQUEST_REVISION,
+            false,
+            -32602,
+            "missing clientCapabilities",
+        ),
+    ] {
+        let meta = if caps {
+            json!({
+                "io.modelcontextprotocol/protocolVersion": revision,
+                "io.modelcontextprotocol/clientCapabilities": {}
+            })
+        } else {
+            json!({ "io.modelcontextprotocol/protocolVersion": revision })
+        };
+        let response = mcp_post(addr, Some(&session))
+            .header("MCP-Protocol-Version", revision)
+            .header("Mcp-Method", "tools/call")
+            .header("Mcp-Name", "bug_info")
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "bug_info",
+                    "arguments": { "bug_ids": [7] },
+                    "_meta": meta
+                }
+            }))
+            .send()
+            .await
+            .expect("the refused call must reach the server");
+        let body = response.text().await.expect("a body");
+        let payload: Value = body
+            .lines()
+            .find_map(|line| line.strip_prefix("data: "))
+            .and_then(|data| serde_json::from_str(data).ok())
+            .unwrap_or_else(|| {
+                serde_json::from_str(&body).unwrap_or_else(|e| panic!("{why}: {body}: {e}"))
+            });
+        assert_eq!(
+            payload["error"]["code"],
+            json!(code),
+            "{why}: expected {code}: {body}"
+        );
+    }
+
+    let events = audit_events(&audit_path);
+    let _ = initialize_of(&events, "pre-dispatch-client");
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e.kind, AuditEventKind::ToolCall(_))),
+        "a pre-dispatch refusal must write no tool_call record"
+    );
+}
+
+#[tokio::test]
 async fn a_per_request_call_cannot_reach_a_tool_the_deployment_pruned_i13() {
     // I13 under the handshake-free lifecycle: the pruned INSTANCE router is
     // what dispatch goes through on this path too, so a write tool

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -949,6 +949,23 @@ Decisions, all deliberate:
   header, path or peer, so it is no oracle. A read-scope caller's refused write
   call IS audited, as one ordinary `tool_call` record with no guard verdict and
   no upstream leg — the same shape an unknown tool name produces.
+- **Pre-dispatch rmcp refusals are logged, not audited.** Independent of
+  the bearer gate: a request whose `_meta` protocol revision is outside
+  the served five (`"9999-01-01"` → `-32022`) or that names a served
+  revision without `clientCapabilities` (`-32602`) dies in rmcp's blanket
+  `Service` impl, before `call_tool` — the only place records are written.
+  Both transports funnel the handler `Err` through
+  `tracing::warn!(%id, ?error, "response error")`, so the distinction
+  lives in the log, not the stream. There is no hook that works on both:
+  a hand-written `Service` wrapper covers stdio, but
+  `StreamableHttpService::new` requires `S: ServerHandler` and re-acquires
+  the blanket impl — wrapping stdio alone would make coverage differ by
+  transport. If a future rmcp stops refusing first, the two arms split:
+  `"9999-01-01"` (`-32022`) fails `lifecycle_of`'s `contains` into
+  `OutOfContract` and becomes a recorded refusal — that arm cannot
+  silently become served. Missing `clientCapabilities` at served
+  `2026-07-28` (`-32602`) is `PerRequest` and would run the tool; the
+  pin still fails, because a `tool_call` appears.
 - **Scope enforcement is a transport property, not a policy one.**
   `BugWarden::with_scope_enforcement` is switched on by `main` for an
   authenticated http listener only: stdio issues no per-request credential and
@@ -1162,8 +1179,9 @@ Decisions, all deliberate:
 - **One record per call (I15).** The hand-written `call_tool` owns the
   record; tools only enrich it through a per-request cell in the request
   extensions (verdict worst-wins merged, suppressed ids unioned). An
-  unknown tool, a protocol error, or a missed enrichment still yields
-  exactly one record — a poorer record is possible, an audit gap is not.
+  unknown tool, a protocol error, or a missed enrichment that reaches
+  the handler still yields exactly one record — a poorer record is
+  possible, an audit gap is not.
   A handler that PANICS is no exception since #253, and used to be one: the
   unwind is caught at the dispatch boundary, the request is answered with a
   JSON-RPC internal error carrying a fixed, content-free text, and the
@@ -1179,7 +1197,10 @@ Decisions, all deliberate:
   `initialize` is always recorded, with no configuration knob to turn it
   off; `list_tools` is not recorded in schema v2 — no event kind exists
   for a listing, deliberately, and the growth rule would permit adding one
-  without a version bump.
+  without a version bump. rmcp's pre-`call_tool` refusals (`-32022` /
+  `-32602`) are another unrecorded class: they die in the blanket
+  `Service` impl and never reach the handler (see "Pre-dispatch rmcp
+  refusals are logged, not audited" under HTTP bearer authentication).
 - **Boundary.** Records go to the sinks the operator named
   (`select_sinks`): the JSONL file (0600, parent 0700), an OTLP
   collector, both, or neither. Never stderr, never any MCP surface. When
@@ -3354,7 +3375,11 @@ wired, `server.rs` and `main.rs` are the reference.
   `initialize` is answered with that revision, mints no `mcp-session-id`,
   and is recorded from the REQUEST's `clientInfo` with no id; a header-only
   `2026-07-28` with no `_meta` is refused by the transport (-32602) with
-  nothing recorded, which is the barrier the handshake arm leans on; and
+  nothing recorded, which is the barrier the handshake arm leans on; a
+  session `tools/call` whose `_meta` names an unserved revision (-32022)
+  or a served one without `clientCapabilities` (-32602) dies in rmcp
+  before `call_tool` and writes no `tool_call` record
+  (`a_pre_dispatch_rmcp_refusal_writes_no_tool_call_record`); and
   I13 and I2 are re-run on the path — a `--read-only`-pruned tool and a
   nonexistent name answer byte-identically, a policy-denied bug and a
   nonexistent one answer with the same uniform text. `list_tools` has its own


### PR DESCRIPTION
Closes #182. Does **not** file rmcp (#204 stays open).

Settlement: do not record. There is no hook that works on both transports (`Service` wrapper is stdio-only; HTTP's `StreamableHttpService` re-acquires the blanket impl).

## What changes

- DESIGN.md sibling of the bearer "Refusals are logged, not audited" bullet: `-32022` (unserved `_meta` revision) and `-32602` (served revision, missing `clientCapabilities`) die in rmcp before `call_tool`. Logged, not streamed.
- Honesty fold: only `-32022` would become `OutOfContract` if rmcp stopped refusing first. Missing `clientCapabilities` at served `2026-07-28` would be `PerRequest` and **run the tool**. Either way the pin fails.
- Stream inventory names this class as unrecorded; http_transport Testing names the pin.
- Test `a_pre_dispatch_rmcp_refusal_writes_no_tool_call_record`: after `initialize`, two `tools/call` rows (`9999-01-01` → `-32022`; served revision without `clientCapabilities` → `-32602`); zero `ToolCall` records.

No production record path change.

## Review before opening

- **Security — MERGE-SAFE.** Served versions unchanged. Test reads a tempfile, not MCP (I15). I2 untouched.
- **Correctness — MERGE-SAFE.** Hits the blanket impl (`-32022`/`-32602`, not HTTP `-32020`). `mcp_post` has a 10s timeout. Zero-ToolCall fails if recording starts.
- **Docs — MERGE-SAFE** after fold. OutOfContract overclaim split; inventory and Testing catalog updated.
