### PR TITLE
chore: ignore local graphify-out/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@
 # to .old
 /mutants.out/
 /mutants.out.old/
+# graphify local knowledge graph (graph.html / graph.json)
+/graphify-out/
 *.rs.bk
 Cargo.lock.bak


### PR DESCRIPTION
Adds `/graphify-out/` to `.gitignore`. The graphify pipeline writes `graph.html` / `graph.json` / `GRAPH_REPORT.md` there; same shape as the existing `/mutants.out/` ignore — generated at the workspace root, not source.

## Adversarial review

- **Scope.** One pattern, root-anchored (`/graphify-out/`). Does not match `examples/`, `docs/`, policy TOML, or crate sources.
- **Security.** Ignoring the dir prevents accidental commit of a local graph dump; it does not hide source or policy. No MCP surface, no I1–I16 change.
- **False positive.** `git check-ignore` matches `graphify-out/graph.json` and does not match `examples/policy.toml`.

## Verify

`git check-ignore -v graphify-out/graph.json` → `.gitignore:8:/graphify-out/`.

_AI-assisted._