### PR TITLE
ci(release): embed cargo-auditable data in shipped binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,27 @@ jobs:
             exit 1
           fi
 
+      - name: Install cargo-auditable
+        # Pinned exactly and --locked: same hermetic rule as cargo-deb.
+        # rust-audit-info extracts .dep-v0; cargo-audit is not installed
+        # here so a new advisory cannot fail the tag (advisories.yml).
+        run: |
+          cargo install cargo-auditable --locked --version 0.7.5
+          cargo install rust-audit-info --locked --version 0.5.4
+
       - name: Build release binary
-        run: cargo build --release --locked -p bugwarden
+        run: cargo auditable build --release --locked -p bugwarden
+
+      - name: Verify auditable section
+        # ELF and Mach-O both carry .dep-v0; missing data fails the tag.
+        shell: bash
+        run: |
+          set -euo pipefail
+          info="$(rust-audit-info target/release/bugwarden)"
+          grep -qF '"name":"bugwarden"' <<<"$info" \
+            || { echo "::error::binary is missing cargo-auditable data"; exit 1; }
+          grep -qF '"name":"rmcp"' <<<"$info" \
+            || { echo "::error::binary is missing crate rmcp in cargo-auditable data"; exit 1; }
 
       - name: Package release artifact
         shell: bash
@@ -116,14 +135,36 @@ jobs:
           cargo install cargo-deb --locked --version 3.7.0
           cargo install cargo-generate-rpm --locked --version 0.16.1
 
+      - name: Install cargo-auditable
+        # Pinned exactly and --locked: same hermetic rule as cargo-deb.
+        # rust-audit-info extracts .dep-v0; cargo-audit is not installed
+        # here so a new advisory cannot fail the tag (advisories.yml).
+        run: |
+          cargo install cargo-auditable --locked --version 0.7.5
+          cargo install rust-audit-info --locked --version 0.5.4
+
       - name: Build release binary
-        run: cargo build --release --locked -p bugwarden
+        run: cargo auditable build --release --locked -p bugwarden
 
       - name: Strip the packaged binary
         # cargo-deb strips by default and cargo-generate-rpm cannot at all, so
         # strip once here and tell cargo-deb not to: both packages then ship a
         # byte-identical binary. The tarballs keep their symbols (unchanged).
-        run: strip target/release/bugwarden
+        # .dep-v0 is ELF sh_flags=0 (not SHF_ALLOC); GNU strip drops it
+        # unless --keep-section=.dep-v0.
+        run: strip --keep-section=.dep-v0 target/release/bugwarden
+
+      - name: Verify auditable section
+        # After strip: a strip that ate .dep-v0 would ship unauditable
+        # .deb/.rpm.
+        shell: bash
+        run: |
+          set -euo pipefail
+          info="$(rust-audit-info target/release/bugwarden)"
+          grep -qF '"name":"bugwarden"' <<<"$info" \
+            || { echo "::error::binary is missing cargo-auditable data"; exit 1; }
+          grep -qF '"name":"rmcp"' <<<"$info" \
+            || { echo "::error::binary is missing crate rmcp in cargo-auditable data"; exit 1; }
 
       - name: Build packages
         shell: bash
@@ -384,6 +425,19 @@ jobs:
           image="ghcr.io/plusky/bugwarden@${{ steps.build.outputs.digest }}"
           docker pull "$image"
           echo "IMAGE=$image" >>"$GITHUB_ENV"
+
+      - name: Verify auditable section
+        # Tarball/deb already run rust-audit-info; this is the image
+        # copy. Both matrix legs are Linux; this job has no rustc.
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker create --name bugwarden-audit "$IMAGE"
+          docker cp bugwarden-audit:/usr/local/bin/bugwarden /tmp/bugwarden
+          docker rm bugwarden-audit
+          readelf -S /tmp/bugwarden | grep -q '\.dep-v0' \
+            || { echo "::error::image binary is missing .dep-v0"; exit 1; }
+
       # ci.yml's assertions, same script, now on both architectures and against
       # what ghcr.io will actually serve (#223) — the arm64 image was never
       # executed anywhere before this. The digest is in ghcr.io before any of

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,9 @@ A release is one push of an annotated tag; nothing is released by hand.
   push-by-digest makes unavoidable. `container` is a sibling of `publish`,
   not upstream of it — a broken image build must not hold back the crates.io
   release of a tag whose binaries already shipped.
+- GitHub tarball, `.deb`, `.rpm` and container binaries are built with
+  `cargo auditable` 0.7.5 so `cargo audit bin` / `rust-audit-info` work;
+  the packaged ELF is stripped with `--keep-section=.dep-v0`.
 - The `.deb`/`.rpm` come from `cargo-deb` and `cargo-generate-rpm`, both
   pinned to an exact version and installed `--locked`, reading
   `[package.metadata.deb]` / `[package.metadata.generate-rpm]` in

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,14 @@ FROM rust:1.98.0-alpine@sha256:a10e64dd139b7387337c7fbe8aca31b959b57b2fd4c8ae20a
 # gcc and musl-dev are already in the base; aws-lc-sys (the rustls crypto
 # provider) compiles C from source and needs cmake plus a make generator.
 RUN apk add --no-cache cmake make
+# Image is a shipped artifact; tarball/deb already embed .dep-v0.
+RUN cargo install cargo-auditable --locked --version 0.7.5
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo build --release --locked -p bugwarden && \
+    cargo auditable build --release --locked -p bugwarden && \
     cp target/release/bugwarden /out
 
 # Both FROMs carry a digest for the same reason the workflows SHA-pin actions:

--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ cargo build --release
 # binary at target/release/bugwarden
 ```
 
+Release artifacts embed the crate list for `cargo audit bin`; a local
+`cargo build --release` does not.
+
 The repository pins its Rust toolchain via `rust-toolchain.toml`; `cargo`
 picks it up automatically (rustup-managed installs). Any recent stable Rust
 works if you build without the pin. The build compiles `aws-lc-sys` from


### PR DESCRIPTION
Follow-up to #196's optional `cargo auditable` so downstreams can `cargo audit bin` a shipped binary instead of trusting the lockfile in the source tarball.

## What changes

- `cargo auditable build --release --locked -p bugwarden` in the `build` and `package` jobs and in the Dockerfile. Wrapper pinned **0.7.5**, `--locked`, same hermetic rule as cargo-deb.
- `rust-audit-info` **0.5.4** must see `"name":"bugwarden"` and `"name":"rmcp"` after the tarball build (both ELF and Mach-O) and **after** `strip --keep-section=.dep-v0` on the packaged ELF. GNU strip without that flag drops the non-`SHF_ALLOC` section.
- Container: same auditable build; after `docker pull` of the digest, `readelf -S | grep .dep-v0` on a `docker cp`'d binary before smoke. No rustc on that job.
- Not a workspace dependency. `ci.yml` tests still plain `cargo test`. `cargo-audit` is **not** a tag gate (advisories.yml remains the messenger).

## Review before opening

- **Security — MERGE-SAFE.** Wrapper links zlib JSON, does not compile extra code. Distroless still copies only the ELF. `cargo install` is pinned `--locked`.
- **Correctness — MERGE-SAFE.** PATH is the same as cargo-deb. macOS never strips; rust-audit-info parses Mach-O. Alpine 0.7.5 has no OpenSSL. Fat LTO does not drop the post-LTO `.o`.
- **Docs — MERGE-SAFE.** AGENTS.md names the pin and the strip flag. README does not claim a local `cargo build --release` embeds.
- Residual (container had no rust-audit-info gate) **folded** as the `readelf` check.
