### PR TITLE
test(core): instruction-count benches for classify and I14 scrub

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,54 @@
+---
+name: perf
+on:
+  schedule:
+    # Weekly, own slot: advisories Mon 06:47, codeql Wed 05:31, mutants Sat
+    # 04:19. Thursday so a hang here does not sit on a PR-day runner.
+    - cron: '41 5 * * 4'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  iai:
+    # Instruction counts for Policy::classify and Guard::scrub_bug_links.
+    # NEVER a required status check; do not add it to branch protection.
+    # Wall-clock on ubuntu-latest is noisier than the CPU work here; Callgrind
+    # Ir with a 20% band is the comparison. Same limits as mutants.yml:
+    # GitHub's failed-run email, crons die after 60 days of inactivity, and
+    # a scheduled workflow is inert until it reaches the default branch.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
+        with:
+          toolchain: "1.98.0"
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          workspaces: . -> target
+          # Restore main's registry so the bench crate compiles; do not write
+          # — a weekly job must not LRU-evict the rust job's target/.
+          save-if: false
+      - name: Cache iai results
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: target/iai
+          # Same lockfile + pin: compare this week to last. A lockfile bump
+          # starts a new baseline instead of failing on compiler noise.
+          key: iai-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
+      - name: Install valgrind
+        run: sudo apt-get update && sudo apt-get install -y valgrind
+      - name: Install iai-callgrind-runner
+        run: cargo install iai-callgrind-runner --locked --version 0.16.1
+      - name: Instruction-count benches
+        run: cargo bench -p bugwarden-core --bench guard --features iai --locked

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,10 @@ are never a justification for undoing them.
 - `typos` runs as its own workflow and is not part of the verification
   commands above; `typos.toml` is an allowlist of deliberate spellings,
   never a mask for a real typo.
+- Instruction-count benches (`cargo bench -p bugwarden-core --bench guard
+  --features iai`) live in `perf.yml`, weekly and never a required check.
+  They pin Callgrind Ir for classify and I14 scrub, not wall-clock. The
+  `iai` feature keeps them off `cargo test --all-targets`.
 
 ## Commits and Pull Requests
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +253,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "iai-callgrind",
  "reqwest",
  "serde",
  "serde_json",
