### PR TITLE
ci: exclude three unreachable serve_failure mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -47,3 +47,16 @@ test_workspace = true
 # A floor and not --timeout, so the 5x multiplier still scales past it on a
 # slow runner or once upstream fixes the baseline.
 minimum_test_timeout = 720
+
+# Three serve_failure match arms #261 already called unreachable: rmcp always
+# constructs ExpectedInitializeRequest(Some(_)), maps this handler's
+# InitializeResult, and ServiceExt::serve never cancels its token. Deleting
+# them is a no-op (the wildcard still compiles) so they survive every week
+# and the scheduled job emails a false gap. Reachable arms stay in scope
+# (Some(frame), ConnectionClosed, InitializeFailed, TransportError). Drop
+# these if rmcp starts constructing the variants.
+exclude_re = [
+    "ExpectedInitializeRequest\\(None\\)",
+    "UnexpectedInitializeResponse",
+    "Failure::Cancelled",
+]


### PR DESCRIPTION
Saturday's cargo-mutants run (5f2d7a03) reported 3 missed / 137 caught. All three are `serve_failure` match arms #261 already called unreachable on rmcp: `ExpectedInitializeRequest(None)`, `UnexpectedInitializeResponse(_)`, `Cancelled`. Deleting them is a no-op against the `#[non_exhaustive]` wildcard, so the weekly email is a false coverage gap. `guard.rs` had zero survivors.

`exclude_re` in `.cargo/mutants.toml` drops only those three. Reachable arms stay in scope (`Some(frame)`, `ConnectionClosed`, `InitializeFailed`, `TransportError`) plus the two `replace serve_failure` return mutants.

Touches I12 only as documentation of why `serve_failure` exists — no runtime change. Drop the excludes if rmcp starts constructing the variants.

## Adversarial review

- **Too-broad regex.** `Failure::Cancelled` not `Cancelled` (avoids a future name collision). `ExpectedInitializeRequest\(None\)` does not match `Some(frame)`. `UnexpectedInitializeResponse` is unique in `--list`.
- **Does not skip I12.** The live classification is `Some(frame)` → JSON-RPC kind → `&'static str`. Those mutants remain. Replacing `serve_failure` with `""` / `"xyzzy"` remains.
- **Does not skip guard.rs.** `--list --file guard.rs` has no hits for these patterns (125 mutants unchanged). main.rs 18 → 15.
- **Not a required check.** mutants.yml stays non-gating. This only stops the scheduled email from looking like a suite hole.

## Verify

```
cargo mutants --list --file crates/bugwarden/src/main.rs --no-shuffle
```
The three missed names are gone; the four reachable arm-deletes and both return-value mutants remain.

_AI-assisted._