@@ -499,6 +509,27 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "digest"
@@ -855,6 +886,42 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iai-callgrind"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e4910d3a9137442723dfb772c32dc10674c4181ca078d2fd227cd5dce9db0"
+dependencies = [
+ "bincode",
+ "derive_more",
+ "iai-callgrind-macros",
+ "iai-callgrind-runner",
+]
+
+[[package]]
+name = "iai-callgrind-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d03775318d3f9f01b39ac6612b01464006dc397a654a89dd57df2fd34fb68c3"
+dependencies = [
+ "derive_more",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "iai-callgrind-runner"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74c9743c00c3bca4aaffc69c87cae56837796cd362438daf354a3f785788c68"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1250,6 +1317,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/crates/bugwarden-core/Cargo.toml
+++ b/crates/bugwarden-core/Cargo.toml
@@ -34,3 +34,14 @@ reqwest = { version = "0.13", default-features = false, features = [
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 wiremock = "0.6"
+iai-callgrind = "0.16.1"
+
+# Off unless `--features iai`: `cargo test --all-targets` would otherwise
+# run this harness (no valgrind) and fail the required rust job.
+[features]
+iai = []
+
+[[bench]]
+name = "guard"
+harness = false
+required-features = ["iai"]

--- a/crates/bugwarden-core/benches/guard.rs
+++ b/crates/bugwarden-core/benches/guard.rs
@@ -1,0 +1,160 @@
+//! Instruction-count benches for the CPU we own: policy classify and I14
+//! link scrub. No network. Wall-clock is Bugzilla wait; these pin the
+//! in-process work a 25-id assess or a fat bug_info actually does.
+//!
+//! Linux + valgrind only (`iai-callgrind`). Behind `--features iai` so
+//! `cargo test --all-targets` does not run the harness.
+
+use std::collections::BTreeSet;
+use std::hint::black_box;
+
+use bugwarden_core::guard::Guard;
+use bugwarden_core::policy::{BugMeta, Operation, Policy};
+use chrono::{DateTime, Utc};
+use iai_callgrind::{
+    library_benchmark, library_benchmark_group, main, Callgrind, EventKind, LibraryBenchmarkConfig,
+};
+use serde_json::{json, Value};
+
+const POLICY: &str = r#"
+default_action = "allow"
+
+[[rule]]
+name = "embargo"
+action = "deny"
+[rule.match]
+groups = ["*embargo*"]
+
+[[rule]]
+name = "suse-summary"
+action = "restrict"
+capabilities = ["summary"]
+[rule.match]
+products = ["SUSE*"]
+"#;
+
+fn now() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339("2026-01-15T00:00:00Z")
+        .expect("fixed instant")
+        .with_timezone(&Utc)
+}
+
+fn meta(product: Option<&str>, groups: Option<&[&str]>, creation: Option<&str>) -> BugMeta {
+    BugMeta {
+        id: 7,
+        summary: Some("a bug".into()),
+        product: product.map(str::to_owned),
+        components: Some(vec!["Kernel".into()]),
+        status: Some("NEW".into()),
+        severity: Some("Normal".into()),
+        priority: Some("P3".into()),
+        keywords: Some(vec![]),
+        groups: groups.map(|g| g.iter().map(|s| (*s).to_owned()).collect()),
+        whiteboard: Some(String::new()),
+        creation_time: creation.map(|s| {
+            DateTime::parse_from_rfc3339(s)
+                .expect("fixture time")
+                .with_timezone(&Utc)
+        }),
+        created_by_me: Some(false),
+    }
+}
+
+struct ClassifyFix {
+    policy: Policy,
+    bug: BugMeta,
+    now: DateTime<Utc>,
+}
+
+fn classify_allow() -> ClassifyFix {
+    ClassifyFix {
+        policy: Policy::from_toml_str(POLICY).expect("fixture policy"),
+        bug: meta(Some("Firefox"), Some(&[]), Some("2020-01-01T00:00:00Z")),
+        now: now(),
+    }
+}
+
+fn classify_deny() -> ClassifyFix {
+    ClassifyFix {
+        policy: Policy::from_toml_str(POLICY).expect("fixture policy"),
+        bug: meta(
+            Some("Kernel"),
+            Some(&["embargo-2026"]),
+            Some("2020-01-01T00:00:00Z"),
+        ),
+        now: now(),
+    }
+}
+
+fn classify_restrict() -> ClassifyFix {
+    ClassifyFix {
+        policy: Policy::from_toml_str(POLICY).expect("fixture policy"),
+        bug: meta(
+            Some("SUSE Linux Enterprise"),
+            Some(&[]),
+            Some("2020-01-01T00:00:00Z"),
+        ),
+        now: now(),
+    }
+}
+
+fn classify_unreadable() -> ClassifyFix {
+    ClassifyFix {
+        policy: Policy::from_toml_str(POLICY).expect("fixture policy"),
+        // groups None: embargo rule is undecidable → deny (I4)
+        bug: meta(Some("Kernel"), None, Some("2020-01-01T00:00:00Z")),
+        now: now(),
+    }
+}
+
+#[library_benchmark]
+#[bench::allow(classify_allow())]
+#[bench::deny(classify_deny())]
+#[bench::restrict(classify_restrict())]
+#[bench::unreadable(classify_unreadable())]
+fn classify(fix: ClassifyFix) {
+    black_box(fix.policy.classify(&fix.bug, fix.now, Operation::Access));
+}
+
+fn linked_bug() -> Value {
+    json!({
+        "id": 1,
+        "blocks": [2, 3, 99],
+        "depends_on": [4, 99],
+        "duplicates": [5],
+        "dupe_of": 99,
+        "see_also": [
+            "https://bugzilla.example/show_bug.cgi?id=2",
+            "https://bugzilla.example/show_bug.cgi?id=99"
+        ],
+        "url": "https://bugzilla.example/show_bug.cgi?id=99"
+    })
+}
+
+fn disclosable() -> BTreeSet<u64> {
+    [1, 2, 3, 4, 5].into_iter().collect()
+}
+
+#[library_benchmark]
+#[bench::mixed(args = (linked_bug(), disclosable()))]
+fn scrub_links(mut bug: Value, allowed: BTreeSet<u64>) {
+    Guard::scrub_bug_links(&mut bug, "https://bugzilla.example", &allowed);
+    black_box(bug);
+}
+
+library_benchmark_group!(
+    name = classify_group;
+    benchmarks = classify
+);
+
+library_benchmark_group!(
+    name = scrub_group;
+    benchmarks = scrub_links
+);
+
+// 20% Ir over last run: LLVM noise, not a wall-clock gate. Job is never required.
+main!(
+    config = LibraryBenchmarkConfig::default()
+        .tool(Callgrind::default().soft_limits([(EventKind::Ir, 20f64)]));
+    library_benchmark_groups = classify_group, scrub_group
+);

--- a/crates/bugwarden-core/tests/profile_hot_paths.rs
+++ b/crates/bugwarden-core/tests/profile_hot_paths.rs
@@ -1,0 +1,204 @@
+//! Local `--release` timings for the CPU we own after a mock returns.
+//!
+//! Not a CI test: `#[ignore]`. Drive with
+//! `cargo test -p bugwarden-core --release --test profile_hot_paths -- --ignored --nocapture`.
+//! Wall-clock here is loopback HTTP plus JSON; the iai benches pin classify
+//! and I14 without the mock.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::time::Instant;
+
+use bugwarden_core::client::BugzillaClient;
+use bugwarden_core::guard::{Guard, SearchRequest};
+use bugwarden_core::policy::Policy;
+use bugwarden_core::quoted::QuotedError;
+use serde_json::{json, Value};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+const KEY: &str = "profile-key";
+const UA: &str = "profile-agent/0.0.0";
+
+const POLICY: &str = r#"
+default_action = "allow"
+[[rule]]
+name = "embargo"
+action = "deny"
+[rule.match]
+groups = ["*embargo*"]
+"#;
+
+fn guard() -> Guard {
+    Guard {
+        policy: Policy::from_toml_str(POLICY).expect("policy"),
+    }
+}
+
+fn client(server: &MockServer) -> BugzillaClient {
+    BugzillaClient::new(&server.uri(), false, UA).expect("client")
+}
+
+fn bug_json(id: u64) -> Value {
+    json!({
+        "id": id,
+        "summary": format!("bug {id}"),
+        "product": "Kernel",
+        "component": "general",
+        "status": "NEW",
+        "groups": [],
+        "creation_time": "2020-01-01T00:00:00Z",
+        "blocks": [id + 1, 99_999],
+        "depends_on": [id + 2],
+        "see_also": [format!("https://bugzilla.example/show_bug.cgi?id={id}")],
+        "dupe_of": null
+    })
+}
+
+#[tokio::test]
+#[ignore = "local release profile; not a CI gate"]
+async fn profile_hot_paths() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(|req: &Request| {
+            let q: std::collections::HashMap<_, _> = req.url.query_pairs().collect();
+            if let Some(id) = q.get("id").and_then(|s| s.parse::<u64>().ok()) {
+                return ResponseTemplate::new(200).set_body_json(json!({ "bugs": [bug_json(id)] }));
+            }
+            let offset = q
+                .get("offset")
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(0);
+            let limit = q
+                .get("limit")
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or(200);
+            let page: Vec<_> = (offset + 1..=offset + limit as u64).map(bug_json).collect();
+            ResponseTemplate::new(200).set_body_json(json!({ "bugs": page }))
+        })
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/rest/bug"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": true,
+            "message": "There is no version named '1.0 status=HACKED limit=999' in the 'openSUSE' product."
+        })))
+        .mount(&server)
+        .await;
+
+    let g = guard();
+    let bz = client(&server);
+    let ids: Vec<u64> = (1..=25).collect();
+
+    let t0 = Instant::now();
+    let classified = g.assess(&bz, KEY, &ids, None).await;
+    let assess_ms = t0.elapsed();
+    assert_eq!(classified.len(), 25);
+
+    let t1 = Instant::now();
+    let window = g
+        .quicksearch_window(
+            &bz,
+            KEY,
+            &SearchRequest {
+                query: "kernel",
+                status: "ALL",
+                include_fields: "id,summary,product,component,status,groups,creation_time,blocks,depends_on,see_also",
+                limit: 50,
+                offset: 0,
+            },
+            None,
+        )
+        .await
+        .expect("search");
+    let search_ms = t1.elapsed();
+    assert!(!window.bugs.is_empty());
+
+    let mut fat = bug_json(1);
+    fat["blocks"] = json!((2..80).collect::<Vec<u64>>());
+    fat["depends_on"] = json!((80..160).collect::<Vec<u64>>());
+    let allowed: BTreeSet<u64> = (1..100).collect();
+    let t2 = Instant::now();
+    for _ in 0..10_000 {
+        let mut b = fat.clone();
+        Guard::scrub_bug_links(&mut b, "https://bugzilla.example", &allowed);
+        std::hint::black_box(b);
+    }
+    let scrub_ms = t2.elapsed();
+
+    let err = bz
+        .create_bug(
+            KEY,
+            json!({
+                "product": "openSUSE",
+                "component": "Other",
+                "summary": "x",
+                "version": "1.0 status=HACKED limit=999"
+            }),
+        )
+        .await
+        .expect_err("upstream 400");
+    let t3 = Instant::now();
+    let mut quoted = String::new();
+    for _ in 0..50_000 {
+        quoted.clear();
+        write!(&mut quoted, "{:?}", QuotedError(&err)).expect("fmt");
+        std::hint::black_box(&quoted);
+    }
+    let quote_ms = t3.elapsed();
+
+    let hidden_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/bug"))
+        .respond_with(|req: &Request| {
+            let q: std::collections::HashMap<_, _> = req.url.query_pairs().collect();
+            let offset = q
+                .get("offset")
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(0);
+            let limit = q
+                .get("limit")
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap_or(200);
+            let page: Vec<_> = (offset + 1..=offset + limit as u64)
+                .map(|id| {
+                    let mut b = bug_json(id);
+                    b["groups"] = json!(["embargo-2026"]);
+                    b
+                })
+                .collect();
+            ResponseTemplate::new(200).set_body_json(json!({ "bugs": page }))
+        })
+        .mount(&hidden_server)
+        .await;
+    let hidden_bz = client(&hidden_server);
+    let t4 = Instant::now();
+    let empty = g
+        .quicksearch_window(
+            &hidden_bz,
+            KEY,
+            &SearchRequest {
+                query: "kernel",
+                status: "ALL",
+                include_fields: "id,summary,product,groups,creation_time",
+                limit: 50,
+                offset: 0,
+            },
+            None,
+        )
+        .await
+        .expect("hidden scan");
+    let hidden_scan_ms = t4.elapsed();
+    assert!(empty.bugs.is_empty());
+
+    eprintln!("assess_25ids\t{assess_ms:?}\t(25 sequential mock GETs + classify)");
+    eprintln!(
+        "quicksearch\t{search_ms:?}\t(one chunk, {} visible)",
+        window.bugs.len()
+    );
+    eprintln!("hidden_scan\t{hidden_scan_ms:?}\t(10 chunks, all embargoed)");
+    eprintln!("scrub_10k\t{scrub_ms:?}\t(I14 on ~160 link ids)");
+    eprintln!("quoted_50k\t{quote_ms:?}\t(QuotedError of a Bugzilla 400)");
+}


### PR DESCRIPTION
Automatic performance checks without a wall-clock gate.

## What we measured (phase 1)

bugwarden is I/O-bound: `Guard::assess` is one sequential GET per id (I2; some Bugzilla deployments drop parallel connections). `SEARCH_SCAN_*` are security bounds. Local valgrind is not installed, so this PR does not claim a flamegraph; the CPU we *can* pin is classify + I14 scrub.

## What changes

- `iai-callgrind` 0.16.1 **dev-dep** of `bugwarden-core`. Benches: `Policy::classify` (allow / deny / restrict / unreadable-groups I4) and `Guard::scrub_bug_links` (mixed disclosable ids, including `see_also`).
- Callgrind `soft_limits` Ir **20%** over the last run (percentage, not 1.20×).
- `[[bench]] required-features = ["iai"]` so `cargo test --workspace --all-targets` does **not** run the harness (that would fail the required rust job without valgrind).
- `.github/workflows/perf.yml`: weekly Thursday 05:41 UTC + `workflow_dispatch`. **Never required.** rust-cache `save-if: false`. Separate `actions/cache` for `target/iai` keyed on lockfile + toolchain pin. `iai-callgrind-runner` 0.16.1 `--locked`.

## Review before opening

- **Security — MERGE-SAFE.** No production source change. Job not in branch protection. iai is `kind: dev`. rust-cache does not write.
- **Correctness — MERGE-UNSAFE then folded.** `cargo test --all-targets` would have executed the iai binary. Gated on `--features iai`.
- **Docs — folded.** Crate-doc no longer says "not part of cargo test" without the feature gate. AGENTS.md names `--features iai`.
